### PR TITLE
feat(classifier): implement residential property exclusion for retail…

### DIFF
--- a/src/rwa_calc/data/schemas.py
+++ b/src/rwa_calc/data/schemas.py
@@ -396,6 +396,10 @@ RESOLVED_HIERARCHY_SCHEMA = {
     # Lending group aggregation
     "lending_group_reference": pl.String,
     "lending_group_total_exposure": pl.Float64,
+    # Retail threshold adjustment (CRR Art. 123(c) - residential property exclusion)
+    "lending_group_adjusted_exposure": pl.Float64,  # Excludes residential RE for retail threshold
+    "residential_collateral_value": pl.Float64,  # Residential RE collateral securing this exposure
+    "exposure_for_retail_threshold": pl.Float64,  # This exposure's contribution (excl. residential RE)
 }
 
 # Schema for exposures after classification

--- a/tests/unit/test_hierarchy.py
+++ b/tests/unit/test_hierarchy.py
@@ -587,9 +587,16 @@ class TestLendingGroupAggregation:
             counterparty_lookup,
         )
 
+        # Calculate residential property coverage (empty for this test)
+        residential_coverage = resolver._calculate_residential_property_coverage(
+            exposures,
+            None,  # No collateral
+        )
+
         lending_group_totals, errors = resolver._calculate_lending_group_totals(
             exposures,
             lending_group_mappings,
+            residential_coverage,
         )
 
         df = lending_group_totals.collect()
@@ -600,6 +607,8 @@ class TestLendingGroupAggregation:
 
         # Total should be sum of anchor + members (300k + 200k + 400k = 900k)
         assert df["total_drawn"][0] == 900000.0
+        # Adjusted exposure should equal total (no residential collateral)
+        assert df["adjusted_exposure"][0] == 900000.0
 
     def test_standalone_not_in_lending_group(
         self,
@@ -674,16 +683,24 @@ class TestLendingGroupAggregation:
             counterparty_lookup,
         )
 
+        # Calculate residential property coverage (empty for this test)
+        residential_coverage = resolver._calculate_residential_property_coverage(
+            exposures,
+            None,  # No collateral
+        )
+
         # Add lending group totals
         lending_group_totals, _ = resolver._calculate_lending_group_totals(
             exposures,
             lending_group_mappings,
+            residential_coverage,
         )
 
         enriched_exposures = resolver._add_lending_group_totals_to_exposures(
             exposures,
             lending_group_mappings,
             lending_group_totals,
+            residential_coverage,
         )
 
         df = enriched_exposures.collect()

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -240,6 +240,10 @@ def mock_resolved_bundle() -> ResolvedHierarchyBundle:
         "lgd": [0.45, 0.10],
         "seniority": ["senior", "senior"],
         "lending_group_total_exposure": [0.0, 0.0],
+        # Residential property exclusion columns (CRR Art. 123(c))
+        "lending_group_adjusted_exposure": [0.0, 0.0],
+        "residential_collateral_value": [0.0, 0.0],
+        "exposure_for_retail_threshold": [500000.0, 250000.0],
     })
 
     # Create counterparty lookup with matching counterparties


### PR DESCRIPTION
This pull request implements comprehensive support for the CRR Article 123(c) residential property exclusion in the EUR 1m retail threshold calculation, both in the user documentation and the core classification engine. It ensures that exposures secured by residential property (and assigned to the residential property class under the Standardised Approach) are excluded from the retail aggregation, as required by the regulation. The changes include new logic for calculating and tracking residential collateral coverage, updates to the classification pipeline to use adjusted exposures, and expanded auditability of the process.

**Key changes include:**

### Regulatory logic and classification engine updates

* Added logic to calculate residential property collateral coverage per exposure and exclude it from the EUR 1m retail threshold calculation, following CRR Art. 123(c) and Basel 3.1 CRE20.65. This includes new columns in the schema (`lending_group_adjusted_exposure`, `residential_collateral_value`, `exposure_for_retail_threshold`) and a new method `_calculate_residential_property_coverage` in `hierarchy.py`. [[1]](diffhunk://#diff-04eeea3da0125ae22d7104c692e0f1d41a86209f6fdfcadd5f061376c8092084R399-R402) [[2]](diffhunk://#diff-054f578a992202e82fb2283dbe871200953301a7eb67f21ff1ca5f24e42a7f7bR692-R809)
* Updated the retail classification pipeline to use the adjusted exposure for threshold tests, and to apply differentiated treatment for Standardised Approach (SA) residential mortgages, IRB, and other retail exposures. The logic now ensures that residential mortgages stay as retail regardless of threshold, while other exposures are reclassified appropriately.
* Enhanced audit trail and classification reasons to track whether the residential property exclusion was applied and to record the relevant amounts for transparency. [[1]](diffhunk://#diff-9d8857ec8c5b43a597a22861ee415145d73aa94872f034a92def436698bf0183R566-R569) [[2]](diffhunk://#diff-9d8857ec8c5b43a597a22861ee415145d73aa94872f034a92def436698bf0183R678-R680)

### Lending group and exposure aggregation

* Modified lending group aggregation logic to compute both total and adjusted exposures, joining in residential collateral values and ensuring nulls are handled correctly. This affects how exposures are grouped and classified for retail treatment. [[1]](diffhunk://#diff-054f578a992202e82fb2283dbe871200953301a7eb67f21ff1ca5f24e42a7f7bL120-R141) [[2]](diffhunk://#diff-054f578a992202e82fb2283dbe871200953301a7eb67f21ff1ca5f24e42a7f7bR563-R574) [[3]](diffhunk://#diff-054f578a992202e82fb2283dbe871200953301a7eb67f21ff1ca5f24e42a7f7bL585-R631)

### Documentation and regulatory references

* Expanded user documentation to clearly explain the residential property exclusion for the EUR 1m threshold, including regulatory references, key rules by approach, and a worked example. The regulatory reference table now also includes relevant EBA Q&A for clarity. [[1]](diffhunk://#diff-dc46cd1258cc5ddce5434505e8921f5b002e2041cfa7fef2df38bb8dbf820eb9L254-R254) [[2]](diffhunk://#diff-dc46cd1258cc5ddce5434505e8921f5b002e2041cfa7fef2df38bb8dbf820eb9R263-R334) [[3]](diffhunk://#diff-dc46cd1258cc5ddce5434505e8921f5b002e2041cfa7fef2df38bb8dbf820eb9L296-R362)

These changes ensure regulatory compliance, improve auditability, and provide clear guidance to users and developers.