### PR TITLE
feat(schema): add cp_is_managed_as_retail flag

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,7 +4,8 @@
       "WebFetch(domain:service.betterregulation.com)",
       "Bash(uv run pytest:*)",
       "Bash(uv run python:*)",
-      "WebFetch(domain:docs.marimo.io)"
+      "WebFetch(domain:docs.marimo.io)",
+      "WebFetch(domain:www.prarulebook.co.uk)"
     ]
   }
 }

--- a/src/rwa_calc/data/schemas.py
+++ b/src/rwa_calc/data/schemas.py
@@ -114,6 +114,7 @@ COUNTERPARTY_SCHEMA = {
     "is_international_org": pl.Boolean,  # International Organisation - 0% RW (CRR Art 118)
     "is_central_counterparty": pl.Boolean,  # CCP exposure treatment (CRR Art 300-311)
     "is_regional_govt_local_auth": pl.Boolean,  # RGLA - may receive sovereign RW (CRR Art 115)
+    "is_managed_as_retail": pl.Boolean,  # SME managed on pooled retail basis (CRR Art 123)
 }
 
 COLLATERAL_SCHEMA = {

--- a/src/rwa_calc/engine/classifier.py
+++ b/src/rwa_calc/engine/classifier.py
@@ -182,6 +182,7 @@ class ExposureClassifier:
             pl.col("is_international_org").alias("cp_is_international_org"),
             pl.col("is_central_counterparty").alias("cp_is_central_counterparty"),
             pl.col("is_regional_govt_local_auth").alias("cp_is_rgla"),
+            pl.col("is_managed_as_retail").alias("cp_is_managed_as_retail"),
         ])
 
         # Join with exposures

--- a/tests/benchmarks/data_generators.py
+++ b/tests/benchmarks/data_generators.py
@@ -184,6 +184,7 @@ def generate_counterparties(config: BenchmarkDataConfig) -> pl.LazyFrame:
         "is_international_org": pl.Series(np.zeros(n, dtype=bool)),
         "is_central_counterparty": pl.Series(is_ccp),
         "is_regional_govt_local_auth": pl.Series(is_rgla),
+        "is_managed_as_retail": pl.Series(np.zeros(n, dtype=bool)),
     }).cast(COUNTERPARTY_SCHEMA).lazy()
 
 

