### PR TITLE
feat(loader): normalize column names in data loaders

### DIFF
--- a/src/rwa_calc/engine/loader.py
+++ b/src/rwa_calc/engine/loader.py
@@ -32,6 +32,22 @@ if TYPE_CHECKING:
     pass
 
 
+def normalize_columns(lf: pl.LazyFrame) -> pl.LazyFrame:
+    """
+    Normalize column names to lowercase with underscores.
+
+    Converts all column names to lowercase and replaces spaces with underscores.
+    This ensures consistent column naming regardless of input data formatting.
+
+    Args:
+        lf: LazyFrame with columns to normalize
+
+    Returns:
+        LazyFrame with normalized column names
+    """
+    return lf.rename(lambda col: col.lower().replace(" ", "_"))
+
+
 @dataclass
 class DataSourceConfig:
     """
@@ -141,7 +157,7 @@ class ParquetLoader:
             raise DataLoadError(f"File not found: {full_path}", source=relative_path)
 
         try:
-            return pl.scan_parquet(full_path)
+            return normalize_columns(pl.scan_parquet(full_path))
         except Exception as e:
             raise DataLoadError(f"Failed to load parquet: {e}", source=relative_path) from e
 
@@ -163,7 +179,7 @@ class ParquetLoader:
             return None
 
         try:
-            return pl.scan_parquet(full_path)
+            return normalize_columns(pl.scan_parquet(full_path))
         except Exception:
             return None
 
@@ -179,7 +195,7 @@ class ParquetLoader:
             full_path = self.base_path / file_path
             if full_path.exists():
                 try:
-                    frames.append(pl.scan_parquet(full_path))
+                    frames.append(normalize_columns(pl.scan_parquet(full_path)))
                 except Exception as e:
                     raise DataLoadError(
                         f"Failed to load counterparty file: {e}",
@@ -302,7 +318,7 @@ class CSVLoader:
             raise DataLoadError(f"File not found: {full_path}", source=relative_path)
 
         try:
-            return pl.scan_csv(full_path, try_parse_dates=True)
+            return normalize_columns(pl.scan_csv(full_path, try_parse_dates=True))
         except Exception as e:
             raise DataLoadError(f"Failed to load CSV: {e}", source=relative_path) from e
 
@@ -324,7 +340,7 @@ class CSVLoader:
             return None
 
         try:
-            return pl.scan_csv(full_path, try_parse_dates=True)
+            return normalize_columns(pl.scan_csv(full_path, try_parse_dates=True))
         except Exception:
             return None
 
@@ -340,7 +356,7 @@ class CSVLoader:
             full_path = self.base_path / file_path
             if full_path.exists():
                 try:
-                    frames.append(pl.scan_csv(full_path, try_parse_dates=True))
+                    frames.append(normalize_columns(pl.scan_csv(full_path, try_parse_dates=True)))
                 except Exception as e:
                     raise DataLoadError(
                         f"Failed to load counterparty file: {e}",

--- a/uv.lock
+++ b/uv.lock
@@ -1173,7 +1173,7 @@ wheels = [
 
 [[package]]
 name = "rwa-calc"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
### This closses issue [24](https://github.com/OpenAfterHours/rwa_calculator/issues/24#issue-3851608478)

This pull request introduces a standardized approach to column name normalization for all data loaded through the `loader.py` module, ensuring consistency across both Parquet and CSV sources. The normalization converts all column names to lowercase and replaces spaces with underscores. Comprehensive tests are also added to verify this behavior for various scenarios.

**Column normalization enhancements:**

* Added a new utility function `normalize_columns` in `src/rwa_calc/engine/loader.py` to convert column names to lowercase and replace spaces with underscores for all loaded data.

* Updated all data loading methods (`_load_parquet`, `_load_parquet_optional`, `_load_and_combine_counterparties`, `_load_csv`, `_load_csv_optional`) in `src/rwa_calc/engine/loader.py` to apply the `normalize_columns` function, ensuring consistent column naming for both Parquet and CSV files. [[1]](diffhunk://#diff-de6ada9d76084938c058fada826ca152e0dfcf64ea0da2208bda65bf7b97548bL144-R160) [[2]](diffhunk://#diff-de6ada9d76084938c058fada826ca152e0dfcf64ea0da2208bda65bf7b97548bL166-R182) [[3]](diffhunk://#diff-de6ada9d76084938c058fada826ca152e0dfcf64ea0da2208bda65bf7b97548bL182-R198) [[4]](diffhunk://#diff-de6ada9d76084938c058fada826ca152e0dfcf64ea0da2208bda65bf7b97548bL305-R321) [[5]](diffhunk://#diff-de6ada9d76084938c058fada826ca152e0dfcf64ea0da2208bda65bf7b97548bL327-R343) [[6]](diffhunk://#diff-de6ada9d76084938c058fada826ca152e0dfcf64ea0da2208bda65bf7b97548bL343-R359)

**Testing improvements:**

* Added a new test class `TestHeaderNormalization` in `tests/unit/test_loader.py` to verify header normalization for Parquet and CSV files, including cases with uppercase headers and headers containing spaces. Also includes a direct test for the `normalize_columns` function.