### PR TITLE
feat(ui): implement multi-app server for RWA Calculator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "pyarrow",
     "pyyaml",
     "pytest",
+    "uvicorn",
 ]
 
 [project.optional-dependencies]

--- a/src/rwa_calc/ui/marimo/.gitignore
+++ b/src/rwa_calc/ui/marimo/.gitignore
@@ -1,0 +1,2 @@
+# Cache directory for sharing results between apps
+.cache/

--- a/src/rwa_calc/ui/marimo/__init__.py
+++ b/src/rwa_calc/ui/marimo/__init__.py
@@ -1,1 +1,30 @@
-"""Marimo UI applications for RWA Calculator."""
+"""Marimo UI applications for RWA Calculator.
+
+Available applications:
+    - rwa_app.py: Main calculator for running RWA calculations
+    - results_explorer.py: Interactive results analysis and filtering
+    - framework_reference.py: Regulatory framework documentation
+
+Usage (Multi-App Server - Recommended):
+    # Start the server with all apps
+    uv run python src/rwa_calc/ui/marimo/server.py
+
+    # Apps available at:
+    #   http://localhost:8000/           (Calculator)
+    #   http://localhost:8000/calculator (Calculator)
+    #   http://localhost:8000/results    (Results Explorer)
+    #   http://localhost:8000/reference  (Framework Reference)
+
+Usage (Single App):
+    # Run individual app in edit mode (development)
+    uv run marimo edit src/rwa_calc/ui/marimo/rwa_app.py
+
+    # Run individual app in read-only mode
+    uv run marimo run src/rwa_calc/ui/marimo/rwa_app.py
+
+    Note: Navigation between apps only works with the multi-app server.
+
+Navigation:
+    All apps include a sidebar with navigation links to switch between apps.
+    Results from the calculator are cached and shared with the results explorer.
+"""

