### PR TITLE
feat(full lazy): transition to pure Polars expressions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ Utilise the following tooling:
 - DuckDB for areas where it is more suitable than polars
 - UV and UV native commands i.e. UV add instead of UV pip install
 - Marimo for workbooks - check the resources found here: https://docs.marimo.io/api/
+- For CF, PPF and PDF use polars-normal-stats package rather than scipy or numpy. This integrates with polars. check the resources here: https://pypi.org/project/polars-normal-stats/
 - Pytest for testing
 
 ## Coding standards

--- a/docs/architecture/components.md
+++ b/docs/architecture/components.md
@@ -422,10 +422,11 @@ The `.irb` namespace provides chainable methods for each calculation step:
 ### Key Features
 
 - **Fluent API**: Namespace enables readable, chainable method calls
-- **NumPy/SciPy performance**: Vectorized batch calculations via `map_batches`
+- **Pure Polars expressions**: Full lazy evaluation with `polars-normal-stats` for statistical functions
+- **Streaming-capable**: No data materialization required, enabling large dataset processing
 - PD and LGD floor application
 - Correlation calculation with SME adjustment
-- K formula implementation (scipy.special.ndtr for normal CDF)
+- K formula implementation using `normal_cdf` and `normal_ppf`
 - Maturity adjustment
 - Expected loss calculation
 - CRR 1.06 scaling factor

--- a/docs/architecture/design-principles.md
+++ b/docs/architecture/design-principles.md
@@ -245,7 +245,7 @@ from decimal import Decimal
 
 # Third-party
 import polars as pl
-from scipy.stats import norm
+from polars_normal_stats import normal_cdf, normal_ppf
 
 # Local - contracts first
 from rwa_calc.contracts.bundles import ResultBundle

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -228,7 +228,7 @@ For typical portfolio sizes:
 |-----------|------------|---------|
 | Data Processing | Polars | High-performance DataFrames |
 | Validation | Pydantic | Type-safe data validation |
-| Numerics | SciPy/NumPy | IRB formulas |
+| Numerics | polars-normal-stats | IRB formulas (pure Polars) |
 | Testing | Pytest | Comprehensive testing |
 | Documentation | MkDocs | This documentation |
 

--- a/docs/development/benchmarks.md
+++ b/docs/development/benchmarks.md
@@ -198,6 +198,31 @@ Individual component performance at 100K scale:
 | `test_classifier_100k` | Exposure classifier performance |
 | `test_sa_calculator_100k` | SA calculator performance |
 
+### IRB Formula Benchmarks
+
+The IRB formula implementation uses pure Polars expressions with `polars-normal-stats` for statistical functions, enabling full lazy evaluation and streaming.
+
+#### Performance Results
+
+| Scale | Mean Time | Throughput |
+|------:|----------:|-----------:|
+| 10,000 | 7.2 ms | 1.4M rows/s |
+| 100,000 | 32.3 ms | 3.1M rows/s |
+| 1,000,000 | 298 ms | 3.4M rows/s |
+
+Key benefits of the pure Polars implementation:
+
+- **Full lazy evaluation**: Query optimization preserved throughout
+- **Streaming-capable**: Datasets larger than memory can be processed
+- **No data conversion**: No NumPy/SciPy overhead
+- **Sub-second for 1M rows**: 1 million IRB exposures processed in ~300ms
+
+Run the IRB formula benchmark:
+
+```bash
+uv run python tests/benchmarks/benchmark_irb_formulas.py
+```
+
 ### Memory Benchmarks
 
 #### `TestPipelineMemoryBenchmark`

--- a/docs/development/code-style.md
+++ b/docs/development/code-style.md
@@ -203,7 +203,7 @@ from pathlib import Path
 
 # 2. Third-party
 import polars as pl
-from scipy.stats import norm
+from polars_normal_stats import normal_cdf, normal_ppf
 
 # 3. Local - contracts first
 from rwa_calc.contracts.bundles import ResultBundle

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -103,8 +103,7 @@ pip install -e ".[dev]"
 |---------|---------|
 | `polars` | High-performance DataFrame operations |
 | `pydantic` | Data validation and settings management |
-| `scipy` | Scientific computing (IRB formulas) |
-| `numpy` | Numerical operations |
+| `polars-normal-stats` | Statistical functions for IRB formulas (normal CDF/PPF) |
 | `pyarrow` | Parquet file support |
 | `pyyaml` | Configuration file parsing |
 | `duckdb` | SQL analytics engine |

--- a/docs/index.md
+++ b/docs/index.md
@@ -138,8 +138,8 @@ The calculator is built using modern, high-performance technologies:
 - **Python 3.13+** - Latest Python features
 - **Polars** - Vectorized DataFrame operations with LazyFrame optimization
 - **Pydantic** - Data validation and type safety