--- a/tests/fixtures/counterparty/corporate.py
+++ b/tests/fixtures/counterparty/corporate.py
@@ -52,6 +52,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         {
             "counterparty_reference": "CORP_UK_002",
@@ -69,6 +70,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # CQS 2 Corporate - 50% Risk Weight
         {
@@ -87,6 +89,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # CQS 3 Corporate - 75% Risk Weight
         {
@@ -105,6 +108,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # CQS 4 Corporate - 100% Risk Weight
         {
@@ -123,6 +127,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # CQS 5/6 Corporate - 150% Risk Weight
         {
@@ -141,6 +146,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # Unrated Corporate - 100% Risk Weight (Scenario A2 from plan)
         {
@@ -159,6 +165,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # SME Corporate (revenue < £44m) - eligible for SME supporting factor
         {
@@ -177,6 +184,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         {
             "counterparty_reference": "CORP_SME_002",
@@ -194,8 +202,9 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
-        # Small SME (revenue < £50m but > £880k, corporate treatment)
+        # Small SME (revenue < £50m but > £880k, managed as retail - 75% RW)
         {
             "counterparty_reference": "CORP_SME_003",
             "counterparty_name": "Small Business Services Ltd",
@@ -212,6 +221,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": True,  # Managed on pooled retail basis (CRR Art. 123)
         },
         # Large Corporate (revenue > £440m)
         {
@@ -230,6 +240,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # PSE treated as corporate
         {
@@ -248,6 +259,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # Defaulted Corporate
         {
@@ -266,6 +278,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # =============================================================================
         # A-IRB TEST: Corporate with bank's own LGD estimate (CRR-C1)
@@ -288,6 +301,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # =============================================================================
         # ORG HIERARCHY TEST GROUP 1: Rated Parent with Unrated Subsidiaries
@@ -310,6 +324,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         {
             "counterparty_reference": "CORP_GRP1_SUB1",
@@ -327,6 +342,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         {
             "counterparty_reference": "CORP_GRP1_SUB2",
@@ -344,6 +360,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         {
             "counterparty_reference": "CORP_GRP1_SUB3",
@@ -361,6 +378,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # =============================================================================
         # ORG HIERARCHY TEST GROUP 2: Multi-level Hierarchy
@@ -383,6 +401,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         {
             "counterparty_reference": "CORP_GRP2_INTHOLD",
@@ -400,6 +419,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         {
             "counterparty_reference": "CORP_GRP2_OPSUB1",
@@ -417,6 +437,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         {
             "counterparty_reference": "CORP_GRP2_OPSUB2",
@@ -434,6 +455,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # =============================================================================
         # ORG HIERARCHY TEST GROUP 3: SME Turnover Aggregation
@@ -456,6 +478,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         {
             "counterparty_reference": "CORP_GRP3_SUB1",
@@ -473,6 +496,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         {
             "counterparty_reference": "CORP_GRP3_SUB2",
@@ -490,6 +514,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # =============================================================================
         # CRR-F: Supporting Factor Test Scenarios
@@ -513,6 +538,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # CRR-F3: SME Large - uses CORP_SME_002 (already exists, turnover £35m)
         # CRR-F5: Infrastructure project (0.75 factor, not tiered)
@@ -532,6 +558,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # CRR-F6: Large Corporate - no SME factor (turnover > £44m)
         {
@@ -550,6 +577,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # CRR-F7: SME at boundary - turnover £20m (at threshold)
         {
@@ -568,6 +596,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # Alias for CRR-F1 (CORP_SME_SMALL -> same characteristics as CORP_SME_001)
         {
@@ -586,6 +615,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # Alias for CRR-F3 (CORP_SME_LARGE -> same characteristics as CORP_SME_002)
         {
@@ -604,6 +634,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # =============================================================================
         # CRR-G: Provisions & Impairments Test Scenarios
@@ -626,6 +657,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # CRR-G2: IRB EL shortfall (F-IRB corporate, PD 2%)
         {
@@ -644,6 +676,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # CRR-G3: IRB EL excess (F-IRB corporate, PD 0.5%)
         {
@@ -662,6 +695,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # =============================================================================
         # CRR-H: Complex/Combined Scenario Test Counterparties
@@ -684,6 +718,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # CRR-H2: Counterparty group parent (rated CQS 2 = 50% RW)
         # Has unrated subsidiary (inherits 50%) and rated subsidiary (CQS 3 = 100%)
@@ -703,6 +738,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # CRR-H2: Unrated subsidiary (inherits parent CQS 2 = 50% RW)
         {
@@ -721,6 +757,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # CRR-H2: Rated subsidiary (own CQS 3 = 100% RW)
         {
@@ -739,6 +776,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # CRR-H3: SME chain with supporting factor (turnover £25m)
         {
@@ -757,6 +795,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # CRR-H4: Full CRM chain (unrated corporate = 100% RW base)
         {
@@ -775,6 +814,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
     ]
 

--- a/tests/fixtures/counterparty/institution.py
+++ b/tests/fixtures/counterparty/institution.py
@@ -49,6 +49,7 @@ def create_institution_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         {
             "counterparty_reference": "INST_UK_002",
@@ -66,6 +67,7 @@ def create_institution_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         {
             "counterparty_reference": "INST_US_001",
@@ -83,6 +85,7 @@ def create_institution_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         {
             "counterparty_reference": "INST_DE_001",
@@ -100,6 +103,7 @@ def create_institution_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # CQS 2 Institution - 30% Risk Weight (UK deviation)
         {
@@ -118,6 +122,7 @@ def create_institution_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # CQS 3 Institution - 50% Risk Weight
         {
@@ -136,6 +141,7 @@ def create_institution_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # CQS 4/5 Institution - 100% Risk Weight
         {
@@ -154,6 +160,7 @@ def create_institution_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # CQS 6 Institution - 150% Risk Weight
         {
@@ -172,6 +179,7 @@ def create_institution_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # Unrated Institution - 40% Risk Weight
         {
@@ -190,6 +198,7 @@ def create_institution_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # Investment Firm - regulated
         {
@@ -208,6 +217,7 @@ def create_institution_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # Central Counterparty
         {
@@ -226,6 +236,7 @@ def create_institution_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": True,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # Defaulted Institution
         {
@@ -244,6 +255,7 @@ def create_institution_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
     ]
 

--- a/tests/fixtures/counterparty/retail.py
+++ b/tests/fixtures/counterparty/retail.py
@@ -52,6 +52,7 @@ def create_retail_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         {
             "counterparty_reference": "RTL_IND_002",
@@ -69,6 +70,7 @@ def create_retail_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         {
             "counterparty_reference": "RTL_IND_003",
@@ -86,6 +88,7 @@ def create_retail_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # Individual - Mortgage borrower (for residential mortgage scenarios)
         {
@@ -104,6 +107,7 @@ def create_retail_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         {
             "counterparty_reference": "RTL_MTG_002",
@@ -121,6 +125,7 @@ def create_retail_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # SME Retail - Turnover under £880k threshold (Scenario A10)
         {
@@ -139,6 +144,7 @@ def create_retail_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": True,  # Managed on pooled retail basis
         },
         {
             "counterparty_reference": "RTL_SME_002",
@@ -156,6 +162,7 @@ def create_retail_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         {
             "counterparty_reference": "RTL_SME_003",
@@ -173,6 +180,7 @@ def create_retail_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # SME at threshold boundary (just under £880k)
         {
@@ -191,6 +199,7 @@ def create_retail_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # QRRE eligible individuals (credit cards, overdrafts)
         {
@@ -209,6 +218,7 @@ def create_retail_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         {
             "counterparty_reference": "RTL_QRRE_002",
@@ -226,6 +236,7 @@ def create_retail_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # High-income individual (still retail if exposure criteria met)
         {
@@ -244,6 +255,7 @@ def create_retail_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # =============================================================================
         # A-IRB TEST: Retail with bank's own estimates (CRR-C2)
@@ -267,6 +279,7 @@ def create_retail_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # Defaulted retail individual
         {
@@ -285,6 +298,7 @@ def create_retail_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # Defaulted SME retail
         {
@@ -303,6 +317,7 @@ def create_retail_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # =============================================================================
         # LENDING GROUP TEST 1: Connected Individuals (Married Couple)
@@ -325,6 +340,7 @@ def create_retail_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         {
             "counterparty_reference": "RTL_LG1_SPOUSE2",
@@ -342,6 +358,7 @@ def create_retail_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # =============================================================================
         # LENDING GROUP TEST 2: Business Owner and Their Company
@@ -364,6 +381,7 @@ def create_retail_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         {
             "counterparty_reference": "RTL_LG2_COMPANY",
@@ -381,6 +399,7 @@ def create_retail_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # =============================================================================
         # LENDING GROUP TEST 3: Family Business Group
@@ -403,6 +422,7 @@ def create_retail_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         {
             "counterparty_reference": "RTL_LG3_PERSON2",
@@ -420,6 +440,7 @@ def create_retail_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         {
             "counterparty_reference": "RTL_LG3_BIZ1",
@@ -437,6 +458,7 @@ def create_retail_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         {
             "counterparty_reference": "RTL_LG3_BIZ2",
@@ -454,6 +476,7 @@ def create_retail_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # =============================================================================
         # LENDING GROUP TEST 4: Threshold Boundary Test
@@ -476,6 +499,7 @@ def create_retail_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         {
             "counterparty_reference": "RTL_LG4_BIZ",
@@ -493,6 +517,7 @@ def create_retail_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # =============================================================================
         # LENDING GROUP TEST 5: Group Exceeding Retail Threshold
@@ -515,6 +540,7 @@ def create_retail_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         {
             "counterparty_reference": "RTL_LG5_BIZ",
@@ -532,6 +558,7 @@ def create_retail_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # =============================================================================
         # CRR-F4: Retail SME with SME Supporting Factor
@@ -553,6 +580,7 @@ def create_retail_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
     ]
 

--- a/tests/fixtures/counterparty/sovereign.py
+++ b/tests/fixtures/counterparty/sovereign.py
@@ -47,6 +47,7 @@ def create_sovereign_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         {
             "counterparty_reference": "SOV_US_001",
@@ -64,6 +65,7 @@ def create_sovereign_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         {
             "counterparty_reference": "SOV_DE_001",
@@ -81,6 +83,7 @@ def create_sovereign_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # CQS 2 Sovereign - 20% Risk Weight
         {
@@ -99,6 +102,7 @@ def create_sovereign_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # CQS 3 Sovereign - 50% Risk Weight
         {
@@ -117,6 +121,7 @@ def create_sovereign_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # CQS 4/5 Sovereign - 100% Risk Weight
         {
@@ -135,6 +140,7 @@ def create_sovereign_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # CQS 6 Sovereign - 150% Risk Weight
         {
@@ -153,6 +159,7 @@ def create_sovereign_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # Unrated Sovereign - 100% Risk Weight
         {
@@ -171,6 +178,7 @@ def create_sovereign_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # Defaulted Sovereign - for scenario testing
         {
@@ -189,6 +197,7 @@ def create_sovereign_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
     ]
 

--- a/tests/fixtures/counterparty/specialised_lending.py
+++ b/tests/fixtures/counterparty/specialised_lending.py
@@ -64,6 +64,7 @@ def create_specialised_lending_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # Project Finance - Good (Scenario E2)
         {
@@ -82,6 +83,7 @@ def create_specialised_lending_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # Project Finance - Satisfactory
         {
@@ -100,6 +102,7 @@ def create_specialised_lending_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # Project Finance - Weak
         {
@@ -118,6 +121,7 @@ def create_specialised_lending_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # Object Finance - Aircraft
         {
@@ -136,6 +140,7 @@ def create_specialised_lending_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # Object Finance - Shipping
         {
@@ -154,6 +159,7 @@ def create_specialised_lending_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # Commodities Finance
         {
@@ -172,6 +178,7 @@ def create_specialised_lending_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         {
             "counterparty_reference": "SL_CF_002",
@@ -189,6 +196,7 @@ def create_specialised_lending_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # IPRE - Strong
         {
@@ -207,6 +215,7 @@ def create_specialised_lending_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # IPRE - Satisfactory/Speculative (Scenario E3)
         {
@@ -225,6 +234,7 @@ def create_specialised_lending_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # HVCRE - High Volatility Commercial Real Estate (Scenario E4)
         {
@@ -243,6 +253,7 @@ def create_specialised_lending_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         {
             "counterparty_reference": "SL_HVCRE_002",
@@ -260,6 +271,7 @@ def create_specialised_lending_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # ADC - Acquisition, Development, Construction
         {
@@ -278,6 +290,7 @@ def create_specialised_lending_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # Defaulted Specialised Lending
         {
@@ -296,6 +309,7 @@ def create_specialised_lending_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # =============================================================================
         # CRR-E Slotting Test Scenarios
@@ -318,6 +332,7 @@ def create_specialised_lending_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # CRR-E2: Project Finance - Good (70% RW under CRR, same as Strong)
         {
@@ -336,6 +351,7 @@ def create_specialised_lending_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # CRR-E3: IPRE - Weak (250% RW - punitive)
         {
@@ -354,6 +370,7 @@ def create_specialised_lending_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
         # CRR-E4: HVCRE - Strong (70% RW under CRR, same as non-HVCRE)
         {
@@ -372,6 +389,7 @@ def create_specialised_lending_counterparties() -> pl.DataFrame:
             "is_international_org": False,
             "is_central_counterparty": False,
             "is_regional_govt_local_auth": False,
+            "is_managed_as_retail": False,
         },
     ]
 

--- a/tests/unit/test_classifier.py
+++ b/tests/unit/test_classifier.py
@@ -95,6 +95,7 @@ def corporate_counterparties() -> pl.LazyFrame:
         "is_international_org": [False, False, False, False],
         "is_central_counterparty": [False, False, False, False],
         "is_regional_govt_local_auth": [False, False, False, False],
+        "is_managed_as_retail": [False, False, False, False],
     }).lazy()
 
 
@@ -138,6 +139,7 @@ def mixed_counterparties() -> pl.LazyFrame:
         "is_international_org": [False, False, False, False, False, False],
         "is_central_counterparty": [False, False, False, False, False, False],
         "is_regional_govt_local_auth": [False, False, False, False, False, False],
+        "is_managed_as_retail": [False, False, False, False, False, False],
     }).lazy()
 
 
@@ -164,6 +166,7 @@ def retail_counterparties() -> pl.LazyFrame:
         "is_international_org": [False, False, False],
         "is_central_counterparty": [False, False, False],
         "is_regional_govt_local_auth": [False, False, False],
+        "is_managed_as_retail": [False, False, False],
     }).lazy()
 
 
@@ -186,6 +189,7 @@ def defaulted_counterparties() -> pl.LazyFrame:
         "is_international_org": [False, False],
         "is_central_counterparty": [False, False],
         "is_regional_govt_local_auth": [False, False],
+        "is_managed_as_retail": [False, False],
     }).lazy()
 
 
@@ -452,6 +456,7 @@ class TestSMEClassification:
             "is_international_org": [False],
             "is_central_counterparty": [False],
             "is_regional_govt_local_auth": [False],
+            "is_managed_as_retail": [False],
         }).lazy()
 
         exposures = pl.DataFrame({
@@ -513,6 +518,7 @@ class TestSMEClassification:
             "is_international_org": [False],
             "is_central_counterparty": [False],
             "is_regional_govt_local_auth": [False],
+            "is_managed_as_retail": [False],
         }).lazy()
 
         exposures = pl.DataFrame({
@@ -576,6 +582,7 @@ class TestSMEClassification:
             "is_international_org": [False],
             "is_central_counterparty": [False],
             "is_regional_govt_local_auth": [False],
+            "is_managed_as_retail": [False],
         }).lazy()
 
         exposures = pl.DataFrame({
@@ -646,6 +653,7 @@ class TestRetailClassification:
             "is_international_org": [False],
             "is_central_counterparty": [False],
             "is_regional_govt_local_auth": [False],
+            "is_managed_as_retail": [False],
         }).lazy()
 
         exposures = pl.DataFrame({
@@ -707,6 +715,7 @@ class TestRetailClassification:
             "is_international_org": [False],
             "is_central_counterparty": [False],
             "is_regional_govt_local_auth": [False],
+            "is_managed_as_retail": [False],
         }).lazy()
 
         exposures = pl.DataFrame({
@@ -852,6 +861,7 @@ class TestApproachAssignment:
             "is_international_org": [False],
             "is_central_counterparty": [False],
             "is_regional_govt_local_auth": [False],
+            "is_managed_as_retail": [False],
         }).lazy()
 
         exposures = pl.DataFrame({

--- a/tests/unit/test_hierarchy.py
+++ b/tests/unit/test_hierarchy.py
@@ -75,6 +75,7 @@ def simple_counterparties() -> pl.LazyFrame:
         "is_international_org": [False, False, False, False],
         "is_central_counterparty": [False, False, False, False],
         "is_regional_govt_local_auth": [False, False, False, False],
+        "is_managed_as_retail": [False, False, False, False],
     }).lazy()
 
 
@@ -188,6 +189,7 @@ def lending_group_counterparties() -> pl.LazyFrame:
         "is_international_org": [False, False, False, False],
         "is_central_counterparty": [False, False, False, False],
         "is_regional_govt_local_auth": [False, False, False, False],
+        "is_managed_as_retail": [False, False, False, False],
     }).lazy()
 
 

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -118,6 +118,7 @@ def mock_raw_data() -> RawDataBundle:
         "is_international_org": [False, False],
         "is_central_counterparty": [False, False],
         "is_regional_govt_local_auth": [False, False],
+        "is_managed_as_retail": [False, False],
     })
 
     # Collateral (empty with full schema)
@@ -249,6 +250,7 @@ def mock_resolved_bundle() -> ResolvedHierarchyBundle:
         "is_international_org": [False, False],
         "is_central_counterparty": [False, False],
         "is_regional_govt_local_auth": [False, False],
+        "is_managed_as_retail": [False, False],
     })
 
     rating_inheritance = pl.LazyFrame({

--- a/uv.lock
+++ b/uv.lock
@@ -1173,7 +1173,7 @@ wheels = [
 
 [[package]]
 name = "rwa-calc"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
This pull request introduces support for the "managed as retail" flag for SME counterparties, aligning the risk weighting logic with CRR Article 123. The changes ensure that SMEs managed on a pooled retail basis are correctly identified and assigned a 75% risk weight, and updates are made throughout the data schema, calculation logic, and test fixtures to support this new attribute.

**Risk Weighting Logic Updates:**
- Modified the risk weight assignment logic in both `calculator.py` and `namespace.py` to use the new `cp_is_managed_as_retail` flag, ensuring SMEs managed as retail receive a 75% risk weight as per CRR Art. 123, instead of relying on the legacy `book_code` field. [[1]](diffhunk://#diff-8dba0c29ad5d8964bb22fdae2dc03db06f1ef6b714e1457e65c0e2b7dc4955a0L262-R269) [[2]](diffhunk://#diff-5501c72cf5af066b7d945aa614b5ae7dbf183a8d5e357d24bb8a2630c8f72fd1L226-R233)

**Schema and Data Pipeline Changes:**
- Added the `is_managed_as_retail` boolean field to the `COUNTERPARTY_SCHEMA` in `schemas.py` and ensured it is included in the counterparty attributes throughout the pipeline. [[1]](diffhunk://#diff-04eeea3da0125ae22d7104c692e0f1d41a86209f6fdfcadd5f061376c8092084R117) [[2]](diffhunk://#diff-9d8857ec8c5b43a597a22861ee415145d73aa94872f034a92def436698bf0183R185)
- Updated data preparation and transformation steps to add the `cp_is_managed_as_retail` column where missing, maintaining backward compatibility with previous data structures. [[1]](diffhunk://#diff-8dba0c29ad5d8964bb22fdae2dc03db06f1ef6b714e1457e65c0e2b7dc4955a0R191-R194) [[2]](diffhunk://#diff-5501c72cf5af066b7d945aa614b5ae7dbf183a8d5e357d24bb8a2630c8f72fd1L133-R140)
- Extended the `calculate_single_exposure` function and its documentation to accept and process the `is_managed_as_retail` parameter. [[1]](diffhunk://#diff-8dba0c29ad5d8964bb22fdae2dc03db06f1ef6b714e1457e65c0e2b7dc4955a0R508) [[2]](diffhunk://#diff-8dba0c29ad5d8964bb22fdae2dc03db06f1ef6b714e1457e65c0e2b7dc4955a0R521) [[3]](diffhunk://#diff-8dba0c29ad5d8964bb22fdae2dc03db06f1ef6b714e1457e65c0e2b7dc4955a0R543)

**Test and Fixture Updates:**
- Updated test data generators and counterparty fixtures to include the `is_managed_as_retail` flag, providing representative cases for SMEs managed as retail. [[1]](diffhunk://#diff-cf7f6c20ad4bc722267da47aa1e8520b887da5c9da0619ff23eea97a32f37291R187) [[2]](diffhunk://#diff-cc9d0f6a13bdd398c8bfb524fbb4c8c2cee44400f93c37e0c13f3e12c01512e9R55) [[3]](diffhunk://#diff-cc9d0f6a13bdd398c8bfb524fbb4c8c2cee44400f93c37e0c13f3e12c01512e9R73) [[4]](diffhunk://#diff-cc9d0f6a13bdd398c8bfb524fbb4c8c2cee44400f93c37e0c13f3e12c01512e9R92) [[5]](diffhunk://#diff-cc9d0f6a13bdd398c8bfb524fbb4c8c2cee44400f93c37e0c13f3e12c01512e9R111) [[6]](diffhunk://#diff-cc9d0f6a13bdd398c8bfb524fbb4c8c2cee44400f93c37e0c13f3e12c01512e9R130) [[7]](diffhunk://#diff-cc9d0f6a13bdd398c8bfb524fbb4c8c2cee44400f93c37e0c13f3e12c01512e9R149) [[8]](diffhunk://#diff-cc9d0f6a13bdd398c8bfb524fbb4c8c2cee44400f93c37e0c13f3e12c01512e9R168) [[9]](diffhunk://#diff-cc9d0f6a13bdd398c8bfb524fbb4c8c2cee44400f93c37e0c13f3e12c01512e9R187) [[10]](diffhunk://#diff-cc9d0f6a13bdd398c8bfb524fbb4c8c2cee44400f93c37e0c13f3e12c01512e9R205-R207) [[11]](diffhunk://#diff-cc9d0f6a13bdd398c8bfb524fbb4c8c2cee44400f93c37e0c13f3e12c01512e9R224) [[12]](diffhunk://#diff-cc9d0f6a13bdd398c8bfb524fbb4c8c2cee44400f93c37e0c13f3e12c01512e9R243) [[13]](diffhunk://#diff-cc9d0f6a13bdd398c8bfb524fbb4c8c2cee44400f93c37e0c13f3e12c01512e9R262) [[14]](diffhunk://#diff-cc9d0f6a13bdd398c8bfb524fbb4c8c2cee44400f93c37e0c13f3e12c01512e9R281) [[15]](diffhunk://#diff-cc9d0f6a13bdd398c8bfb524fbb4c8c2cee44400f93c37e0c13f3e12c01512e9R304) [[16]](diffhunk://#diff-cc9d0f6a13bdd398c8bfb524fbb4c8c2cee44400f93c37e0c13f3e12c01512e9R327) [[17]](diffhunk://#diff-cc9d0f6a13bdd398c8bfb524fbb4c8c2cee44400f93c37e0c13f3e12c01512e9R345) [[18]](diffhunk://#diff-cc9d0f6a13bdd398c8bfb524fbb4c8c2cee44400f93c37e0c13f3e12c01512e9R363) [[19]](diffhunk://#diff-cc9d0f6a13bdd398c8bfb524fbb4c8c2cee44400f93c37e0c13f3e12c01512e9R381) [[20]](diffhunk://#diff-cc9d0f6a13bdd398c8bfb524fbb4c8c2cee44400f93c37e0c13f3e12c01512e9R404) [[21]](diffhunk://#diff-cc9d0f6a13bdd398c8bfb524fbb4c8c2cee44400f93c37e0c13f3e12c01512e9R422) [[22]](diffhunk://#diff-cc9d0f6a13bdd398c8bfb524fbb4c8c2cee44400f93c37e0c13f3e12c01512e9R440) [[23]](diffhunk://#diff-cc9d0f6a13bdd398c8bfb524fbb4c8c2cee44400f93c37e0c13f3e12c01512e9R458) [[24]](diffhunk://#diff-cc9d0f6a13bdd398c8bfb524fbb4c8c2cee44400f93c37e0c13f3e12c01512e9R481)

**Configuration Update:**
- Added `WebFetch(domain:www.prarulebook.co.uk)` to the `.claude/settings.local.json` file, likely to support referencing regulatory documentation.