--- a/src/rwa_calc/ui/marimo/__marimo__/session/rwa_app.py.json
+++ b/src/rwa_calc/ui/marimo/__marimo__/session/rwa_app.py.json
@@ -6,7 +6,7 @@
   "cells": [
     {
       "id": "Hbol",
-      "code_hash": "cffbe0e2fe3883d908f6c18ccc996726",
+      "code_hash": "6350c3f99e3d03e93091fc06bbeae538",
       "outputs": [
         {
           "type": "data",
@@ -18,13 +18,13 @@
       "console": []
     },
     {
-      "id": "vblA",
-      "code_hash": "bb125dcecb87a1dcda8c40ecb1746f35",
+      "id": "MJUe",
+      "code_hash": "3081b19cb664b8bbf22f924354edb531",
       "outputs": [
         {
           "type": "data",
           "data": {
-            "text/html": "<div style='display: flex;flex: 1;flex-direction: column;justify-content: flex-start;align-items: normal;flex-wrap: nowrap;gap: 0.5rem'><span class=\"markdown prose dark:prose-invert contents\"><h3 id=\"data-configuration\">Data Configuration</h3></span><marimo-ui-element object-id='vblA-0' random-id='69018bad-61c9-a373-3c87-00a5895943bd'><marimo-text data-initial-value='&quot;C:&#92;&#92;Users&#92;&#92;philm&#92;&#92;PycharmProjects&#92;&#92;rwa_calculator&#92;&#92;tests&#92;&#92;fixtures&quot;' data-label='&quot;&lt;span class=&#92;&quot;markdown prose dark:prose-invert contents&#92;&quot;&gt;&lt;span class=&#92;&quot;paragraph&#92;&quot;&gt;Data Path&lt;/span&gt;&lt;/span&gt;&quot;' data-placeholder='&quot;Enter path to data directory&quot;' data-kind='&quot;text&quot;' data-full-width='true' data-disabled='false' data-debounce='true'></marimo-text></marimo-ui-element></div>"
+            "text/html": "<marimo-sidebar ><div style='display: flex;flex: 1;flex-direction: column;justify-content: space-between;align-items: normal;flex-wrap: nowrap;gap: 0.5rem'><div style='display: flex;flex: 1;flex-direction: column;justify-content: flex-start;align-items: normal;flex-wrap: nowrap;gap: 0.5rem'><span class=\"markdown prose dark:prose-invert contents\"><h1 id=\"rwa-calculator\">RWA Calculator</h1></span><marimo-nav-menu data-items='[{&quot;label&quot;:&quot;&lt;span class=&#92;&quot;markdown prose dark:prose-invert contents&#92;&quot;&gt;&lt;span class=&#92;&quot;paragraph&#92;&quot;&gt;&lt;iconify-icon icon=&#x27;calculator&#x27; inline&gt;&lt;/iconify-icon&gt; Calculator&lt;/span&gt;&lt;/span&gt;&quot;,&quot;href&quot;:&quot;/rwa_app.py&quot;,&quot;description&quot;:null},{&quot;label&quot;:&quot;&lt;span class=&#92;&quot;markdown prose dark:prose-invert contents&#92;&quot;&gt;&lt;span class=&#92;&quot;paragraph&#92;&quot;&gt;&lt;iconify-icon icon=&#x27;table&#x27; inline&gt;&lt;/iconify-icon&gt; Results Explorer&lt;/span&gt;&lt;/span&gt;&quot;,&quot;href&quot;:&quot;/results_explorer.py&quot;,&quot;description&quot;:null},{&quot;label&quot;:&quot;&lt;span class=&#92;&quot;markdown prose dark:prose-invert contents&#92;&quot;&gt;&lt;span class=&#92;&quot;paragraph&#92;&quot;&gt;&lt;iconify-icon icon=&#x27;book&#x27; inline&gt;&lt;/iconify-icon&gt; Framework Reference&lt;/span&gt;&lt;/span&gt;&quot;,&quot;href&quot;:&quot;/framework_reference.py&quot;,&quot;description&quot;:null}]' data-orientation='&quot;vertical&quot;'></marimo-nav-menu><span class=\"markdown prose dark:prose-invert contents\"><hr /></span><span class=\"markdown prose dark:prose-invert contents\"><span class=\"paragraph\"><strong>Quick Links</strong></span>\n<ul>\n<li><a href=\"https://www.bankofengland.co.uk/prudential-regulation/publication/2024/september/implementation-of-the-basel-3-1-standards-near-final-policy-statement-part-2\" rel=\"noopener noreferrer\" target=\"_blank\">PRA PS9/24</a></li>\n<li><a href=\"https://www.legislation.gov.uk/eur/2013/575/contents\" rel=\"noopener noreferrer\" target=\"_blank\">UK CRR</a></li>\n<li><a href=\"https://www.bis.org/basel_framework/\" rel=\"noopener noreferrer\" target=\"_blank\">BCBS Framework</a></li>\n</ul></span></div><span class=\"markdown prose dark:prose-invert contents\"><span class=\"paragraph\"><em>RWA Calculator v1.0</em></span></span></div></marimo-sidebar>"
           }
         }
       ],
@@ -32,12 +32,12 @@
     },
     {
       "id": "bkHC",
-      "code_hash": "df6418e35c3d46907ac080f854087f40",
+      "code_hash": "bb125dcecb87a1dcda8c40ecb1746f35",
       "outputs": [
         {
           "type": "data",
           "data": {
-            "text/html": "<div style='display: flex;flex: 1;flex-direction: row;justify-content: flex-start;align-items: normal;flex-wrap: nowrap;gap: 2rem'><marimo-ui-element object-id='bkHC-0' random-id='ab969e05-14d0-cef0-213b-c285e51db909'><marimo-dropdown data-initial-value='[&quot;CRR&quot;]' data-label='&quot;&lt;span class=&#92;&quot;markdown prose dark:prose-invert contents&#92;&quot;&gt;&lt;span class=&#92;&quot;paragraph&#92;&quot;&gt;Regulatory Framework&lt;/span&gt;&lt;/span&gt;&quot;' data-options='[&quot;CRR&quot;,&quot;BASEL_3_1&quot;]' data-allow-select-none='false' data-searchable='false' data-full-width='false'></marimo-dropdown></marimo-ui-element><marimo-ui-element object-id='bkHC-1' random-id='ed26053d-0078-7a55-fafe-6ce7efc727e7'><marimo-dropdown data-initial-value='[&quot;parquet&quot;]' data-label='&quot;&lt;span class=&#92;&quot;markdown prose dark:prose-invert contents&#92;&quot;&gt;&lt;span class=&#92;&quot;paragraph&#92;&quot;&gt;Data Format&lt;/span&gt;&lt;/span&gt;&quot;' data-options='[&quot;parquet&quot;,&quot;csv&quot;]' data-allow-select-none='false' data-searchable='false' data-full-width='false'></marimo-dropdown></marimo-ui-element><marimo-ui-element object-id='bkHC-2' random-id='c6ebb19a-4e91-ab9b-be94-e86d93e6a14a'><marimo-switch data-initial-value='false' data-label='&quot;&lt;span class=&#92;&quot;markdown prose dark:prose-invert contents&#92;&quot;&gt;&lt;span class=&#92;&quot;paragraph&#92;&quot;&gt;Enable IRB Approaches&lt;/span&gt;&lt;/span&gt;&quot;' data-disabled='false'></marimo-switch></marimo-ui-element></div>"
+            "text/html": "<div style='display: flex;flex: 1;flex-direction: column;justify-content: flex-start;align-items: normal;flex-wrap: nowrap;gap: 0.5rem'><span class=\"markdown prose dark:prose-invert contents\"><h3 id=\"data-configuration\">Data Configuration</h3></span><marimo-ui-element object-id='bkHC-0' random-id='4880e27a-3aae-c79e-c2f6-46f95e278b88'><marimo-text data-initial-value='&quot;C:&#92;&#92;Users&#92;&#92;philm&#92;&#92;PycharmProjects&#92;&#92;rwa_calculator&#92;&#92;tests&#92;&#92;fixtures&quot;' data-label='&quot;&lt;span class=&#92;&quot;markdown prose dark:prose-invert contents&#92;&quot;&gt;&lt;span class=&#92;&quot;paragraph&#92;&quot;&gt;Data Path&lt;/span&gt;&lt;/span&gt;&quot;' data-placeholder='&quot;Enter path to data directory&quot;' data-kind='&quot;text&quot;' data-full-width='true' data-disabled='false' data-debounce='true'></marimo-text></marimo-ui-element></div>"
           }
         }
       ],
@@ -45,12 +45,12 @@
     },
     {
       "id": "lEQa",
-      "code_hash": "28365339ee399857e281842ae1664bab",
+      "code_hash": "df6418e35c3d46907ac080f854087f40",
       "outputs": [
         {
           "type": "data",
           "data": {
-            "text/html": "<marimo-ui-element object-id='lEQa-0' random-id='7c8a9f6d-f946-b81c-c2c4-da5042383414'><marimo-date data-initial-value='&quot;2026-01-19&quot;' data-label='&quot;&lt;span class=&#92;&quot;markdown prose dark:prose-invert contents&#92;&quot;&gt;&lt;span class=&#92;&quot;paragraph&#92;&quot;&gt;Reporting Date&lt;/span&gt;&lt;/span&gt;&quot;' data-start='&quot;0001-01-01&quot;' data-stop='&quot;9999-12-31&quot;' data-full-width='false' data-disabled='false'></marimo-date></marimo-ui-element>"
+            "text/html": "<div style='display: flex;flex: 1;flex-direction: row;justify-content: flex-start;align-items: normal;flex-wrap: nowrap;gap: 2rem'><marimo-ui-element object-id='lEQa-0' random-id='59fd4622-e237-2d2b-2aa1-b4537289346c'><marimo-dropdown data-initial-value='[&quot;CRR&quot;]' data-label='&quot;&lt;span class=&#92;&quot;markdown prose dark:prose-invert contents&#92;&quot;&gt;&lt;span class=&#92;&quot;paragraph&#92;&quot;&gt;Regulatory Framework&lt;/span&gt;&lt;/span&gt;&quot;' data-options='[&quot;CRR&quot;,&quot;BASEL_3_1&quot;]' data-allow-select-none='false' data-searchable='false' data-full-width='false'></marimo-dropdown></marimo-ui-element><marimo-ui-element object-id='lEQa-1' random-id='85128c73-b2a7-e558-0425-eea2c0533221'><marimo-dropdown data-initial-value='[&quot;parquet&quot;]' data-label='&quot;&lt;span class=&#92;&quot;markdown prose dark:prose-invert contents&#92;&quot;&gt;&lt;span class=&#92;&quot;paragraph&#92;&quot;&gt;Data Format&lt;/span&gt;&lt;/span&gt;&quot;' data-options='[&quot;parquet&quot;,&quot;csv&quot;]' data-allow-select-none='false' data-searchable='false' data-full-width='false'></marimo-dropdown></marimo-ui-element><marimo-ui-element object-id='lEQa-2' random-id='a1beb78a-fdf9-c6c9-963f-b3a6995b0a62'><marimo-switch data-initial-value='false' data-label='&quot;&lt;span class=&#92;&quot;markdown prose dark:prose-invert contents&#92;&quot;&gt;&lt;span class=&#92;&quot;paragraph&#92;&quot;&gt;Enable IRB Approaches&lt;/span&gt;&lt;/span&gt;&quot;' data-disabled='false'></marimo-switch></marimo-ui-element></div>"
           }
         }
       ],
@@ -58,6 +58,19 @@
     },
     {
       "id": "PKri",
+      "code_hash": "28365339ee399857e281842ae1664bab",
+      "outputs": [
+        {
+          "type": "data",
+          "data": {
+            "text/html": "<marimo-ui-element object-id='PKri-0' random-id='b171194d-2ce2-0b6b-fbb7-cde36ae5e6e8'><marimo-date data-initial-value='&quot;2026-01-19&quot;' data-label='&quot;&lt;span class=&#92;&quot;markdown prose dark:prose-invert contents&#92;&quot;&gt;&lt;span class=&#92;&quot;paragraph&#92;&quot;&gt;Reporting Date&lt;/span&gt;&lt;/span&gt;&quot;' data-start='&quot;0001-01-01&quot;' data-stop='&quot;9999-12-31&quot;' data-full-width='false' data-disabled='false'></marimo-date></marimo-ui-element>"
+          }
+        }
+      ],
+      "console": []
+    },
+    {
+      "id": "Xref",
       "code_hash": "b038e380080ac5bc886bf065a4132fd0",
       "outputs": [
         {
@@ -70,26 +83,13 @@
       "console": []
     },
     {
-      "id": "Xref",
+      "id": "SFPL",
       "code_hash": "5bf517263380795da2bd4d46e652e0b7",
       "outputs": [
         {
           "type": "data",
           "data": {
-            "text/html": "<div style='display: flex;flex: 1;flex-direction: row;justify-content: center;align-items: normal;flex-wrap: nowrap;gap: 0.5rem'><marimo-ui-element object-id='Xref-0' random-id='aec63246-a208-e804-80fe-66dce01e98e8'><marimo-button data-initial-value='0' data-label='&quot;&lt;span class=&#92;&quot;markdown prose dark:prose-invert contents&#92;&quot;&gt;&lt;span class=&#92;&quot;paragraph&#92;&quot;&gt;Run Calculation&lt;/span&gt;&lt;/span&gt;&quot;' data-kind='&quot;neutral&quot;' data-disabled='false' data-full-width='false'></marimo-button></marimo-ui-element></div>"
-          }
-        }
-      ],
-      "console": []
-    },
-    {
-      "id": "SFPL",
-      "code_hash": "5f9fb60ab59f8d71b5c19fd1e4ec6261",
-      "outputs": [
-        {
-          "type": "data",
-          "data": {
-            "text/html": "<marimo-callout-output data-html='&quot;&lt;span&gt;Calculation completed successfully!&lt;/span&gt;&quot;' data-kind='&quot;success&quot;'></marimo-callout-output>"
+            "text/html": "<div style='display: flex;flex: 1;flex-direction: row;justify-content: center;align-items: normal;flex-wrap: nowrap;gap: 0.5rem'><marimo-ui-element object-id='SFPL-0' random-id='86f0b5b0-77fa-c252-0e00-a5f23c233dbe'><marimo-button data-initial-value='0' data-label='&quot;&lt;span class=&#92;&quot;markdown prose dark:prose-invert contents&#92;&quot;&gt;&lt;span class=&#92;&quot;paragraph&#92;&quot;&gt;Run Calculation&lt;/span&gt;&lt;/span&gt;&quot;' data-kind='&quot;neutral&quot;' data-disabled='false' data-full-width='false'></marimo-button></marimo-ui-element></div>"
           }
         }
       ],
@@ -97,12 +97,12 @@
     },
     {
       "id": "BYtC",
-      "code_hash": "a14579a99c8085e08494165e234359d4",
+      "code_hash": "78a4b4e956c73e8227ecded5ac7f151d",
       "outputs": [
         {
           "type": "data",
           "data": {
-            "text/markdown": "<span class=\"markdown prose dark:prose-invert contents\"><h2 id=\"summary-statistics\">Summary Statistics</h2>\n<table>\n<thead>\n<tr>\n<th>Metric</th>\n<th>Value</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td><strong>Total EAD</strong></td>\n<td>384,109,768</td>\n</tr>\n<tr>\n<td><strong>Total RWA</strong></td>\n<td>140,240,796</td>\n</tr>\n<tr>\n<td><strong>Average Risk Weight</strong></td>\n<td>36.51%</td>\n</tr>\n<tr>\n<td><strong>Exposure Count</strong></td>\n<td>77</td>\n</tr>\n<tr>\n<td><strong>SA RWA</strong></td>\n<td>53,733,137</td>\n</tr>\n<tr>\n<td><strong>IRB RWA</strong></td>\n<td>86,507,659</td>\n</tr>\n<tr>\n<td><strong>Slotting RWA</strong></td>\n<td>0</td>\n</tr>\n<tr>\n<td><strong>Floor Applied</strong></td>\n<td>No</td>\n</tr>\n<tr>\n<td><strong>Floor Impact</strong></td>\n<td>0</td>\n</tr>\n</tbody>\n</table></span>"
+            "text/html": "<marimo-callout-output data-html='&quot;&lt;span class=&#92;&quot;markdown prose dark:prose-invert contents&#92;&quot;&gt;&lt;span class=&#92;&quot;paragraph&#92;&quot;&gt;Calculation completed successfully! &lt;a href=&#92;&quot;/results_explorer.py&#92;&quot;&gt;Open Results Explorer&lt;/a&gt; to analyze.&lt;/span&gt;&lt;/span&gt;&quot;' data-kind='&quot;success&quot;'></marimo-callout-output>"
           }
         }
       ],
@@ -110,12 +110,12 @@
     },
     {
       "id": "RGSE",
-      "code_hash": "66917b6e705e90823d1ef65d86f5869e",
+      "code_hash": "a14579a99c8085e08494165e234359d4",
       "outputs": [
         {
           "type": "data",
           "data": {
-            "text/markdown": "<span class=\"markdown prose dark:prose-invert contents\"><h3 id=\"performance\">Performance</h3>\n<ul>\n<li><strong>Duration</strong>: 0.62 seconds</li>\n<li><strong>Throughput</strong>: 125 exposures/second</li>\n</ul></span>"
+            "text/markdown": "<span class=\"markdown prose dark:prose-invert contents\"><h2 id=\"summary-statistics\">Summary Statistics</h2>\n<table>\n<thead>\n<tr>\n<th>Metric</th>\n<th>Value</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td><strong>Total EAD</strong></td>\n<td>378,560,966</td>\n</tr>\n<tr>\n<td><strong>Total RWA</strong></td>\n<td>205,745,015</td>\n</tr>\n<tr>\n<td><strong>Average Risk Weight</strong></td>\n<td>54.35%</td>\n</tr>\n<tr>\n<td><strong>Exposure Count</strong></td>\n<td>77</td>\n</tr>\n<tr>\n<td><strong>SA RWA</strong></td>\n<td>205,745,015</td>\n</tr>\n<tr>\n<td><strong>IRB RWA</strong></td>\n<td>0</td>\n</tr>\n<tr>\n<td><strong>Slotting RWA</strong></td>\n<td>0</td>\n</tr>\n<tr>\n<td><strong>Floor Applied</strong></td>\n<td>No</td>\n</tr>\n<tr>\n<td><strong>Floor Impact</strong></td>\n<td>0</td>\n</tr>\n</tbody>\n</table></span>"
           }
         }
       ],
@@ -123,12 +123,12 @@
     },
     {
       "id": "Kclp",
-      "code_hash": "097bc968eb9d02c48219e64e201f371f",
+      "code_hash": "66917b6e705e90823d1ef65d86f5869e",
       "outputs": [
         {
           "type": "data",
           "data": {
-            "text/html": "<div style='display: flex;flex: 1;flex-direction: column;justify-content: flex-start;align-items: normal;flex-wrap: nowrap;gap: 0.5rem'><span class=\"markdown prose dark:prose-invert contents\"><h2 id=\"detailed-results\">Detailed Results</h2></span><marimo-ui-element object-id='Kclp-0' random-id='a7320b7d-669f-f6d1-4752-d6229c1d6ed8'><marimo-table data-initial-value='[]' data-label='null' data-data='&quot;[{&#92;&quot;exposure_reference&#92;&quot;:&#92;&quot;LOAN_SOV_UK_001&#92;&quot;,&#92;&quot;exposure_class&#92;&quot;:&#92;&quot;sovereign&#92;&quot;,&#92;&quot;approach_applied&#92;&quot;:&#92;&quot;SA&#92;&quot;,&#92;&quot;ead_final&#92;&quot;:1000000.0,&#92;&quot;risk_weight&#92;&quot;:0.0,&#92;&quot;rwa_final&#92;&quot;:0.0},{&#92;&quot;exposure_reference&#92;&quot;:&#92;&quot;LOAN_SOV_US_001&#92;&quot;,&#92;&quot;exposure_class&#92;&quot;:&#92;&quot;sovereign&#92;&quot;,&#92;&quot;approach_applied&#92;&quot;:&#92;&quot;SA&#92;&quot;,&#92;&quot;ead_final&#92;&quot;:4645136.842105263,&#92;&quot;risk_weight&#92;&quot;:0.0,&#92;&quot;rwa_final&#92;&quot;:0.0},{&#92;&quot;exposure_reference&#92;&quot;:&#92;&quot;LOAN_SOV_BR_001&#92;&quot;,&#92;&quot;exposure_class&#92;&quot;:&#92;&quot;sovereign&#92;&quot;,&#92;&quot;approach_applied&#92;&quot;:&#92;&quot;SA&#92;&quot;,&#92;&quot;ead_final&#92;&quot;:2000000.0,&#92;&quot;risk_weight&#92;&quot;:0.0,&#92;&quot;rwa_final&#92;&quot;:0.0},{&#92;&quot;exposure_reference&#92;&quot;:&#92;&quot;LOAN_INST_UK_001&#92;&quot;,&#92;&quot;exposure_class&#92;&quot;:&#92;&quot;institution&#92;&quot;,&#92;&quot;approach_applied&#92;&quot;:&#92;&quot;SA&#92;&quot;,&#92;&quot;ead_final&#92;&quot;:49943578.94736842,&#92;&quot;risk_weight&#92;&quot;:0.2,&#92;&quot;rwa_final&#92;&quot;:9988715.789473685},{&#92;&quot;exposure_reference&#92;&quot;:&#92;&quot;LOAN_INST_UK_003&#92;&quot;,&#92;&quot;exposure_class&#92;&quot;:&#92;&quot;institution&#92;&quot;,&#92;&quot;approach_applied&#92;&quot;:&#92;&quot;SA&#92;&quot;,&#92;&quot;ead_final&#92;&quot;:1000000.0,&#92;&quot;risk_weight&#92;&quot;:0.3,&#92;&quot;rwa_final&#92;&quot;:300000.0},{&#92;&quot;exposure_reference&#92;&quot;:&#92;&quot;LOAN_INST_UR_001&#92;&quot;,&#92;&quot;exposure_class&#92;&quot;:&#92;&quot;institution&#92;&quot;,&#92;&quot;approach_applied&#92;&quot;:&#92;&quot;SA&#92;&quot;,&#92;&quot;ead_final&#92;&quot;:9861052.631578946,&#92;&quot;risk_weight&#92;&quot;:0.29859094790777113,&#92;&quot;rwa_final&#92;&quot;:2944421.052631579},{&#92;&quot;exposure_reference&#92;&quot;:&#92;&quot;LOAN_SL_AIRB_001&#92;&quot;,&#92;&quot;exposure_class&#92;&quot;:&#92;&quot;other&#92;&quot;,&#92;&quot;approach_applied&#92;&quot;:&#92;&quot;SA&#92;&quot;,&#92;&quot;ead_final&#92;&quot;:10000000.0,&#92;&quot;risk_weight&#92;&quot;:1.0,&#92;&quot;rwa_final&#92;&quot;:10000000.0},{&#92;&quot;exposure_reference&#92;&quot;:&#92;&quot;LOAN_SL_PF_001&#92;&quot;,&#92;&quot;exposure_class&#92;&quot;:&#92;&quot;other&#92;&quot;,&#92;&quot;approach_applied&#92;&quot;:&#92;&quot;SA&#92;&quot;,&#92;&quot;ead_final&#92;&quot;:10000000.0,&#92;&quot;risk_weight&#92;&quot;:1.0,&#92;&quot;rwa_final&#92;&quot;:10000000.0},{&#92;&quot;exposure_reference&#92;&quot;:&#92;&quot;LOAN_SL_PF_002&#92;&quot;,&#92;&quot;exposure_class&#92;&quot;:&#92;&quot;other&#92;&quot;,&#92;&quot;approach_applied&#92;&quot;:&#92;&quot;SA&#92;&quot;,&#92;&quot;ead_final&#92;&quot;:10000000.0,&#92;&quot;risk_weight&#92;&quot;:1.0,&#92;&quot;rwa_final&#92;&quot;:10000000.0},{&#92;&quot;exposure_reference&#92;&quot;:&#92;&quot;LOAN_SL_IPRE_001&#92;&quot;,&#92;&quot;exposure_class&#92;&quot;:&#92;&quot;other&#92;&quot;,&#92;&quot;approach_applied&#92;&quot;:&#92;&quot;SA&#92;&quot;,&#92;&quot;ead_final&#92;&quot;:5000000.0,&#92;&quot;risk_weight&#92;&quot;:1.0,&#92;&quot;rwa_final&#92;&quot;:5000000.0}]&quot;' data-total-rows='77' data-total-columns='6' data-max-columns='50' data-banner-text='&quot;&quot;' data-pagination='true' data-page-size='10' data-field-types='[[&quot;exposure_reference&quot;,[&quot;string&quot;,&quot;str&quot;]],[&quot;exposure_class&quot;,[&quot;string&quot;,&quot;str&quot;]],[&quot;approach_applied&quot;,[&quot;string&quot;,&quot;str&quot;]],[&quot;ead_final&quot;,[&quot;number&quot;,&quot;f64&quot;]],[&quot;risk_weight&quot;,[&quot;number&quot;,&quot;f64&quot;]],[&quot;rwa_final&quot;,[&quot;number&quot;,&quot;f64&quot;]]]' data-show-filters='true' data-show-download='true' data-show-column-summaries='true' data-show-data-types='true' data-show-page-size-selector='true' data-show-column-explorer='true' data-show-chart-builder='true' data-row-headers='[]' data-has-stable-row-id='false' data-lazy='false' data-preload='false'></marimo-table></marimo-ui-element></div>"
+            "text/markdown": "<span class=\"markdown prose dark:prose-invert contents\"><h3 id=\"performance\">Performance</h3>\n<ul>\n<li><strong>Duration</strong>: 0.79 seconds</li>\n<li><strong>Throughput</strong>: 97 exposures/second</li>\n</ul></span>"
           }
         }
       ],
@@ -136,12 +136,12 @@
     },
     {
       "id": "emfo",
-      "code_hash": "3c4ac2f6cabb0ab3cb7a4edfa89c71f0",
+      "code_hash": "cfa02640fbf1b0b3fc96aef01f7384e0",
       "outputs": [
         {
           "type": "data",
           "data": {
-            "text/html": "<div style='display: flex;flex: 1;flex-direction: column;justify-content: flex-start;align-items: normal;flex-wrap: nowrap;gap: 0.5rem'><span class=\"markdown prose dark:prose-invert contents\"><h3 id=\"summary-by-exposure-class\">Summary by Exposure Class</h3></span><marimo-ui-element object-id='emfo-0' random-id='1786f01d-2d98-a5e7-abb2-3ee913eea11a'><marimo-table data-initial-value='[]' data-label='null' data-data='&quot;[{&#92;&quot;exposure_class&#92;&quot;:&#92;&quot;corporate&#92;&quot;,&#92;&quot;total_ead&#92;&quot;:238500000.0,&#92;&quot;total_rwa&#92;&quot;:79258454.06751518,&#92;&quot;exposure_count&#92;&quot;:41,&#92;&quot;avg_risk_weight&#92;&quot;:0.33232056212794625},{&#92;&quot;exposure_class&#92;&quot;:&#92;&quot;corporate_sme&#92;&quot;,&#92;&quot;total_ead&#92;&quot;:33050000.0,&#92;&quot;total_rwa&#92;&quot;:7106125.658615474,&#92;&quot;exposure_count&#92;&quot;:15,&#92;&quot;avg_risk_weight&#92;&quot;:0.27567047883523166},{&#92;&quot;exposure_class&#92;&quot;:&#92;&quot;other&#92;&quot;,&#92;&quot;total_ead&#92;&quot;:40000000.0,&#92;&quot;total_rwa&#92;&quot;:40000000.0,&#92;&quot;exposure_count&#92;&quot;:5,&#92;&quot;avg_risk_weight&#92;&quot;:1.0},{&#92;&quot;exposure_class&#92;&quot;:&#92;&quot;institution&#92;&quot;,&#92;&quot;total_ead&#92;&quot;:63304631.578947365,&#92;&quot;total_rwa&#92;&quot;:13733136.842105264,&#92;&quot;exposure_count&#92;&quot;:4,&#92;&quot;avg_risk_weight&#92;&quot;:0.21693731563667082},{&#92;&quot;exposure_class&#92;&quot;:&#92;&quot;retail_mortgage&#92;&quot;,&#92;&quot;total_ead&#92;&quot;:1350000.0,&#92;&quot;total_rwa&#92;&quot;:71303.37911130594,&#92;&quot;exposure_count&#92;&quot;:2,&#92;&quot;avg_risk_weight&#92;&quot;:0.05281731786022662},{&#92;&quot;exposure_class&#92;&quot;:&#92;&quot;retail_other&#92;&quot;,&#92;&quot;total_ead&#92;&quot;:260000.0,&#92;&quot;total_rwa&#92;&quot;:71776.13229129065,&#92;&quot;exposure_count&#92;&quot;:7,&#92;&quot;avg_risk_weight&#92;&quot;:0.2760620472741948},{&#92;&quot;exposure_class&#92;&quot;:&#92;&quot;sovereign&#92;&quot;,&#92;&quot;total_ead&#92;&quot;:7645136.842105263,&#92;&quot;total_rwa&#92;&quot;:0.0,&#92;&quot;exposure_count&#92;&quot;:3,&#92;&quot;avg_risk_weight&#92;&quot;:0.0}]&quot;' data-total-rows='7' data-total-columns='5' data-max-columns='50' data-banner-text='&quot;&quot;' data-pagination='false' data-page-size='10' data-field-types='[[&quot;exposure_class&quot;,[&quot;string&quot;,&quot;str&quot;]],[&quot;total_ead&quot;,[&quot;number&quot;,&quot;f64&quot;]],[&quot;total_rwa&quot;,[&quot;number&quot;,&quot;f64&quot;]],[&quot;exposure_count&quot;,[&quot;integer&quot;,&quot;u32&quot;]],[&quot;avg_risk_weight&quot;,[&quot;number&quot;,&quot;f64&quot;]]]' data-show-filters='true' data-show-download='true' data-show-column-summaries='false' data-show-data-types='true' data-show-page-size-selector='true' data-show-column-explorer='true' data-show-chart-builder='true' data-row-headers='[]' data-has-stable-row-id='false' data-lazy='false' data-preload='false'></marimo-table></marimo-ui-element></div>"
+            "text/html": "<div style='display: flex;flex: 1;flex-direction: column;justify-content: flex-start;align-items: normal;flex-wrap: nowrap;gap: 0.5rem'><span class=\"markdown prose dark:prose-invert contents\"><h2 id=\"results-preview-first-100-rows\">Results Preview (first 100 rows)</h2></span><span class=\"markdown prose dark:prose-invert contents\"><span class=\"paragraph\"><em>For full analysis, use the <a href=\"/results_explorer.py\">Results Explorer</a></em></span></span><marimo-ui-element object-id='emfo-0' random-id='1074ddc7-8ad8-ffdd-e318-648bc4d34382'><marimo-table data-initial-value='[]' data-label='null' data-data='&quot;[{&#92;&quot;exposure_reference&#92;&quot;:&#92;&quot;LOAN_SOV_UK_001&#92;&quot;,&#92;&quot;exposure_class&#92;&quot;:&#92;&quot;sovereign&#92;&quot;,&#92;&quot;approach_applied&#92;&quot;:&#92;&quot;SA&#92;&quot;,&#92;&quot;ead_final&#92;&quot;:1000000.0,&#92;&quot;risk_weight&#92;&quot;:0.0,&#92;&quot;rwa_final&#92;&quot;:0.0},{&#92;&quot;exposure_reference&#92;&quot;:&#92;&quot;LOAN_SOV_US_001&#92;&quot;,&#92;&quot;exposure_class&#92;&quot;:&#92;&quot;sovereign&#92;&quot;,&#92;&quot;approach_applied&#92;&quot;:&#92;&quot;SA&#92;&quot;,&#92;&quot;ead_final&#92;&quot;:4645136.842105263,&#92;&quot;risk_weight&#92;&quot;:0.0,&#92;&quot;rwa_final&#92;&quot;:0.0},{&#92;&quot;exposure_reference&#92;&quot;:&#92;&quot;LOAN_SOV_BR_001&#92;&quot;,&#92;&quot;exposure_class&#92;&quot;:&#92;&quot;sovereign&#92;&quot;,&#92;&quot;approach_applied&#92;&quot;:&#92;&quot;SA&#92;&quot;,&#92;&quot;ead_final&#92;&quot;:2000000.0,&#92;&quot;risk_weight&#92;&quot;:0.0,&#92;&quot;rwa_final&#92;&quot;:0.0},{&#92;&quot;exposure_reference&#92;&quot;:&#92;&quot;LOAN_INST_UK_001&#92;&quot;,&#92;&quot;exposure_class&#92;&quot;:&#92;&quot;institution&#92;&quot;,&#92;&quot;approach_applied&#92;&quot;:&#92;&quot;SA&#92;&quot;,&#92;&quot;ead_final&#92;&quot;:49943578.94736842,&#92;&quot;risk_weight&#92;&quot;:0.2,&#92;&quot;rwa_final&#92;&quot;:9988715.789473685},{&#92;&quot;exposure_reference&#92;&quot;:&#92;&quot;LOAN_INST_UK_003&#92;&quot;,&#92;&quot;exposure_class&#92;&quot;:&#92;&quot;institution&#92;&quot;,&#92;&quot;approach_applied&#92;&quot;:&#92;&quot;SA&#92;&quot;,&#92;&quot;ead_final&#92;&quot;:1000000.0,&#92;&quot;risk_weight&#92;&quot;:0.3,&#92;&quot;rwa_final&#92;&quot;:300000.0},{&#92;&quot;exposure_reference&#92;&quot;:&#92;&quot;LOAN_INST_UR_001&#92;&quot;,&#92;&quot;exposure_class&#92;&quot;:&#92;&quot;institution&#92;&quot;,&#92;&quot;approach_applied&#92;&quot;:&#92;&quot;SA&#92;&quot;,&#92;&quot;ead_final&#92;&quot;:9861052.631578946,&#92;&quot;risk_weight&#92;&quot;:0.29859094790777113,&#92;&quot;rwa_final&#92;&quot;:2944421.052631579},{&#92;&quot;exposure_reference&#92;&quot;:&#92;&quot;LOAN_CORP_UR_001&#92;&quot;,&#92;&quot;exposure_class&#92;&quot;:&#92;&quot;corporate&#92;&quot;,&#92;&quot;approach_applied&#92;&quot;:&#92;&quot;SA&#92;&quot;,&#92;&quot;ead_final&#92;&quot;:1000000.0,&#92;&quot;risk_weight&#92;&quot;:1.0,&#92;&quot;rwa_final&#92;&quot;:1000000.0},{&#92;&quot;exposure_reference&#92;&quot;:&#92;&quot;LOAN_CORP_UK_003&#92;&quot;,&#92;&quot;exposure_class&#92;&quot;:&#92;&quot;corporate&#92;&quot;,&#92;&quot;approach_applied&#92;&quot;:&#92;&quot;SA&#92;&quot;,&#92;&quot;ead_final&#92;&quot;:1000000.0,&#92;&quot;risk_weight&#92;&quot;:0.5,&#92;&quot;rwa_final&#92;&quot;:500000.0},{&#92;&quot;exposure_reference&#92;&quot;:&#92;&quot;LOAN_CORP_UK_001&#92;&quot;,&#92;&quot;exposure_class&#92;&quot;:&#92;&quot;corporate&#92;&quot;,&#92;&quot;approach_applied&#92;&quot;:&#92;&quot;SA&#92;&quot;,&#92;&quot;ead_final&#92;&quot;:25000000.0,&#92;&quot;risk_weight&#92;&quot;:0.2,&#92;&quot;rwa_final&#92;&quot;:5000000.0},{&#92;&quot;exposure_reference&#92;&quot;:&#92;&quot;LOAN_CORP_SUB_001&#92;&quot;,&#92;&quot;exposure_class&#92;&quot;:&#92;&quot;corporate&#92;&quot;,&#92;&quot;approach_applied&#92;&quot;:&#92;&quot;SA&#92;&quot;,&#92;&quot;ead_final&#92;&quot;:3650000.0,&#92;&quot;risk_weight&#92;&quot;:0.5,&#92;&quot;rwa_final&#92;&quot;:1825000.0}]&quot;' data-total-rows='77' data-total-columns='6' data-max-columns='50' data-banner-text='&quot;&quot;' data-pagination='true' data-page-size='10' data-field-types='[[&quot;exposure_reference&quot;,[&quot;string&quot;,&quot;str&quot;]],[&quot;exposure_class&quot;,[&quot;string&quot;,&quot;str&quot;]],[&quot;approach_applied&quot;,[&quot;string&quot;,&quot;str&quot;]],[&quot;ead_final&quot;,[&quot;number&quot;,&quot;f64&quot;]],[&quot;risk_weight&quot;,[&quot;number&quot;,&quot;f64&quot;]],[&quot;rwa_final&quot;,[&quot;number&quot;,&quot;f64&quot;]]]' data-show-filters='true' data-show-download='true' data-show-column-summaries='true' data-show-data-types='true' data-show-page-size-selector='true' data-show-column-explorer='true' data-show-chart-builder='true' data-row-headers='[]' data-has-stable-row-id='false' data-lazy='false' data-preload='false'></marimo-table></marimo-ui-element></div>"
           }
         }
       ],
@@ -149,19 +149,6 @@
     },
     {
       "id": "Hstk",
-      "code_hash": "ef827137957894f3800f0844be5d9472",
-      "outputs": [
-        {
-          "type": "data",
-          "data": {
-            "text/html": "<div style='display: flex;flex: 1;flex-direction: column;justify-content: flex-start;align-items: normal;flex-wrap: nowrap;gap: 0.5rem'><span class=\"markdown prose dark:prose-invert contents\"><h3 id=\"summary-by-approach\">Summary by Approach</h3></span><marimo-ui-element object-id='Hstk-0' random-id='9d04f144-24f6-3c77-f03e-5de43808d691'><marimo-table data-initial-value='[]' data-label='null' data-data='&quot;[{&#92;&quot;approach_applied&#92;&quot;:&#92;&quot;advanced_irb&#92;&quot;,&#92;&quot;total_ead&#92;&quot;:273160000.0,&#92;&quot;total_rwa&#92;&quot;:86507659.23753324,&#92;&quot;exposure_count&#92;&quot;:65,&#92;&quot;total_expected_loss&#92;&quot;:357941.00000000006},{&#92;&quot;approach_applied&#92;&quot;:&#92;&quot;SA&#92;&quot;,&#92;&quot;total_ead&#92;&quot;:110949768.42105263,&#92;&quot;total_rwa&#92;&quot;:53733136.84210526,&#92;&quot;exposure_count&#92;&quot;:12,&#92;&quot;total_expected_loss&#92;&quot;:0.0}]&quot;' data-total-rows='2' data-total-columns='5' data-max-columns='50' data-banner-text='&quot;&quot;' data-pagination='false' data-page-size='10' data-field-types='[[&quot;approach_applied&quot;,[&quot;string&quot;,&quot;str&quot;]],[&quot;total_ead&quot;,[&quot;number&quot;,&quot;f64&quot;]],[&quot;total_rwa&quot;,[&quot;number&quot;,&quot;f64&quot;]],[&quot;exposure_count&quot;,[&quot;integer&quot;,&quot;u32&quot;]],[&quot;total_expected_loss&quot;,[&quot;number&quot;,&quot;f64&quot;]]]' data-show-filters='true' data-show-download='true' data-show-column-summaries='false' data-show-data-types='true' data-show-page-size-selector='false' data-show-column-explorer='true' data-show-chart-builder='true' data-row-headers='[]' data-has-stable-row-id='false' data-lazy='false' data-preload='false'></marimo-table></marimo-ui-element></div>"
-          }
-        }
-      ],
-      "console": []
-    },
-    {
-      "id": "nWHF",
       "code_hash": "55fc7801d51996e0a6d28ef9867ef646",
       "outputs": [
         {
@@ -174,33 +161,20 @@
       "console": []
     },
     {
-      "id": "iLit",
+      "id": "nWHF",
       "code_hash": "fdd84dbb413765e8e7a01c5e0ce8f41a",
       "outputs": [
         {
           "type": "data",
           "data": {
-            "text/html": "<div style='display: flex;flex: 1;flex-direction: column;justify-content: flex-start;align-items: normal;flex-wrap: nowrap;gap: 0.5rem'><span class=\"markdown prose dark:prose-invert contents\"><h3 id=\"export-results\">Export Results</h3></span><marimo-ui-element object-id='iLit-0' random-id='1cb79ae8-4cbf-5f0b-6a52-fe57bb37540c'><marimo-download data-initial-value='null' data-label='&quot;&lt;span class=&#92;&quot;markdown prose dark:prose-invert contents&#92;&quot;&gt;&lt;span class=&#92;&quot;paragraph&#92;&quot;&gt;Download CSV&lt;/span&gt;&lt;/span&gt;&quot;' data-data='&quot;./@file/68913-17636-KTkP5shE.xls&quot;' data-filename='&quot;rwa_results.csv&quot;' data-disabled='false' data-lazy='false'></marimo-download></marimo-ui-element></div>"
+            "text/html": "<div style='display: flex;flex: 1;flex-direction: column;justify-content: flex-start;align-items: normal;flex-wrap: nowrap;gap: 0.5rem'><span class=\"markdown prose dark:prose-invert contents\"><h3 id=\"export-results\">Export Results</h3></span><marimo-ui-element object-id='nWHF-0' random-id='d27c6251-c757-768a-6de0-7d8d1b16c366'><marimo-download data-initial-value='null' data-label='&quot;&lt;span class=&#92;&quot;markdown prose dark:prose-invert contents&#92;&quot;&gt;&lt;span class=&#92;&quot;paragraph&#92;&quot;&gt;Download CSV&lt;/span&gt;&lt;/span&gt;&quot;' data-data='&quot;./@file/61209-68552-zJ6TtAb2.xls&quot;' data-filename='&quot;rwa_results.csv&quot;' data-disabled='false' data-lazy='false'></marimo-download></marimo-ui-element></div>"
           }
         }
       ],
       "console": []
     },
     {
-      "id": "MJUe",
-      "code_hash": "199288f889e7b7e4094fab8cc0595cbf",
-      "outputs": [
-        {
-          "type": "data",
-          "data": {
-            "text/markdown": "<span class=\"markdown prose dark:prose-invert contents\"><h1 id=\"rwa-calculator\">RWA Calculator</h1>\n<hr /></span>"
-          }
-        }
-      ],
-      "console": []
-    },
-    {
-      "id": "ZHCJ",
+      "id": "vblA",
       "code_hash": null,
       "outputs": [
         {

--- a/src/rwa_calc/ui/marimo/framework_reference.py
+++ b/src/rwa_calc/ui/marimo/framework_reference.py
@@ -1,0 +1,342 @@
+"""
+RWA Framework Reference Marimo Application.
+
+Reference documentation for CRR and Basel 3.1 regulatory frameworks.
+
+Usage:
+    uv run marimo edit src/rwa_calc/ui/marimo/framework_reference.py
+    uv run marimo run src/rwa_calc/ui/marimo/framework_reference.py
+
+Features:
+    - CRR (Basel 3.0) reference tables
+    - Basel 3.1 (PRA PS9/24) reference tables
+    - Risk weight tables
+    - Supporting factor details
+    - IRB parameters
+"""
+
+import marimo
+
+__generated_with = "0.19.4"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+    import polars as pl
+
+    return mo, pl
+
+
+@app.cell
+def _(mo):
+    mo.sidebar(
+        [
+            mo.md("# RWA Calculator"),
+            mo.nav_menu(
+                {
+                    "/calculator": f"{mo.icon('calculator')} Calculator",
+                    "/results": f"{mo.icon('table')} Results Explorer",
+                    "/reference": f"{mo.icon('book')} Framework Reference",
+                },
+                orientation="vertical",
+            ),
+            mo.md("---"),
+            mo.md("""
+**Quick Links**
+- [PRA PS9/24](https://www.bankofengland.co.uk/prudential-regulation/publication/2024/september/implementation-of-the-basel-3-1-standards-near-final-policy-statement-part-2)
+- [UK CRR](https://www.legislation.gov.uk/eur/2013/575/contents)
+- [BCBS Framework](https://www.bis.org/basel_framework/)
+            """),
+        ],
+        footer=mo.md("*RWA Calculator v1.0*"),
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    return mo.md("""
+# Framework Reference
+
+Regulatory reference documentation for RWA calculations under CRR and Basel 3.1.
+    """)
+
+
+@app.cell
+def _(mo):
+    framework_tabs = mo.ui.tabs({
+        "Overview": "overview",
+        "CRR (Basel 3.0)": "crr",
+        "Basel 3.1": "basel31",
+        "Risk Weights": "rw",
+        "IRB Parameters": "irb",
+    })
+
+    mo.output.replace(framework_tabs)
+    return (framework_tabs,)
+
+
+@app.cell
+def _(framework_tabs, mo, pl):
+    if framework_tabs.value == "overview":
+        mo.output.replace(mo.md("""
+## Framework Overview
+
+### Timeline
+
+| Framework | Status | Effective Period |
+|-----------|--------|------------------|
+| **CRR (Basel 3.0)** | Current | Until 31 December 2026 |
+| **Basel 3.1** | Upcoming | From 1 January 2027 |
+
+### Key Differences
+
+| Feature | CRR | Basel 3.1 |
+|---------|-----|-----------|
+| **SME Supporting Factor** | 0.7619 (Art. 501) | Removed |
+| **Infrastructure Factor** | 0.75 (Art. 501a) | Removed |
+| **Output Floor** | None | 72.5% of SA RWA |
+| **PD Floor** | 0.03% (all classes) | 0.03% - 0.10% (differentiated) |
+| **LGD Floors** | Based on CRR rules | New floors by collateral type |
+| **Credit Conversion Factors** | Regulatory CCFs | Revised CCFs |
+
+### Regulatory Sources
+
+- **UK CRR**: [legislation.gov.uk](https://www.legislation.gov.uk/eur/2013/575/contents)
+- **PRA PS9/24**: [Bank of England](https://www.bankofengland.co.uk/prudential-regulation/publication/2024/september/implementation-of-the-basel-3-1-standards-near-final-policy-statement-part-2)
+- **BCBS Framework**: [bis.org](https://www.bis.org/basel_framework/)
+        """))
+
+    elif framework_tabs.value == "crr":
+        mo.output.replace(mo.md("""
+## CRR (Basel 3.0) Framework
+
+### Supporting Factors
+
+#### SME Supporting Factor (Article 501)
+Exposures to SMEs qualify for a reduction in capital requirements:
+
+| Condition | Factor |
+|-----------|--------|
+| Total exposure ≤ €2.5m | 0.7619 |
+| Total exposure > €2.5m | 0.7619 (on first €2.5m) |
+
+**Eligibility Criteria:**
+- Counterparty is an SME (annual turnover ≤ €50m)
+- Total exposure to the SME group ≤ €1.5m
+
+#### Infrastructure Supporting Factor (Article 501a)
+
+| Condition | Factor |
+|-----------|--------|
+| Qualifying infrastructure exposure | 0.75 |
+
+**Eligibility Criteria:**
+- Project entity operates infrastructure
+- Cash flows predictable
+- Contractual arrangements provide security
+- Debt repayment from project revenues
+
+### Exposure Classes (Article 112)
+
+| Class | Description |
+|-------|-------------|
+| Central Governments | Sovereigns, central banks |
+| Regional/Local Authorities | Sub-national governments |
+| Public Sector Entities | Government-related entities |
+| Multilateral Development Banks | MDBs (special treatment) |
+| International Organisations | IMF, BIS, etc. |
+| Institutions | Banks, investment firms |
+| Corporates | Non-financial corporates |
+| Retail | SME and natural persons |
+| Secured by Real Estate | Mortgage exposures |
+| In Default | Defaulted exposures |
+| High Risk | Venture capital, etc. |
+| Covered Bonds | Covered bond exposures |
+| Securitisation | Securitisation positions |
+| CIUs | Collective investment undertakings |
+| Equity | Equity holdings |
+| Other Items | Residual exposures |
+        """))
+
+    elif framework_tabs.value == "basel31":
+        mo.output.replace(mo.md("""
+## Basel 3.1 Framework (PRA PS9/24)
+
+### Key Changes from CRR
+
+#### 1. Output Floor
+- Floor = 72.5% of SA RWA
+- Transitional period: 50% (2027) rising to 72.5% (2030)
+- Applies to banks using IRB approach
+
+#### 2. Removal of Supporting Factors
+- SME supporting factor: **Removed**
+- Infrastructure supporting factor: **Removed**
+
+#### 3. Revised Standardised Approach
+
+**Corporate Risk Weights:**
+
+| Rating | Risk Weight |
+|--------|-------------|
+| AAA to AA- | 20% |
+| A+ to A- | 50% |
+| BBB+ to BBB- | 75% |
+| BB+ to BB- | 100% |
+| Below BB- | 150% |
+| Unrated | 100% |
+
+**SME Corporates:** 85% (if unrated, turnover ≤ €50m)
+
+#### 4. Real Estate Exposures
+
+**Residential (Income-Producing):**
+
+| LTV | Risk Weight |
+|-----|-------------|
+| ≤ 50% | 30% |
+| 50-60% | 35% |
+| 60-80% | 45% |
+| 80-90% | 60% |
+| 90-100% | 75% |
+| > 100% | 105% |
+
+**Commercial:**
+
+| LTV | Risk Weight |
+|-----|-------------|
+| ≤ 60% | 70% |
+| > 60% | 110% |
+
+#### 5. Off-Balance Sheet Items
+
+| Category | CCF |
+|----------|-----|
+| Unconditionally cancellable commitments | 10% |
+| Other commitments | 40% |
+| Direct credit substitutes | 100% |
+| Trade-related contingencies | 20% |
+| Transaction-related contingencies | 50% |
+        """))
+
+    elif framework_tabs.value == "rw":
+        # Risk weight tables
+        sa_rw_table = pl.DataFrame({
+            "Exposure Class": [
+                "Central Governments (AAA-AA)",
+                "Central Governments (A)",
+                "Central Governments (BBB)",
+                "Central Governments (BB)",
+                "Central Governments (B)",
+                "Central Governments (Below B)",
+                "Institutions (AAA-AA)",
+                "Institutions (A)",
+                "Institutions (BBB)",
+                "Institutions (BB)",
+                "Institutions (Below BB)",
+                "Corporates (AAA-AA)",
+                "Corporates (A)",
+                "Corporates (BBB)",
+                "Corporates (BB)",
+                "Corporates (Below BB)",
+                "Corporates (Unrated)",
+                "Retail",
+                "Residential Mortgage (LTV ≤ 80%)",
+                "Commercial Real Estate",
+                "Defaulted",
+            ],
+            "CRR RW": [
+                "0%", "20%", "50%", "100%", "100%", "150%",
+                "20%", "50%", "50%", "100%", "150%",
+                "20%", "50%", "100%", "100%", "150%", "100%",
+                "75%", "35%", "100%", "150%",
+            ],
+            "Basel 3.1 RW": [
+                "0%", "20%", "50%", "100%", "100%", "150%",
+                "20%", "30%", "50%", "100%", "150%",
+                "20%", "50%", "75%", "100%", "150%", "100%",
+                "75%", "45%*", "70-110%*", "100-150%",
+            ],
+        })
+
+        mo.output.replace(
+            mo.vstack([
+                mo.md("## Standardised Approach Risk Weights"),
+                mo.md("*Note: Basel 3.1 values marked with * are dependent on LTV or other conditions*"),
+                mo.ui.table(sa_rw_table, selection=None),
+            ])
+        )
+
+    elif framework_tabs.value == "irb":
+        mo.output.replace(mo.md("""
+## IRB Parameters
+
+### PD Floors
+
+| Exposure Class | CRR Floor | Basel 3.1 Floor |
+|----------------|-----------|-----------------|
+| Corporates | 0.03% | 0.05% |
+| Banks/Financial Institutions | 0.03% | 0.05% |
+| Sovereigns | 0.03% | 0.03% |
+| Retail - Mortgages | 0.03% | 0.05% |
+| Retail - QRRE | 0.03% | 0.05% |
+| Retail - Other | 0.03% | 0.10% |
+
+### LGD Values (Foundation IRB)
+
+| Collateral Type | CRR LGD | Basel 3.1 Floor |
+|-----------------|---------|-----------------|
+| Senior unsecured | 45% | 25% |
+| Subordinated | 75% | 25% |
+| Financial collateral | Varies | Varies |
+| Receivables | 35% | 20% |
+| Commercial/Residential RE | 35% | 20% |
+| Other physical collateral | 40% | 25% |
+
+### Maturity (M)
+
+| IRB Approach | CRR | Basel 3.1 |
+|--------------|-----|-----------|
+| Foundation IRB | 2.5 years (fixed) | 2.5 years (fixed) |
+| Advanced IRB | Bank estimate | Bank estimate |
+| Floor | 1 year | 1 year |
+| Cap | 5 years | 5 years |
+
+### Correlation (R)
+
+**Corporate Formula:**
+```
+R = 0.12 × (1 - EXP(-50 × PD)) / (1 - EXP(-50))
+  + 0.24 × (1 - (1 - EXP(-50 × PD)) / (1 - EXP(-50)))
+```
+
+**SME Adjustment (CRR only):**
+```
+R_SME = R - 0.04 × (1 - (S - 5) / 45)
+```
+Where S = turnover in € millions (floored at 5, capped at 50)
+
+**Basel 3.1 Note:** SME correlation adjustment is removed.
+
+### Capital Requirement Formula
+
+```
+K = LGD × N[(1-R)^(-0.5) × G(PD) + (R/(1-R))^0.5 × G(0.999)]
+    - PD × LGD
+```
+
+Where:
+- N = Standard normal CDF
+- G = Inverse standard normal CDF
+- R = Asset correlation
+- PD = Probability of default
+- LGD = Loss given default
+        """))
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/src/rwa_calc/ui/marimo/results_explorer.py
+++ b/src/rwa_calc/ui/marimo/results_explorer.py
@@ -1,0 +1,428 @@
+"""
+RWA Results Explorer Marimo Application.
+
+Interactive UI for exploring and analyzing RWA calculation results.
+
+Usage:
+    uv run marimo edit src/rwa_calc/ui/marimo/results_explorer.py
+    uv run marimo run src/rwa_calc/ui/marimo/results_explorer.py
+
+Features:
+    - Load cached results from calculator
+    - Filter by exposure class, approach, risk weight range
+    - Aggregation by different dimensions
+    - Drill-down into individual exposures
+    - Charts and visualizations
+    - Export filtered results
+"""
+
+import marimo
+
+__generated_with = "0.19.4"
+app = marimo.App(width="full")
+
+
+@app.cell
+def _():
+    import marimo as mo
+    import polars as pl
+    import json
+    from pathlib import Path
+
+    cache_dir = Path(__file__).parent / ".cache"
+
+    return Path, cache_dir, json, mo, pl
+
+
+@app.cell
+def _(mo):
+    mo.sidebar(
+        [
+            mo.md("# RWA Calculator"),
+            mo.nav_menu(
+                {
+                    "/calculator": f"{mo.icon('calculator')} Calculator",
+                    "/results": f"{mo.icon('table')} Results Explorer",
+                    "/reference": f"{mo.icon('book')} Framework Reference",
+                },
+                orientation="vertical",
+            ),
+            mo.md("---"),
+            mo.md("""
+**Quick Links**
+- [PRA PS9/24](https://www.bankofengland.co.uk/prudential-regulation/publication/2024/september/implementation-of-the-basel-3-1-standards-near-final-policy-statement-part-2)
+- [UK CRR](https://www.legislation.gov.uk/eur/2013/575/contents)
+- [BCBS Framework](https://www.bis.org/basel_framework/)
+            """),
+        ],
+        footer=mo.md("*RWA Calculator v1.0*"),
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    return mo.md("""
+# Results Explorer
+
+Analyze and drill down into your RWA calculation results. Use the filters below to explore the data.
+    """)
+
+
+@app.cell
+def _(cache_dir, json, mo, pl):
+    results_file = cache_dir / "last_results.parquet"
+    meta_file = cache_dir / "last_results_meta.json"
+
+    if results_file.exists():
+        results_df = pl.read_parquet(results_file)
+        metadata = json.loads(meta_file.read_text()) if meta_file.exists() else {}
+        has_results = True
+
+        mo.output.replace(
+            mo.callout(
+                mo.md(f"""
+**Loaded Results**
+- Framework: {metadata.get('framework', 'Unknown')}
+- Reporting Date: {metadata.get('reporting_date', 'Unknown')}
+- Total Exposures: {results_df.height:,}
+- Total RWA: {metadata.get('total_rwa', 0):,.0f}
+                """),
+                kind="success",
+            )
+        )
+    else:
+        results_df = pl.DataFrame()
+        metadata = {}
+        has_results = False
+
+        mo.output.replace(
+            mo.callout(
+                mo.md("No results found. Please run a calculation in the [Calculator](/calculator) first."),
+                kind="warn",
+            )
+        )
+
+    return has_results, metadata, results_df
+
+
+@app.cell
+def _(has_results, mo, results_df):
+    if has_results and results_df.height > 0:
+        # Get unique values for filters
+        exposure_classes = ["All"] + sorted(
+            results_df.select("exposure_class").unique().to_series().to_list()
+        ) if "exposure_class" in results_df.columns else ["All"]
+
+        approaches = ["All"] + sorted(
+            results_df.select("approach_applied").unique().to_series().to_list()
+        ) if "approach_applied" in results_df.columns else ["All"]
+
+        # Create filter widgets
+        class_filter = mo.ui.dropdown(
+            options=exposure_classes,
+            value="All",
+            label="Exposure Class",
+        )
+
+        approach_filter = mo.ui.dropdown(
+            options=approaches,
+            value="All",
+            label="Approach",
+        )
+
+        rw_min = mo.ui.number(
+            value=0.0,
+            start=0.0,
+            stop=5.0,
+            step=0.01,
+            label="Min Risk Weight",
+        )
+
+        rw_max = mo.ui.number(
+            value=5.0,
+            start=0.0,
+            stop=5.0,
+            step=0.01,
+            label="Max Risk Weight",
+        )
+
+        mo.output.replace(
+            mo.vstack([
+                mo.md("### Filters"),
+                mo.hstack([
+                    class_filter,
+                    approach_filter,
+                    rw_min,
+                    rw_max,
+                ], justify="start", gap=2),
+            ])
+        )
+    else:
+        class_filter = None
+        approach_filter = None
+        rw_min = None
+        rw_max = None
+
+    return approach_filter, class_filter, rw_max, rw_min
+
+
+@app.cell
+def _(approach_filter, class_filter, has_results, mo, pl, results_df, rw_max, rw_min):
+    if has_results and results_df.height > 0 and class_filter is not None:
+        # Apply filters
+        filtered_df = results_df
+
+        if class_filter.value != "All" and "exposure_class" in filtered_df.columns:
+            filtered_df = filtered_df.filter(pl.col("exposure_class") == class_filter.value)
+
+        if approach_filter.value != "All" and "approach_applied" in filtered_df.columns:
+            filtered_df = filtered_df.filter(pl.col("approach_applied") == approach_filter.value)
+
+        if "risk_weight" in filtered_df.columns:
+            filtered_df = filtered_df.filter(
+                (pl.col("risk_weight") >= rw_min.value) &
+                (pl.col("risk_weight") <= rw_max.value)
+            )
+
+        # Compute filtered statistics
+        if "ead_final" in filtered_df.columns and "rwa_final" in filtered_df.columns:
+            total_ead = filtered_df.select(pl.col("ead_final").sum()).item()
+            total_rwa = filtered_df.select(pl.col("rwa_final").sum()).item()
+            avg_rw = total_rwa / total_ead if total_ead > 0 else 0
+        else:
+            total_ead = 0
+            total_rwa = 0
+            avg_rw = 0
+
+        mo.output.replace(
+            mo.hstack([
+                mo.stat(
+                    value=f"{filtered_df.height:,}",
+                    label="Exposures",
+                ),
+                mo.stat(
+                    value=f"{total_ead:,.0f}",
+                    label="Total EAD",
+                ),
+                mo.stat(
+                    value=f"{total_rwa:,.0f}",
+                    label="Total RWA",
+                ),
+                mo.stat(
+                    value=f"{avg_rw:.2%}",
+                    label="Avg Risk Weight",
+                ),
+            ], justify="space-around")
+        )
+    else:
+        filtered_df = pl.DataFrame()
+        total_ead = 0
+        total_rwa = 0
+
+    return avg_rw, filtered_df, total_ead, total_rwa
+
+
+@app.cell
+def _(filtered_df, has_results, mo):
+    if has_results and filtered_df.height > 0:
+        # Aggregation selector
+        agg_options = ["None", "By Exposure Class", "By Approach", "By Risk Weight Band"]
+        agg_selector = mo.ui.dropdown(
+            options=agg_options,
+            value="None",
+            label="Aggregate By",
+        )
+
+        mo.output.replace(
+            mo.vstack([
+                mo.md("### Analysis View"),
+                agg_selector,
+            ])
+        )
+    else:
+        agg_selector = None
+
+    return (agg_selector,)
+
+
+@app.cell
+def _(agg_selector, filtered_df, has_results, mo, pl):
+    if has_results and filtered_df.height > 0 and agg_selector is not None:
+        if agg_selector.value == "By Exposure Class" and "exposure_class" in filtered_df.columns:
+            agg_df = filtered_df.group_by("exposure_class").agg([
+                pl.col("ead_final").sum().alias("total_ead"),
+                pl.col("rwa_final").sum().alias("total_rwa"),
+                pl.len().alias("count"),
+            ]).with_columns(
+                (pl.col("total_rwa") / pl.col("total_ead")).alias("avg_risk_weight")
+            ).sort("total_rwa", descending=True)
+
+            mo.output.replace(
+                mo.vstack([
+                    mo.md("#### Summary by Exposure Class"),
+                    mo.ui.table(agg_df, selection=None),
+                ])
+            )
+
+        elif agg_selector.value == "By Approach" and "approach_applied" in filtered_df.columns:
+            agg_df = filtered_df.group_by("approach_applied").agg([
+                pl.col("ead_final").sum().alias("total_ead"),
+                pl.col("rwa_final").sum().alias("total_rwa"),
+                pl.len().alias("count"),
+            ]).with_columns(
+                (pl.col("total_rwa") / pl.col("total_ead")).alias("avg_risk_weight")
+            ).sort("total_rwa", descending=True)
+
+            mo.output.replace(
+                mo.vstack([
+                    mo.md("#### Summary by Approach"),
+                    mo.ui.table(agg_df, selection=None),
+                ])
+            )
+
+        elif agg_selector.value == "By Risk Weight Band" and "risk_weight" in filtered_df.columns:
+            agg_df = filtered_df.with_columns(
+                pl.when(pl.col("risk_weight") <= 0.20).then(pl.lit("0-20%"))
+                .when(pl.col("risk_weight") <= 0.50).then(pl.lit("20-50%"))
+                .when(pl.col("risk_weight") <= 0.75).then(pl.lit("50-75%"))
+                .when(pl.col("risk_weight") <= 1.00).then(pl.lit("75-100%"))
+                .when(pl.col("risk_weight") <= 1.50).then(pl.lit("100-150%"))
+                .otherwise(pl.lit("150%+"))
+                .alias("rw_band")
+            ).group_by("rw_band").agg([
+                pl.col("ead_final").sum().alias("total_ead"),
+                pl.col("rwa_final").sum().alias("total_rwa"),
+                pl.len().alias("count"),
+            ]).with_columns(
+                (pl.col("total_rwa") / pl.col("total_ead")).alias("avg_risk_weight")
+            ).sort("rw_band")
+
+            mo.output.replace(
+                mo.vstack([
+                    mo.md("#### Summary by Risk Weight Band"),
+                    mo.ui.table(agg_df, selection=None),
+                ])
+            )
+
+        else:
+            agg_df = None
+    else:
+        agg_df = None
+
+    return (agg_df,)
+
+
+@app.cell
+def _(filtered_df, has_results, mo):
+    if has_results and filtered_df.height > 0:
+        # Column selector for detailed view
+        available_cols = filtered_df.columns
+
+        # Default columns to show
+        default_cols = [
+            col for col in [
+                "exposure_reference",
+                "counterparty_name",
+                "exposure_class",
+                "approach_applied",
+                "ead_final",
+                "risk_weight",
+                "rwa_final",
+            ] if col in available_cols
+        ]
+
+        column_selector = mo.ui.multiselect(
+            options=available_cols,
+            value=default_cols,
+            label="Columns to Display",
+        )
+
+        mo.output.replace(
+            mo.vstack([
+                mo.md("### Detailed Results"),
+                column_selector,
+            ])
+        )
+    else:
+        column_selector = None
+
+    return (column_selector,)
+
+
+@app.cell
+def _(column_selector, filtered_df, has_results, mo):
+    if has_results and filtered_df.height > 0 and column_selector is not None and column_selector.value:
+        display_cols = [c for c in column_selector.value if c in filtered_df.columns]
+
+        if display_cols:
+            display_df = filtered_df.select(display_cols)
+
+            mo.output.replace(
+                mo.vstack([
+                    mo.md(f"*Showing {min(display_df.height, 500):,} of {display_df.height:,} rows*"),
+                    mo.ui.table(display_df.head(500), selection=None),
+                ])
+            )
+    return (display_cols,)
+
+
+@app.cell
+def _(filtered_df, has_results, mo):
+    import io
+
+    if has_results and filtered_df.height > 0:
+        # Export options
+        csv_data = filtered_df.write_csv()
+
+        # Write parquet to bytes buffer
+        parquet_buffer = io.BytesIO()
+        filtered_df.write_parquet(parquet_buffer)
+        parquet_bytes = parquet_buffer.getvalue()
+
+        mo.output.replace(
+            mo.vstack([
+                mo.md("### Export Filtered Results"),
+                mo.hstack([
+                    mo.download(
+                        data=csv_data.encode("utf-8"),
+                        filename="filtered_rwa_results.csv",
+                        label="Download CSV",
+                    ),
+                    mo.download(
+                        data=parquet_bytes,
+                        filename="filtered_rwa_results.parquet",
+                        label="Download Parquet",
+                    ),
+                ], gap=2),
+            ])
+        )
+    return
+
+
+@app.cell
+def _(cache_dir, has_results, mo, pl):
+    # Load summary tables if available
+    class_summary_file = cache_dir / "last_summary_by_class.parquet"
+    approach_summary_file = cache_dir / "last_summary_by_approach.parquet"
+
+    if has_results:
+        output_parts = []
+
+        if class_summary_file.exists():
+            class_summary_df = pl.read_parquet(class_summary_file)
+            output_parts.append(mo.md("### Original Summary by Exposure Class"))
+            output_parts.append(mo.ui.table(class_summary_df, selection=None))
+
+        if approach_summary_file.exists():
+            approach_summary_df = pl.read_parquet(approach_summary_file)
+            output_parts.append(mo.md("### Original Summary by Approach"))
+            output_parts.append(mo.ui.table(approach_summary_df, selection=None))
+
+        if output_parts:
+            mo.output.replace(mo.vstack(output_parts))
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/src/rwa_calc/ui/marimo/rwa_app.py
+++ b/src/rwa_calc/ui/marimo/rwa_app.py
@@ -35,16 +35,47 @@ def _():
     project_root = Path(__file__).parent.parent.parent.parent.parent
     if str(project_root) not in sys.path:
         sys.path.insert(0, str(project_root))
-    return Decimal, Path, date, mo, project_root
+
+    # Cache directory for sharing results between apps
+    cache_dir = Path(__file__).parent / ".cache"
+    cache_dir.mkdir(exist_ok=True)
+
+    return Decimal, Path, cache_dir, date, mo, pl, project_root
 
 
 @app.cell
 def _(mo):
-    mo.md(r"""
-    # RWA Calculator
-    ***
-    """)
+    mo.sidebar(
+        [
+            mo.md("# RWA Calculator"),
+            mo.nav_menu(
+                {
+                    "/calculator": f"{mo.icon('calculator')} Calculator",
+                    "/results": f"{mo.icon('table')} Results Explorer",
+                    "/reference": f"{mo.icon('book')} Framework Reference",
+                },
+                orientation="vertical",
+            ),
+            mo.md("---"),
+            mo.md("""
+**Quick Links**
+- [PRA PS9/24](https://www.bankofengland.co.uk/prudential-regulation/publication/2024/september/implementation-of-the-basel-3-1-standards-near-final-policy-statement-part-2)
+- [UK CRR](https://www.legislation.gov.uk/eur/2013/575/contents)
+- [BCBS Framework](https://www.bis.org/basel_framework/)
+            """),
+        ],
+        footer=mo.md("*RWA Calculator v1.0*"),
+    )
     return
+
+
+@app.cell
+def _(mo):
+    return mo.md("""
+# RWA Calculator
+
+Configure your calculation parameters below, then click **Run Calculation** to compute Risk-Weighted Assets.
+    """)
 
 
 @app.cell
@@ -168,6 +199,7 @@ def _(mo, validation_result):
 
 @app.cell
 def _(
+    cache_dir,
     data_path_input,
     format_dropdown,
     framework_dropdown,
@@ -178,6 +210,7 @@ def _(
 ):
     from rwa_calc.api import RWAService, CalculationRequest
     from datetime import date as date_type
+    import json
 
     calculation_response = None
     calculation_error = None
@@ -200,6 +233,25 @@ def _(
 
             calculation_response = service.calculate(request)
 
+            # Cache results for the results explorer
+            if calculation_response and calculation_response.success:
+                calculation_response.results.write_parquet(cache_dir / "last_results.parquet")
+
+                # Save metadata
+                metadata = {
+                    "framework": calculation_response.framework,
+                    "reporting_date": str(calculation_response.reporting_date),
+                    "total_ead": float(calculation_response.summary.total_ead),
+                    "total_rwa": float(calculation_response.summary.total_rwa),
+                    "exposure_count": calculation_response.summary.exposure_count,
+                }
+                (cache_dir / "last_results_meta.json").write_text(json.dumps(metadata, indent=2))
+
+                if calculation_response.summary_by_class is not None:
+                    calculation_response.summary_by_class.write_parquet(cache_dir / "last_summary_by_class.parquet")
+                if calculation_response.summary_by_approach is not None:
+                    calculation_response.summary_by_approach.write_parquet(cache_dir / "last_summary_by_approach.parquet")
+
         except Exception as e:
             calculation_error = str(e)
 
@@ -209,7 +261,12 @@ def _(
         error_msgs = [e.message for e in calculation_response.errors[:3]]
         mo.output.replace(mo.callout(f"Calculation completed with errors: {'; '.join(error_msgs)}", kind="warn"))
     elif run_button.value and calculation_response and calculation_response.success:
-        mo.output.replace(mo.callout("Calculation completed successfully!", kind="success"))
+        mo.output.replace(
+            mo.callout(
+                mo.md(f"Calculation completed successfully! [Open Results Explorer](/results) to analyze."),
+                kind="success",
+            )
+        )
     return (calculation_response,)
 
 
@@ -225,19 +282,19 @@ def _(Decimal, calculation_response, mo):
             return f"{float(val) * 100:.2f}%"
 
         mo.output.replace(mo.md(f"""
-    ## Summary Statistics
+## Summary Statistics
 
-    | Metric | Value |
-    |--------|-------|
-    | **Total EAD** | {fmt_num(summary.total_ead)} |
-    | **Total RWA** | {fmt_num(summary.total_rwa)} |
-    | **Average Risk Weight** | {fmt_pct(summary.average_risk_weight)} |
-    | **Exposure Count** | {summary.exposure_count:,} |
-    | **SA RWA** | {fmt_num(summary.total_rwa_sa)} |
-    | **IRB RWA** | {fmt_num(summary.total_rwa_irb)} |
-    | **Slotting RWA** | {fmt_num(summary.total_rwa_slotting)} |
-    | **Floor Applied** | {"Yes" if summary.floor_applied else "No"} |
-    | **Floor Impact** | {fmt_num(summary.floor_impact)} |
+| Metric | Value |
+|--------|-------|
+| **Total EAD** | {fmt_num(summary.total_ead)} |
+| **Total RWA** | {fmt_num(summary.total_rwa)} |
+| **Average Risk Weight** | {fmt_pct(summary.average_risk_weight)} |
+| **Exposure Count** | {summary.exposure_count:,} |
+| **SA RWA** | {fmt_num(summary.total_rwa_sa)} |
+| **IRB RWA** | {fmt_num(summary.total_rwa_irb)} |
+| **Slotting RWA** | {fmt_num(summary.total_rwa_slotting)} |
+| **Floor Applied** | {"Yes" if summary.floor_applied else "No"} |
+| **Floor Impact** | {fmt_num(summary.floor_impact)} |
         """))
     elif calculation_response:
         mo.output.replace(mo.md("## Summary Statistics\n\n*Calculation did not complete successfully.*"))
@@ -249,10 +306,10 @@ def _(calculation_response, mo):
     if calculation_response and calculation_response.performance:
         perf = calculation_response.performance
         mo.output.replace(mo.md(f"""
-    ### Performance
+### Performance
 
-    - **Duration**: {perf.duration_seconds:.2f} seconds
-    - **Throughput**: {perf.exposures_per_second:,.0f} exposures/second
+- **Duration**: {perf.duration_seconds:.2f} seconds
+- **Throughput**: {perf.exposures_per_second:,.0f} exposures/second
         """))
     return
 
@@ -274,49 +331,16 @@ def _(calculation_response, mo):
         ]
 
         if display_cols:
-            display_df = results_df.select(display_cols)
+            display_df = results_df.select(display_cols).head(100)
             mo.output.replace(
                 mo.vstack([
-                    mo.md("## Detailed Results"),
+                    mo.md("## Results Preview (first 100 rows)"),
+                    mo.md("*For full analysis, use the [Results Explorer](/results)*"),
                     mo.ui.table(display_df, selection=None),
                 ])
             )
     elif calculation_response:
         mo.output.replace(mo.md("## Detailed Results\n\n*No results to display.*"))
-    return
-
-
-@app.cell
-def _(calculation_response, mo):
-    if (
-        calculation_response
-        and calculation_response.success
-        and calculation_response.summary_by_class is not None
-        and calculation_response.summary_by_class.height > 0
-    ):
-        mo.output.replace(
-            mo.vstack([
-                mo.md("### Summary by Exposure Class"),
-                mo.ui.table(calculation_response.summary_by_class, selection=None),
-            ])
-        )
-    return
-
-
-@app.cell
-def _(calculation_response, mo):
-    if (
-        calculation_response
-        and calculation_response.success
-        and calculation_response.summary_by_approach is not None
-        and calculation_response.summary_by_approach.height > 0
-    ):
-        mo.output.replace(
-            mo.vstack([
-                mo.md("### Summary by Approach"),
-                mo.ui.table(calculation_response.summary_by_approach, selection=None),
-            ])
-        )
     return
 
 
@@ -337,9 +361,9 @@ def _(calculation_response, mo):
             ])
             more_errors = f"\n\n*({len(error_list) - 10} more errors)*" if len(error_list) > 10 else ""
             output_parts.append(mo.md(f"""
-    ### Errors ({len(error_list)})
+### Errors ({len(error_list)})
 
-    {error_items}{more_errors}
+{error_items}{more_errors}
             """))
 
         if warnings:
@@ -349,9 +373,9 @@ def _(calculation_response, mo):
             ])
             more_warnings = f"\n\n*({len(warnings) - 10} more warnings)*" if len(warnings) > 10 else ""
             output_parts.append(mo.md(f"""
-    ### Warnings ({len(warnings)})
+### Warnings ({len(warnings)})
 
-    {warning_items}{more_warnings}
+{warning_items}{more_warnings}
             """))
 
         if output_parts:
@@ -374,11 +398,6 @@ def _(calculation_response, mo):
                 ),
             ])
         )
-    return
-
-
-@app.cell
-def _():
     return
 
 

--- a/src/rwa_calc/ui/marimo/server.py
+++ b/src/rwa_calc/ui/marimo/server.py
@@ -1,0 +1,37 @@
+"""
+RWA Calculator Multi-App Server.
+
+Serves all Marimo applications with proper navigation between them.
+
+Usage:
+    uv run python src/rwa_calc/ui/marimo/server.py
+
+    Or with uvicorn directly:
+    uv run uvicorn rwa_calc.ui.marimo.server:app --host 0.0.0.0 --port 8000
+"""
+
+import marimo
+from pathlib import Path
+
+# Get the directory containing the apps
+apps_dir = Path(__file__).parent
+
+# Create marimo ASGI app with all notebooks and build it
+app = (
+    marimo.create_asgi_app()
+    .with_app(path="", root=str(apps_dir / "rwa_app.py"))
+    .with_app(path="/calculator", root=str(apps_dir / "rwa_app.py"))
+    .with_app(path="/results", root=str(apps_dir / "results_explorer.py"))
+    .with_app(path="/reference", root=str(apps_dir / "framework_reference.py"))
+    .build()
+)
+
+if __name__ == "__main__":
+    import uvicorn
+    print("Starting RWA Calculator server...")
+    print("Apps available at:")
+    print("  - http://localhost:8000/           (Calculator)")
+    print("  - http://localhost:8000/calculator (Calculator)")
+    print("  - http://localhost:8000/results    (Results Explorer)")
+    print("  - http://localhost:8000/reference  (Framework Reference)")
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/uv.lock
+++ b/uv.lock
@@ -1163,6 +1163,7 @@ dependencies = [
     { name = "pytest" },
     { name = "pyyaml" },
     { name = "scipy" },
+    { name = "uvicorn" },
 ]
 
 [package.optional-dependencies]
@@ -1203,6 +1204,7 @@ requires-dist = [
     { name = "pyyaml" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "scipy" },
+    { name = "uvicorn" },
 ]
 provides-extras = ["dev"]
 


### PR DESCRIPTION
This pull request introduces improvements to the Marimo UI applications for the RWA Calculator, focusing on documentation, dependency management, and developer experience. The most significant updates are the addition of usage instructions and app descriptions, support for running the multi-app server with `uvicorn`, and improved caching and sharing of results between apps.

**Documentation and Developer Experience:**
* Expanded the module docstring in `__init__.py` to include descriptions of all available Marimo apps, detailed usage instructions for both multi-app and single-app modes, navigation guidance, and notes about caching and app switching.

**Dependency and Environment Updates:**
* Added `uvicorn` to the list of required dependencies in `pyproject.toml` to support running the multi-app server.
* Added `.cache/` to the `.gitignore` in the Marimo UI directory to exclude cache files used for sharing results between apps.

**App and Session Caching:**
* Updated the code hash in the Marimo session file for `rwa_app.py`, likely reflecting changes in the app logic or caching mechanism.