-- **SciPy/NumPy** - Numerical computations for IRB formulas
-- **Pytest** - Comprehensive test coverage (468+ tests)
+- **polars-normal-stats** - Pure Polars statistical functions for IRB formulas
+- **Pytest** - Comprehensive test coverage (800+ tests)
 
 ## Regulatory References
 

--- a/docs/user-guide/methodology/irb-approach.md
+++ b/docs/user-guide/methodology/irb-approach.md
@@ -19,7 +19,7 @@ Two IRB variants are available:
 
 ## IRB Formula
 
-The core IRB formula calculates the capital requirement (K). See [`irb/formulas.py:260-291`](https://github.com/OpenAfterHours/rwa_calculator/blob/master/src/rwa_calc/engine/irb/formulas.py#L260-L291) for the vectorized NumPy implementation.
+The core IRB formula calculates the capital requirement (K). See [`irb/formulas.py`](https://github.com/OpenAfterHours/rwa_calculator/blob/master/src/rwa_calc/engine/irb/formulas.py) for the pure Polars implementation using `polars-normal-stats`.
 
 ```
 K = [LGD × N((1-R)^(-0.5) × G(PD) + (R/(1-R))^0.5 × G(0.999)) - LGD × PD] × MA
@@ -129,7 +129,7 @@ M = max(1, min(5, weighted_average_life))
 
 ## Asset Correlation
 
-Asset correlation (R) determines how sensitive the exposure is to systematic risk. See [`irb/formulas.py:190-257`](https://github.com/OpenAfterHours/rwa_calculator/blob/master/src/rwa_calc/engine/irb/formulas.py#L190-L257) for the vectorized implementation.
+Asset correlation (R) determines how sensitive the exposure is to systematic risk. See [`_polars_correlation_expr()`](https://github.com/OpenAfterHours/rwa_calculator/blob/master/src/rwa_calc/engine/irb/formulas.py) for the pure Polars implementation.
 
 ### Corporate/Bank Correlation
 
@@ -176,7 +176,7 @@ R = 0.03 × (1 - exp(-35 × PD)) / (1 - exp(-35)) +
 
 ## Maturity Adjustment
 
-For non-retail exposures. See [`irb/formulas.py:293-316`](https://github.com/OpenAfterHours/rwa_calculator/blob/master/src/rwa_calc/engine/irb/formulas.py#L293-L316) for implementation.
+For non-retail exposures. See [`_polars_maturity_adjustment_expr()`](https://github.com/OpenAfterHours/rwa_calculator/blob/master/src/rwa_calc/engine/irb/formulas.py) for the pure Polars implementation.
 
 ```python
 # Maturity factor b
@@ -384,7 +384,7 @@ print(f"Expected Loss: {result.total_expected_loss:,.2f}")
 
 ### Using IRB Formulas Directly
 
-The IRB formulas are implemented in [`irb/formulas.py`](https://github.com/OpenAfterHours/rwa_calculator/blob/master/src/rwa_calc/engine/irb/formulas.py). Both scalar and vectorized (NumPy/Polars) versions are available.
+The IRB formulas are implemented in [`irb/formulas.py`](https://github.com/OpenAfterHours/rwa_calculator/blob/master/src/rwa_calc/engine/irb/formulas.py). Both scalar functions and pure Polars expression functions are available, using `polars-normal-stats` for statistical operations.
 
 ```python
 from rwa_calc.engine.irb.formulas import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,11 +27,10 @@ classifiers = [
 dependencies = [
     "polars>=1.0.0",
     "pydantic>=2.0.0",
-    "scipy>=1.11.0",
-    "numpy>=1.26.0",
     "duckdb>=0.9.0",
     "pyarrow>=14.0.0",
     "pyyaml>=6.0.0",
+    "polars-normal-stats>=0.1.0",
 ]
 
 [project.scripts]
@@ -59,6 +58,7 @@ dev = [
     "mkdocs-material>=9.5.0",
     "mkdocs-mermaid2-plugin>=1.1.0",
     "mkdocstrings[python]>=0.24.0",
+    "numpy>=1.26.0",  # For benchmark data generation only
 ]
 all = [
     "rwa-calc[ui,dev]",
@@ -123,4 +123,5 @@ dev = [
     "mkdocstrings[python]>=1.0.0",
     "mypy>=1.19.1",
     "pytest-benchmark>=5.2.3",
+    "numpy>=1.26.0",  # For benchmark data generation only
 ]

--- a/tests/benchmarks/benchmark_irb_formulas.py
+++ b/tests/benchmarks/benchmark_irb_formulas.py
@@ -1,9 +1,10 @@
 """
 Benchmark for IRB formulas implementation.
 
-The IRB formulas use a hybrid approach combining:
-- Polars lazy evaluation (query optimization, streaming)
-- NumPy/SciPy via map_batches (fast statistical functions)
+The IRB formulas use pure Polars expressions with polars-normal-stats:
+- Full Polars lazy evaluation (query optimization, streaming)
+- polars-normal-stats for statistical functions (normal_cdf, normal_ppf)
+- No scipy/numpy dependency in production code
 
 This benchmark demonstrates performance at various scales.
 
@@ -18,7 +19,7 @@ import time
 from dataclasses import dataclass
 from datetime import date
 
-import numpy as np
+import numpy as np  # For test data generation only
 import polars as pl
 
 from rwa_calc.contracts.config import CalculationConfig
@@ -131,14 +132,14 @@ def run_benchmark(
 def main():
     """Run the IRB formulas benchmark."""
     print("=" * 70)
-    print("IRB Formulas Benchmark (map_batches with NumPy/SciPy)")
+    print("IRB Formulas Benchmark (Pure Polars with polars-normal-stats)")
     print("=" * 70)
     print()
-    print("Implementation: Polars lazy evaluation + NumPy/SciPy via map_batches")
+    print("Implementation: Pure Polars expressions + polars-normal-stats")
     print("Benefits:")
-    print("  - Preserves lazy evaluation (query optimization)")
-    print("  - Fast NumPy/SciPy statistical functions")
-    print("  - ~1.5x faster than full collect-compute-lazy pattern")
+    print("  - Full lazy evaluation (query optimization, streaming)")
+    print("  - No scipy/numpy dependency in production code")
+    print("  - Enables streaming for large datasets")
     print()
 
     row_counts = [1_000, 10_000, 100_000]
@@ -174,10 +175,11 @@ def main():
 
     print()
     print("Implementation details:")
-    print("  - Correlation: NumPy vectorized (exposure class dependent)")
-    print("  - Capital K: SciPy norm.ppf/cdf for statistical functions")
-    print("  - Maturity Adjustment: NumPy vectorized")
+    print("  - Correlation: Pure Polars expressions (exposure class dependent)")
+    print("  - Capital K: polars-normal-stats (normal_ppf/normal_cdf)")
+    print("  - Maturity Adjustment: Pure Polars expressions")
     print("  - RWA/Risk Weight/EL: Pure Polars expressions")
+    print("  - Full lazy evaluation preserved throughout")
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -849,6 +849,18 @@ wheels = [
 ]
 
 [[package]]
+name = "polars-normal-stats"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "polars" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/fd/2942d29f834778146b0c755a92e6a88a09eec5e643d90ad2d7281794fed4/polars_normal_stats-0.1.0.tar.gz", hash = "sha256:cb70b6f90b477abb2889bc0a876a9da63dd2576b9df0ccb5d9fdd755200ec693", size = 41087, upload-time = "2026-01-25T04:18:14.879Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/fb/0846409069c1ea634cc08e0ab9b12334d08649ed46defdbcb61d747b90b7/polars_normal_stats-0.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:859be5e583c234df2d2c174a59f7684831fd5f39af6d33284d0e1953c2fdf908", size = 4351271, upload-time = "2026-01-25T04:18:13.341Z" },
+]
+
+[[package]]
 name = "polars-runtime-32"
 version = "1.37.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1177,12 +1189,11 @@ version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },
-    { name = "numpy" },
     { name = "polars" },
+    { name = "polars-normal-stats" },
     { name = "pyarrow" },
     { name = "pydantic" },
     { name = "pyyaml" },
-    { name = "scipy" },
 ]
 
 [package.optional-dependencies]
@@ -1193,6 +1204,7 @@ all = [
     { name = "mkdocs-mermaid2-plugin" },
     { name = "mkdocstrings", extra = ["python"] },
     { name = "mypy" },
+    { name = "numpy" },
     { name = "pytest" },
     { name = "pytest-benchmark" },
     { name = "pytest-cov" },
@@ -1205,6 +1217,7 @@ dev = [
     { name = "mkdocs-mermaid2-plugin" },
     { name = "mkdocstrings", extra = ["python"] },
     { name = "mypy" },
+    { name = "numpy" },
     { name = "pytest" },
     { name = "pytest-benchmark" },
     { name = "pytest-cov" },
@@ -1222,6 +1235,7 @@ dev = [
     { name = "mkdocs-mermaid2-plugin" },
     { name = "mkdocstrings", extra = ["python"] },
     { name = "mypy" },
+    { name = "numpy" },
     { name = "pytest-benchmark" },
 ]
 
@@ -1234,8 +1248,9 @@ requires-dist = [
     { name = "mkdocs-mermaid2-plugin", marker = "extra == 'dev'", specifier = ">=1.1.0" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8.0" },
-    { name = "numpy", specifier = ">=1.26.0" },
+    { name = "numpy", marker = "extra == 'dev'", specifier = ">=1.26.0" },
     { name = "polars", specifier = ">=1.0.0" },
+    { name = "polars-normal-stats", specifier = ">=0.1.0" },
     { name = "pyarrow", specifier = ">=14.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
@@ -1244,7 +1259,6 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.3.0" },
     { name = "rwa-calc", extras = ["ui", "dev"], marker = "extra == 'all'" },
-    { name = "scipy", specifier = ">=1.11.0" },
     { name = "uvicorn", marker = "extra == 'ui'", specifier = ">=0.27.0" },
 ]
 provides-extras = ["ui", "dev", "all"]
@@ -1256,58 +1270,8 @@ dev = [
     { name = "mkdocs-mermaid2-plugin", specifier = ">=1.2.3" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=1.0.0" },
     { name = "mypy", specifier = ">=1.19.1" },
+    { name = "numpy", specifier = ">=1.26.0" },
     { name = "pytest-benchmark", specifier = ">=5.2.3" },
-]
-
-[[package]]
-name = "scipy"
-version = "1.17.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/56/3e/9cca699f3486ce6bc12ff46dc2031f1ec8eb9ccc9a320fdaf925f1417426/scipy-1.17.0.tar.gz", hash = "sha256:2591060c8e648d8b96439e111ac41fd8342fdeff1876be2e19dea3fe8930454e", size = 30396830, upload-time = "2026-01-10T21:34:23.009Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/51/3468fdfd49387ddefee1636f5cf6d03ce603b75205bf439bbf0e62069bfd/scipy-1.17.0-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:65ec32f3d32dfc48c72df4291345dae4f048749bc8d5203ee0a3f347f96c5ce6", size = 31344101, upload-time = "2026-01-10T21:26:30.25Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/9a/9406aec58268d437636069419e6977af953d1e246df941d42d3720b7277b/scipy-1.17.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:1f9586a58039d7229ce77b52f8472c972448cded5736eaf102d5658bbac4c269", size = 27950385, upload-time = "2026-01-10T21:26:36.801Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/98/e7342709e17afdfd1b26b56ae499ef4939b45a23a00e471dfb5375eea205/scipy-1.17.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:9fad7d3578c877d606b1150135c2639e9de9cecd3705caa37b66862977cc3e72", size = 20122115, upload-time = "2026-01-10T21:26:42.107Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/0e/9eeeb5357a64fd157cbe0302c213517c541cc16b8486d82de251f3c68ede/scipy-1.17.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:423ca1f6584fc03936972b5f7c06961670dbba9f234e71676a7c7ccf938a0d61", size = 22442402, upload-time = "2026-01-10T21:26:48.029Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/10/be13397a0e434f98e0c79552b2b584ae5bb1c8b2be95db421533bbca5369/scipy-1.17.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fe508b5690e9eaaa9467fc047f833af58f1152ae51a0d0aed67aa5801f4dd7d6", size = 32696338, upload-time = "2026-01-10T21:26:55.521Z" },
-    { url = "https://files.pythonhosted.org/packages/63/1e/12fbf2a3bb240161651c94bb5cdd0eae5d4e8cc6eaeceb74ab07b12a753d/scipy-1.17.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6680f2dfd4f6182e7d6db161344537da644d1cf85cf293f015c60a17ecf08752", size = 34977201, upload-time = "2026-01-10T21:27:03.501Z" },
-    { url = "https://files.pythonhosted.org/packages/19/5b/1a63923e23ccd20bd32156d7dd708af5bbde410daa993aa2500c847ab2d2/scipy-1.17.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:eec3842ec9ac9de5917899b277428886042a93db0b227ebbe3a333b64ec7643d", size = 34777384, upload-time = "2026-01-10T21:27:11.423Z" },
-    { url = "https://files.pythonhosted.org/packages/39/22/b5da95d74edcf81e540e467202a988c50fef41bd2011f46e05f72ba07df6/scipy-1.17.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d7425fcafbc09a03731e1bc05581f5fad988e48c6a861f441b7ab729a49a55ea", size = 37379586, upload-time = "2026-01-10T21:27:20.171Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/b6/8ac583d6da79e7b9e520579f03007cb006f063642afd6b2eeb16b890bf93/scipy-1.17.0-cp313-cp313-win_amd64.whl", hash = "sha256:87b411e42b425b84777718cc41516b8a7e0795abfa8e8e1d573bf0ef014f0812", size = 36287211, upload-time = "2026-01-10T21:28:43.122Z" },
-    { url = "https://files.pythonhosted.org/packages/55/fb/7db19e0b3e52f882b420417644ec81dd57eeef1bd1705b6f689d8ff93541/scipy-1.17.0-cp313-cp313-win_arm64.whl", hash = "sha256:357ca001c6e37601066092e7c89cca2f1ce74e2a520ca78d063a6d2201101df2", size = 24312646, upload-time = "2026-01-10T21:28:49.893Z" },
-    { url = "https://files.pythonhosted.org/packages/20/b6/7feaa252c21cc7aff335c6c55e1b90ab3e3306da3f048109b8b639b94648/scipy-1.17.0-cp313-cp313t-macosx_10_14_x86_64.whl", hash = "sha256:ec0827aa4d36cb79ff1b81de898e948a51ac0b9b1c43e4a372c0508c38c0f9a3", size = 31693194, upload-time = "2026-01-10T21:27:27.454Z" },
-    { url = "https://files.pythonhosted.org/packages/76/bb/bbb392005abce039fb7e672cb78ac7d158700e826b0515cab6b5b60c26fb/scipy-1.17.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:819fc26862b4b3c73a60d486dbb919202f3d6d98c87cf20c223511429f2d1a97", size = 28365415, upload-time = "2026-01-10T21:27:34.26Z" },
-    { url = "https://files.pythonhosted.org/packages/37/da/9d33196ecc99fba16a409c691ed464a3a283ac454a34a13a3a57c0d66f3a/scipy-1.17.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:363ad4ae2853d88ebcde3ae6ec46ccca903ea9835ee8ba543f12f575e7b07e4e", size = 20537232, upload-time = "2026-01-10T21:27:40.306Z" },
-    { url = "https://files.pythonhosted.org/packages/56/9d/f4b184f6ddb28e9a5caea36a6f98e8ecd2a524f9127354087ce780885d83/scipy-1.17.0-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:979c3a0ff8e5ba254d45d59ebd38cde48fce4f10b5125c680c7a4bfe177aab07", size = 22791051, upload-time = "2026-01-10T21:27:46.539Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/9d/025cccdd738a72140efc582b1641d0dd4caf2e86c3fb127568dc80444e6e/scipy-1.17.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:130d12926ae34399d157de777472bf82e9061c60cc081372b3118edacafe1d00", size = 32815098, upload-time = "2026-01-10T21:27:54.389Z" },
-    { url = "https://files.pythonhosted.org/packages/48/5f/09b879619f8bca15ce392bfc1894bd9c54377e01d1b3f2f3b595a1b4d945/scipy-1.17.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6e886000eb4919eae3a44f035e63f0fd8b651234117e8f6f29bad1cd26e7bc45", size = 35031342, upload-time = "2026-01-10T21:28:03.012Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/9a/f0f0a9f0aa079d2f106555b984ff0fbb11a837df280f04f71f056ea9c6e4/scipy-1.17.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:13c4096ac6bc31d706018f06a49abe0485f96499deb82066b94d19b02f664209", size = 34893199, upload-time = "2026-01-10T21:28:10.832Z" },
-    { url = "https://files.pythonhosted.org/packages/90/b8/4f0f5cf0c5ea4d7548424e6533e6b17d164f34a6e2fb2e43ffebb6697b06/scipy-1.17.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:cacbaddd91fcffde703934897c5cd2c7cb0371fac195d383f4e1f1c5d3f3bd04", size = 37438061, upload-time = "2026-01-10T21:28:19.684Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/cc/2bd59140ed3b2fa2882fb15da0a9cb1b5a6443d67cfd0d98d4cec83a57ec/scipy-1.17.0-cp313-cp313t-win_amd64.whl", hash = "sha256:edce1a1cf66298cccdc48a1bdf8fb10a3bf58e8b58d6c3883dd1530e103f87c0", size = 36328593, upload-time = "2026-01-10T21:28:28.007Z" },
-    { url = "https://files.pythonhosted.org/packages/13/1b/c87cc44a0d2c7aaf0f003aef2904c3d097b422a96c7e7c07f5efd9073c1b/scipy-1.17.0-cp313-cp313t-win_arm64.whl", hash = "sha256:30509da9dbec1c2ed8f168b8d8aa853bc6723fede1dbc23c7d43a56f5ab72a67", size = 24625083, upload-time = "2026-01-10T21:28:35.188Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/2d/51006cd369b8e7879e1c630999a19d1fbf6f8b5ed3e33374f29dc87e53b3/scipy-1.17.0-cp314-cp314-macosx_10_14_x86_64.whl", hash = "sha256:c17514d11b78be8f7e6331b983a65a7f5ca1fd037b95e27b280921fe5606286a", size = 31346803, upload-time = "2026-01-10T21:28:57.24Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/2e/2349458c3ce445f53a6c93d4386b1c4c5c0c540917304c01222ff95ff317/scipy-1.17.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:4e00562e519c09da34c31685f6acc3aa384d4d50604db0f245c14e1b4488bfa2", size = 27967182, upload-time = "2026-01-10T21:29:04.107Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/7c/df525fbfa77b878d1cfe625249529514dc02f4fd5f45f0f6295676a76528/scipy-1.17.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:f7df7941d71314e60a481e02d5ebcb3f0185b8d799c70d03d8258f6c80f3d467", size = 20139125, upload-time = "2026-01-10T21:29:10.179Z" },
-    { url = "https://files.pythonhosted.org/packages/33/11/fcf9d43a7ed1234d31765ec643b0515a85a30b58eddccc5d5a4d12b5f194/scipy-1.17.0-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:aabf057c632798832f071a8dde013c2e26284043934f53b00489f1773b33527e", size = 22443554, upload-time = "2026-01-10T21:29:15.888Z" },
-    { url = "https://files.pythonhosted.org/packages/80/5c/ea5d239cda2dd3d31399424967a24d556cf409fbea7b5b21412b0fd0a44f/scipy-1.17.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a38c3337e00be6fd8a95b4ed66b5d988bac4ec888fd922c2ea9fe5fb1603dd67", size = 32757834, upload-time = "2026-01-10T21:29:23.406Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/7e/8c917cc573310e5dc91cbeead76f1b600d3fb17cf0969db02c9cf92e3cfa/scipy-1.17.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00fb5f8ec8398ad90215008d8b6009c9db9fa924fd4c7d6be307c6f945f9cd73", size = 34995775, upload-time = "2026-01-10T21:29:31.915Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/43/176c0c3c07b3f7df324e7cdd933d3e2c4898ca202b090bd5ba122f9fe270/scipy-1.17.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f2a4942b0f5f7c23c7cd641a0ca1955e2ae83dedcff537e3a0259096635e186b", size = 34841240, upload-time = "2026-01-10T21:29:39.995Z" },
-    { url = "https://files.pythonhosted.org/packages/44/8c/d1f5f4b491160592e7f084d997de53a8e896a3ac01cd07e59f43ca222744/scipy-1.17.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:dbf133ced83889583156566d2bdf7a07ff89228fe0c0cb727f777de92092ec6b", size = 37394463, upload-time = "2026-01-10T21:29:48.723Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/ec/42a6657f8d2d087e750e9a5dde0b481fd135657f09eaf1cf5688bb23c338/scipy-1.17.0-cp314-cp314-win_amd64.whl", hash = "sha256:3625c631a7acd7cfd929e4e31d2582cf00f42fcf06011f59281271746d77e061", size = 37053015, upload-time = "2026-01-10T21:30:51.418Z" },
-    { url = "https://files.pythonhosted.org/packages/27/58/6b89a6afd132787d89a362d443a7bddd511b8f41336a1ae47f9e4f000dc4/scipy-1.17.0-cp314-cp314-win_arm64.whl", hash = "sha256:9244608d27eafe02b20558523ba57f15c689357c85bdcfe920b1828750aa26eb", size = 24951312, upload-time = "2026-01-10T21:30:56.771Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/01/f58916b9d9ae0112b86d7c3b10b9e685625ce6e8248df139d0fcb17f7397/scipy-1.17.0-cp314-cp314t-macosx_10_14_x86_64.whl", hash = "sha256:2b531f57e09c946f56ad0b4a3b2abee778789097871fc541e267d2eca081cff1", size = 31706502, upload-time = "2026-01-10T21:29:56.326Z" },
-    { url = "https://files.pythonhosted.org/packages/59/8e/2912a87f94a7d1f8b38aabc0faf74b82d3b6c9e22be991c49979f0eceed8/scipy-1.17.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:13e861634a2c480bd237deb69333ac79ea1941b94568d4b0efa5db5e263d4fd1", size = 28380854, upload-time = "2026-01-10T21:30:01.554Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/1c/874137a52dddab7d5d595c1887089a2125d27d0601fce8c0026a24a92a0b/scipy-1.17.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:eb2651271135154aa24f6481cbae5cc8af1f0dd46e6533fb7b56aa9727b6a232", size = 20552752, upload-time = "2026-01-10T21:30:05.93Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/f0/7518d171cb735f6400f4576cf70f756d5b419a07fe1867da34e2c2c9c11b/scipy-1.17.0-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:c5e8647f60679790c2f5c76be17e2e9247dc6b98ad0d3b065861e082c56e078d", size = 22803972, upload-time = "2026-01-10T21:30:10.651Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/74/3498563a2c619e8a3ebb4d75457486c249b19b5b04a30600dfd9af06bea5/scipy-1.17.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5fb10d17e649e1446410895639f3385fd2bf4c3c7dfc9bea937bddcbc3d7b9ba", size = 32829770, upload-time = "2026-01-10T21:30:16.359Z" },
-    { url = "https://files.pythonhosted.org/packages/48/d1/7b50cedd8c6c9d6f706b4b36fa8544d829c712a75e370f763b318e9638c1/scipy-1.17.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8547e7c57f932e7354a2319fab613981cde910631979f74c9b542bb167a8b9db", size = 35051093, upload-time = "2026-01-10T21:30:22.987Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/82/a2d684dfddb87ba1b3ea325df7c3293496ee9accb3a19abe9429bce94755/scipy-1.17.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:33af70d040e8af9d5e7a38b5ed3b772adddd281e3062ff23fec49e49681c38cf", size = 34909905, upload-time = "2026-01-10T21:30:28.704Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/5e/e565bd73991d42023eb82bb99e51c5b3d9e2c588ca9d4b3e2cc1d3ca62a6/scipy-1.17.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f9eb55bb97d00f8b7ab95cb64f873eb0bf54d9446264d9f3609130381233483f", size = 37457743, upload-time = "2026-01-10T21:30:34.819Z" },
-    { url = "https://files.pythonhosted.org/packages/58/a8/a66a75c3d8f1fb2b83f66007d6455a06a6f6cf5618c3dc35bc9b69dd096e/scipy-1.17.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1ff269abf702f6c7e67a4b7aad981d42871a11b9dd83c58d2d2ea624efbd1088", size = 37098574, upload-time = "2026-01-10T21:30:40.782Z" },
-    { url = "https://files.pythonhosted.org/packages/56/a5/df8f46ef7da168f1bc52cd86e09a9de5c6f19cc1da04454d51b7d4f43408/scipy-1.17.0-cp314-cp314t-win_arm64.whl", hash = "sha256:031121914e295d9791319a1875444d55079885bbae5bdc9c5e0f2ee5f09d34ff", size = 25246266, upload-time = "2026-01-10T21:30:45.923Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request migrates the IRB formula implementation from using NumPy/SciPy with `map_batches` to a pure Polars approach, leveraging the `polars-normal-stats` package for statistical functions (normal CDF/PPF). This change enables full lazy evaluation, true streaming for large datasets, and removes the runtime dependency on NumPy/SciPy for core calculations. The documentation, benchmarks, and code examples are updated throughout to reflect this new approach.

**Core IRB Formula Implementation:**

- Replaced all NumPy/SciPy-based statistical computations in `src/rwa_calc/engine/irb/formulas.py` with pure Polars expressions using `polars-normal-stats` (`normal_cdf`, `normal_ppf`). This affects correlation, capital requirement (K), and maturity adjustment calculations. [[1]](diffhunk://#diff-92acd6b8b81c0e78bcda7f4438ee89c4afcd4024ee3fb1922069a70a7db00721L30-R31) [[2]](diffhunk://#diff-92acd6b8b81c0e78bcda7f4438ee89c4afcd4024ee3fb1922069a70a7db00721L125-R150)

- Updated the main IRB formula pipeline to eliminate all uses of `.map_batches` and NumPy/SciPy, ensuring all steps (including statistical functions) are performed with Polars expressions for maximum performance and streaming capability. [[1]](diffhunk://#diff-92acd6b8b81c0e78bcda7f4438ee89c4afcd4024ee3fb1922069a70a7db00721L71-R70) [[2]](diffhunk://#diff-92acd6b8b81c0e78bcda7f4438ee89c4afcd4024ee3fb1922069a70a7db00721L80-R82) [[3]](diffhunk://#diff-92acd6b8b81c0e78bcda7f4438ee89c4afcd4024ee3fb1922069a70a7db00721L109-R108) [[4]](diffhunk://#diff-92acd6b8b81c0e78bcda7f4438ee89c4afcd4024ee3fb1922069a70a7db00721L125-R150)

**Dependency and Environment Changes:**

- Removed `scipy` and `numpy` from core dependencies in `pyproject.toml`, and added `polars-normal-stats` as a required dependency. `numpy` is now only included for development/benchmark data generation. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L30-R33) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R61) [[3]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R126)

**Documentation and Usage Updates:**

- Updated all documentation to reference `polars-normal-stats` instead of SciPy/NumPy for IRB formulas, including installation instructions, architecture, methodology, and code style. [[1]](diffhunk://#diff-6828264893dbf2a68733af90bf5996b5b8afec681e5d6f216edca2ec9c8d1fa5L106-R106) [[2]](diffhunk://#diff-71a87b35224a82a8fa67ccd14f0f9b00673efea0b16a6bcbc0434baa09f5f9f8L231-R231) [[3]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L141-R142) [[4]](diffhunk://#diff-706cd55b2b2017939cdcf7e5738bb3b801164711c85ccad515f1775d925628afL248-R248) [[5]](diffhunk://#diff-afdcdc3fe29f4ecab226697752863d1c2266c7152b9c3ea2795a559d7f1d91c0L206-R206) [[6]](diffhunk://#diff-363b6cfefe4a473fe977c0213d979f21e06495233335d64a58fcb44c9e1d0108L425-R429) [[7]](diffhunk://#diff-eed40674b3d8cf4d2e82fa0ead4d43a2aa941d62fbf10747701b908ce7854f56L22-R22) [[8]](diffhunk://#diff-eed40674b3d8cf4d2e82fa0ead4d43a2aa941d62fbf10747701b908ce7854f56L132-R132) [[9]](diffhunk://#diff-eed40674b3d8cf4d2e82fa0ead4d43a2aa941d62fbf10747701b908ce7854f56L179-R179) [[10]](diffhunk://#diff-eed40674b3d8cf4d2e82fa0ead4d43a2aa941d62fbf10747701b908ce7854f56L387-R387) [[11]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R31)

- Revised code examples and extension guides to demonstrate how to use pure Polars expressions and `polars-normal-stats` for custom calculations, removing all NumPy/SciPy-based examples. [[1]](diffhunk://#diff-cfa448e979275a7754e5ee82790cd1e0002d36392b57edbc8f6089307c67ca77L449-R472) [[2]](diffhunk://#diff-cfa448e979275a7754e5ee82790cd1e0002d36392b57edbc8f6089307c67ca77L519-R521)

**Performance and Benchmarks:**

- Added new IRB formula benchmarks and performance results to documentation, highlighting sub-second processing for 1M rows and the benefits of the pure Polars approach (lazy evaluation, streaming, no data conversion).

**Summary of Most Important Changes:**

**IRB Formula Implementation:**
- Migrated all statistical computations (CDF, PPF) in `formulas.py` to use pure Polars expressions with `polars-normal-stats`, removing all NumPy/SciPy dependencies from the calculation pipeline. [[1]](diffhunk://#diff-92acd6b8b81c0e78bcda7f4438ee89c4afcd4024ee3fb1922069a70a7db00721L30-R31) [[2]](diffhunk://#diff-92acd6b8b81c0e78bcda7f4438ee89c4afcd4024ee3fb1922069a70a7db00721L125-R150)
- Refactored the IRB formula pipeline to use only Polars expressions, eliminating `.map_batches` and any conversion to NumPy arrays. [[1]](diffhunk://#diff-92acd6b8b81c0e78bcda7f4438ee89c4afcd4024ee3fb1922069a70a7db00721L71-R70) [[2]](diffhunk://#diff-92acd6b8b81c0e78bcda7f4438ee89c4afcd4024ee3fb1922069a70a7db00721L80-R82) [[3]](diffhunk://#diff-92acd6b8b81c0e78bcda7f4438ee89c4afcd4024ee3fb1922069a70a7db00721L109-R108) [[4]](diffhunk://#diff-92acd6b8b81c0e78bcda7f4438ee89c4afcd4024ee3fb1922069a70a7db00721L125-R150)

**Dependencies:**
- Removed `scipy` and `numpy` from core dependencies, and added `polars-normal-stats` as a required dependency in `pyproject.toml`.

**Documentation:**
- Updated all user and developer documentation to reference `polars-normal-stats` and the pure Polars approach, replacing all mentions and examples of SciPy/NumPy. [[1]](diffhunk://#diff-6828264893dbf2a68733af90bf5996b5b8afec681e5d6f216edca2ec9c8d1fa5L106-R106) [[2]](diffhunk://#diff-71a87b35224a82a8fa67ccd14f0f9b00673efea0b16a6bcbc0434baa09f5f9f8L231-R231) [[3]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L141-R142) [[4]](diffhunk://#diff-706cd55b2b2017939cdcf7e5738bb3b801164711c85ccad515f1775d925628afL248-R248) [[5]](diffhunk://#diff-afdcdc3fe29f4ecab226697752863d1c2266c7152b9c3ea2795a559d7f1d91c0L206-R206) [[6]](diffhunk://#diff-363b6cfefe4a473fe977c0213d979f21e06495233335d64a58fcb44c9e1d0108L425-R429) [[7]](diffhunk://#diff-eed40674b3d8cf4d2e82fa0ead4d43a2aa941d62fbf10747701b908ce7854f56L22-R22) [[8]](diffhunk://#diff-eed40674b3d8cf4d2e82fa0ead4d43a2aa941d62fbf10747701b908ce7854f56L132-R132) [[9]](diffhunk://#diff-eed40674b3d8cf4d2e82fa0ead4d43a2aa941d62fbf10747701b908ce7854f56L179-R179) [[10]](diffhunk://#diff-eed40674b3d8cf4d2e82fa0ead4d43a2aa941d62fbf10747701b908ce7854f56L387-R387) [[11]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R31) [[12]](diffhunk://#diff-cfa448e979275a7754e5ee82790cd1e0002d36392b57edbc8f6089307c67ca77L449-R472) [[13]](diffhunk://#diff-cfa448e979275a7754e5ee82790cd1e0002d36392b57edbc8f6089307c67ca77L519-R521)

**Benchmarks:**
- Added new benchmark results and documentation, demonstrating high throughput and sub-second performance for large IRB portfolios using the new implementation.