### PR TITLE
feat(stats): implement backend detection for statistical functions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "duckdb>=0.9.0",
     "pyarrow>=14.0.0",
     "pyyaml>=6.0.0",
-    "polars-normal-stats>=0.1.0",
+    "scipy>=1.10.0",  # Stats backend fallback (always available)
 ]
 
 [project.scripts]
@@ -44,6 +44,9 @@ Issues = "https://github.com/OpenAfterHours/rwa_calculator/issues"
 Changelog = "https://github.com/OpenAfterHours/rwa_calculator/blob/master/docs/appendix/changelog.md"
 
 [project.optional-dependencies]
+fast-stats = [
+    "polars-normal-stats>=0.1.0",  # Native Polars stats (faster, streaming-compatible)
+]
 ui = [
     "marimo>=0.5.0",
     "uvicorn>=0.27.0",
@@ -61,7 +64,7 @@ dev = [
     "numpy>=1.26.0",  # For benchmark data generation only
 ]
 all = [
-    "rwa-calc[ui,dev]",
+    "rwa-calc[fast-stats,ui,dev]",
 ]
 
 [build-system]

--- a/src/rwa_calc/engine/irb/__init__.py
+++ b/src/rwa_calc/engine/irb/__init__.py
@@ -32,14 +32,15 @@ import rwa_calc.engine.irb.namespace  # noqa: F401
 
 from rwa_calc.engine.irb.calculator import IRBCalculator, create_irb_calculator
 from rwa_calc.engine.irb.formulas import (
+    apply_irb_formulas,
     calculate_correlation,
+    calculate_expected_loss,
+    calculate_irb_rwa,
     calculate_k,
     calculate_maturity_adjustment,
-    calculate_irb_rwa,
-    calculate_expected_loss,
-    apply_irb_formulas,
 )
-from rwa_calc.engine.irb.namespace import IRBLazyFrame, IRBExpr
+from rwa_calc.engine.irb.namespace import IRBExpr, IRBLazyFrame
+from rwa_calc.engine.irb.stats_backend import get_backend
 
 __all__ = [
     "IRBCalculator",
@@ -53,4 +54,6 @@ __all__ = [
     # Namespace classes
     "IRBLazyFrame",
     "IRBExpr",
+    # Backend diagnostics
+    "get_backend",
 ]

--- a/src/rwa_calc/engine/irb/stats_backend.py
+++ b/src/rwa_calc/engine/irb/stats_backend.py
@@ -1,0 +1,165 @@
+"""Statistical function backend abstraction for IRB formulas.
+
+Provides normal_cdf() and normal_ppf() expressions with automatic backend detection.
+Tries polars-normal-stats first (native, fast), falls back to scipy (universal).
+
+Usage:
+    from rwa_calc.engine.irb.stats_backend import normal_cdf, normal_ppf, get_backend
+
+    # In expressions
+    result = df.with_columns(normal_cdf(pl.col("x")).alias("cdf"))
+
+    # Check which backend is active
+    backend = get_backend()  # Returns "polars-normal-stats" or "scipy"
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import polars as pl
+
+if TYPE_CHECKING:
+    pass
+
+
+# =============================================================================
+# BACKEND DETECTION
+# =============================================================================
+
+_BACKEND: str | None = None
+
+
+def _detect_backend() -> str:
+    """Detect available statistical backend at import time."""
+    global _BACKEND
+    if _BACKEND is not None:
+        return _BACKEND
+
+    # Try polars-normal-stats first (native Polars, fastest)
+    try:
+        import polars_normal_stats  # noqa: F401
+
+        _BACKEND = "polars-normal-stats"
+        return _BACKEND
+    except ImportError:
+        pass
+
+    # Fall back to scipy (universal)
+    try:
+        import scipy.stats  # noqa: F401
+
+        _BACKEND = "scipy"
+        return _BACKEND
+    except ImportError:
+        pass
+
+    msg = (
+        "No statistical backend available. "
+        "Install either 'polars-normal-stats' or 'scipy':\n"
+        "  uv add polars-normal-stats  # Recommended: native Polars\n"
+        "  uv add scipy                # Fallback: universal"
+    )
+    raise ImportError(msg)
+
+
+def get_backend() -> str:
+    """Return the name of the active statistical backend.
+
+    Returns:
+        "polars-normal-stats" or "scipy"
+
+    Raises:
+        ImportError: If no backend is available
+    """
+    return _detect_backend()
+
+
+# =============================================================================
+# SCIPY BACKEND IMPLEMENTATION
+# =============================================================================
+
+
+def _scipy_normal_cdf(expr: pl.Expr) -> pl.Expr:
+    """Apply normal CDF using scipy via map_batches."""
+    from scipy.stats import norm
+
+    def _cdf_batch(s: pl.Series) -> pl.Series:
+        values = s.to_numpy()
+        result = norm.cdf(values)
+        return pl.Series(name=s.name, values=result)
+
+    return expr.map_batches(_cdf_batch, return_dtype=pl.Float64)
+
+
+def _scipy_normal_ppf(expr: pl.Expr) -> pl.Expr:
+    """Apply normal PPF (inverse CDF) using scipy via map_batches."""
+    from scipy.stats import norm
+
+    def _ppf_batch(s: pl.Series) -> pl.Series:
+        values = s.to_numpy()
+        result = norm.ppf(values)
+        return pl.Series(name=s.name, values=result)
+
+    return expr.map_batches(_ppf_batch, return_dtype=pl.Float64)
+
+
+# =============================================================================
+# PUBLIC API
+# =============================================================================
+
+
+def normal_cdf(expr: pl.Expr) -> pl.Expr:
+    """Standard normal CDF (cumulative distribution function).
+
+    Computes P(X <= x) for standard normal distribution.
+
+    Args:
+        expr: Polars expression containing x values
+
+    Returns:
+        Polars expression with CDF values in [0, 1]
+
+    Example:
+        df.with_columns(normal_cdf(pl.col("z_score")).alias("probability"))
+    """
+    backend = _detect_backend()
+
+    if backend == "polars-normal-stats":
+        from polars_normal_stats import normal_cdf as native_cdf
+
+        return native_cdf(expr)
+    else:
+        return _scipy_normal_cdf(expr)
+
+
+def normal_ppf(expr: pl.Expr) -> pl.Expr:
+    """Standard normal PPF (percent point function / inverse CDF).
+
+    Computes the z-score such that P(X <= z) = p.
+
+    Args:
+        expr: Polars expression containing probability values in (0, 1)
+
+    Returns:
+        Polars expression with z-scores
+
+    Example:
+        df.with_columns(normal_ppf(pl.col("probability")).alias("z_score"))
+    """
+    backend = _detect_backend()
+
+    if backend == "polars-normal-stats":
+        from polars_normal_stats import normal_ppf as native_ppf
+
+        return native_ppf(expr)
+    else:
+        return _scipy_normal_ppf(expr)
+
+
+# =============================================================================
+# MODULE INITIALIZATION
+# =============================================================================
+
+# Detect backend at import time to fail fast
+_detect_backend()

--- a/uv.lock
+++ b/uv.lock
@@ -1190,10 +1190,10 @@ source = { editable = "." }
 dependencies = [
     { name = "duckdb" },
     { name = "polars" },
-    { name = "polars-normal-stats" },
     { name = "pyarrow" },
     { name = "pydantic" },
     { name = "pyyaml" },
+    { name = "scipy" },
 ]
 
 [package.optional-dependencies]
@@ -1205,6 +1205,7 @@ all = [
     { name = "mkdocstrings", extra = ["python"] },
     { name = "mypy" },
     { name = "numpy" },
+    { name = "polars-normal-stats" },
     { name = "pytest" },
     { name = "pytest-benchmark" },
     { name = "pytest-cov" },
@@ -1222,6 +1223,9 @@ dev = [
     { name = "pytest-benchmark" },
     { name = "pytest-cov" },
     { name = "ruff" },
+]
+fast-stats = [
+    { name = "polars-normal-stats" },
 ]
 ui = [
     { name = "marimo" },
@@ -1250,7 +1254,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8.0" },
     { name = "numpy", marker = "extra == 'dev'", specifier = ">=1.26.0" },
     { name = "polars", specifier = ">=1.0.0" },
-    { name = "polars-normal-stats", specifier = ">=0.1.0" },
+    { name = "polars-normal-stats", marker = "extra == 'fast-stats'", specifier = ">=0.1.0" },
     { name = "pyarrow", specifier = ">=14.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
@@ -1258,10 +1262,11 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.3.0" },
-    { name = "rwa-calc", extras = ["ui", "dev"], marker = "extra == 'all'" },
+    { name = "rwa-calc", extras = ["fast-stats", "ui", "dev"], marker = "extra == 'all'" },
+    { name = "scipy", specifier = ">=1.10.0" },
     { name = "uvicorn", marker = "extra == 'ui'", specifier = ">=0.27.0" },
 ]
-provides-extras = ["ui", "dev", "all"]
+provides-extras = ["fast-stats", "ui", "dev", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1272,6 +1277,57 @@ dev = [
     { name = "mypy", specifier = ">=1.19.1" },
     { name = "numpy", specifier = ">=1.26.0" },
     { name = "pytest-benchmark", specifier = ">=5.2.3" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/3e/9cca699f3486ce6bc12ff46dc2031f1ec8eb9ccc9a320fdaf925f1417426/scipy-1.17.0.tar.gz", hash = "sha256:2591060c8e648d8b96439e111ac41fd8342fdeff1876be2e19dea3fe8930454e", size = 30396830, upload-time = "2026-01-10T21:34:23.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/51/3468fdfd49387ddefee1636f5cf6d03ce603b75205bf439bbf0e62069bfd/scipy-1.17.0-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:65ec32f3d32dfc48c72df4291345dae4f048749bc8d5203ee0a3f347f96c5ce6", size = 31344101, upload-time = "2026-01-10T21:26:30.25Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/9a/9406aec58268d437636069419e6977af953d1e246df941d42d3720b7277b/scipy-1.17.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:1f9586a58039d7229ce77b52f8472c972448cded5736eaf102d5658bbac4c269", size = 27950385, upload-time = "2026-01-10T21:26:36.801Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/98/e7342709e17afdfd1b26b56ae499ef4939b45a23a00e471dfb5375eea205/scipy-1.17.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:9fad7d3578c877d606b1150135c2639e9de9cecd3705caa37b66862977cc3e72", size = 20122115, upload-time = "2026-01-10T21:26:42.107Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/0e/9eeeb5357a64fd157cbe0302c213517c541cc16b8486d82de251f3c68ede/scipy-1.17.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:423ca1f6584fc03936972b5f7c06961670dbba9f234e71676a7c7ccf938a0d61", size = 22442402, upload-time = "2026-01-10T21:26:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/10/be13397a0e434f98e0c79552b2b584ae5bb1c8b2be95db421533bbca5369/scipy-1.17.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fe508b5690e9eaaa9467fc047f833af58f1152ae51a0d0aed67aa5801f4dd7d6", size = 32696338, upload-time = "2026-01-10T21:26:55.521Z" },
+    { url = "https://files.pythonhosted.org/packages/63/1e/12fbf2a3bb240161651c94bb5cdd0eae5d4e8cc6eaeceb74ab07b12a753d/scipy-1.17.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6680f2dfd4f6182e7d6db161344537da644d1cf85cf293f015c60a17ecf08752", size = 34977201, upload-time = "2026-01-10T21:27:03.501Z" },
+    { url = "https://files.pythonhosted.org/packages/19/5b/1a63923e23ccd20bd32156d7dd708af5bbde410daa993aa2500c847ab2d2/scipy-1.17.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:eec3842ec9ac9de5917899b277428886042a93db0b227ebbe3a333b64ec7643d", size = 34777384, upload-time = "2026-01-10T21:27:11.423Z" },
+    { url = "https://files.pythonhosted.org/packages/39/22/b5da95d74edcf81e540e467202a988c50fef41bd2011f46e05f72ba07df6/scipy-1.17.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d7425fcafbc09a03731e1bc05581f5fad988e48c6a861f441b7ab729a49a55ea", size = 37379586, upload-time = "2026-01-10T21:27:20.171Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/b6/8ac583d6da79e7b9e520579f03007cb006f063642afd6b2eeb16b890bf93/scipy-1.17.0-cp313-cp313-win_amd64.whl", hash = "sha256:87b411e42b425b84777718cc41516b8a7e0795abfa8e8e1d573bf0ef014f0812", size = 36287211, upload-time = "2026-01-10T21:28:43.122Z" },
+    { url = "https://files.pythonhosted.org/packages/55/fb/7db19e0b3e52f882b420417644ec81dd57eeef1bd1705b6f689d8ff93541/scipy-1.17.0-cp313-cp313-win_arm64.whl", hash = "sha256:357ca001c6e37601066092e7c89cca2f1ce74e2a520ca78d063a6d2201101df2", size = 24312646, upload-time = "2026-01-10T21:28:49.893Z" },
+    { url = "https://files.pythonhosted.org/packages/20/b6/7feaa252c21cc7aff335c6c55e1b90ab3e3306da3f048109b8b639b94648/scipy-1.17.0-cp313-cp313t-macosx_10_14_x86_64.whl", hash = "sha256:ec0827aa4d36cb79ff1b81de898e948a51ac0b9b1c43e4a372c0508c38c0f9a3", size = 31693194, upload-time = "2026-01-10T21:27:27.454Z" },
+    { url = "https://files.pythonhosted.org/packages/76/bb/bbb392005abce039fb7e672cb78ac7d158700e826b0515cab6b5b60c26fb/scipy-1.17.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:819fc26862b4b3c73a60d486dbb919202f3d6d98c87cf20c223511429f2d1a97", size = 28365415, upload-time = "2026-01-10T21:27:34.26Z" },
+    { url = "https://files.pythonhosted.org/packages/37/da/9d33196ecc99fba16a409c691ed464a3a283ac454a34a13a3a57c0d66f3a/scipy-1.17.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:363ad4ae2853d88ebcde3ae6ec46ccca903ea9835ee8ba543f12f575e7b07e4e", size = 20537232, upload-time = "2026-01-10T21:27:40.306Z" },
+    { url = "https://files.pythonhosted.org/packages/56/9d/f4b184f6ddb28e9a5caea36a6f98e8ecd2a524f9127354087ce780885d83/scipy-1.17.0-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:979c3a0ff8e5ba254d45d59ebd38cde48fce4f10b5125c680c7a4bfe177aab07", size = 22791051, upload-time = "2026-01-10T21:27:46.539Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/9d/025cccdd738a72140efc582b1641d0dd4caf2e86c3fb127568dc80444e6e/scipy-1.17.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:130d12926ae34399d157de777472bf82e9061c60cc081372b3118edacafe1d00", size = 32815098, upload-time = "2026-01-10T21:27:54.389Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5f/09b879619f8bca15ce392bfc1894bd9c54377e01d1b3f2f3b595a1b4d945/scipy-1.17.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6e886000eb4919eae3a44f035e63f0fd8b651234117e8f6f29bad1cd26e7bc45", size = 35031342, upload-time = "2026-01-10T21:28:03.012Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/9a/f0f0a9f0aa079d2f106555b984ff0fbb11a837df280f04f71f056ea9c6e4/scipy-1.17.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:13c4096ac6bc31d706018f06a49abe0485f96499deb82066b94d19b02f664209", size = 34893199, upload-time = "2026-01-10T21:28:10.832Z" },
+    { url = "https://files.pythonhosted.org/packages/90/b8/4f0f5cf0c5ea4d7548424e6533e6b17d164f34a6e2fb2e43ffebb6697b06/scipy-1.17.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:cacbaddd91fcffde703934897c5cd2c7cb0371fac195d383f4e1f1c5d3f3bd04", size = 37438061, upload-time = "2026-01-10T21:28:19.684Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/cc/2bd59140ed3b2fa2882fb15da0a9cb1b5a6443d67cfd0d98d4cec83a57ec/scipy-1.17.0-cp313-cp313t-win_amd64.whl", hash = "sha256:edce1a1cf66298cccdc48a1bdf8fb10a3bf58e8b58d6c3883dd1530e103f87c0", size = 36328593, upload-time = "2026-01-10T21:28:28.007Z" },
+    { url = "https://files.pythonhosted.org/packages/13/1b/c87cc44a0d2c7aaf0f003aef2904c3d097b422a96c7e7c07f5efd9073c1b/scipy-1.17.0-cp313-cp313t-win_arm64.whl", hash = "sha256:30509da9dbec1c2ed8f168b8d8aa853bc6723fede1dbc23c7d43a56f5ab72a67", size = 24625083, upload-time = "2026-01-10T21:28:35.188Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/2d/51006cd369b8e7879e1c630999a19d1fbf6f8b5ed3e33374f29dc87e53b3/scipy-1.17.0-cp314-cp314-macosx_10_14_x86_64.whl", hash = "sha256:c17514d11b78be8f7e6331b983a65a7f5ca1fd037b95e27b280921fe5606286a", size = 31346803, upload-time = "2026-01-10T21:28:57.24Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2e/2349458c3ce445f53a6c93d4386b1c4c5c0c540917304c01222ff95ff317/scipy-1.17.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:4e00562e519c09da34c31685f6acc3aa384d4d50604db0f245c14e1b4488bfa2", size = 27967182, upload-time = "2026-01-10T21:29:04.107Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/7c/df525fbfa77b878d1cfe625249529514dc02f4fd5f45f0f6295676a76528/scipy-1.17.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:f7df7941d71314e60a481e02d5ebcb3f0185b8d799c70d03d8258f6c80f3d467", size = 20139125, upload-time = "2026-01-10T21:29:10.179Z" },
+    { url = "https://files.pythonhosted.org/packages/33/11/fcf9d43a7ed1234d31765ec643b0515a85a30b58eddccc5d5a4d12b5f194/scipy-1.17.0-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:aabf057c632798832f071a8dde013c2e26284043934f53b00489f1773b33527e", size = 22443554, upload-time = "2026-01-10T21:29:15.888Z" },
+    { url = "https://files.pythonhosted.org/packages/80/5c/ea5d239cda2dd3d31399424967a24d556cf409fbea7b5b21412b0fd0a44f/scipy-1.17.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a38c3337e00be6fd8a95b4ed66b5d988bac4ec888fd922c2ea9fe5fb1603dd67", size = 32757834, upload-time = "2026-01-10T21:29:23.406Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7e/8c917cc573310e5dc91cbeead76f1b600d3fb17cf0969db02c9cf92e3cfa/scipy-1.17.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00fb5f8ec8398ad90215008d8b6009c9db9fa924fd4c7d6be307c6f945f9cd73", size = 34995775, upload-time = "2026-01-10T21:29:31.915Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/43/176c0c3c07b3f7df324e7cdd933d3e2c4898ca202b090bd5ba122f9fe270/scipy-1.17.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f2a4942b0f5f7c23c7cd641a0ca1955e2ae83dedcff537e3a0259096635e186b", size = 34841240, upload-time = "2026-01-10T21:29:39.995Z" },
+    { url = "https://files.pythonhosted.org/packages/44/8c/d1f5f4b491160592e7f084d997de53a8e896a3ac01cd07e59f43ca222744/scipy-1.17.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:dbf133ced83889583156566d2bdf7a07ff89228fe0c0cb727f777de92092ec6b", size = 37394463, upload-time = "2026-01-10T21:29:48.723Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ec/42a6657f8d2d087e750e9a5dde0b481fd135657f09eaf1cf5688bb23c338/scipy-1.17.0-cp314-cp314-win_amd64.whl", hash = "sha256:3625c631a7acd7cfd929e4e31d2582cf00f42fcf06011f59281271746d77e061", size = 37053015, upload-time = "2026-01-10T21:30:51.418Z" },
+    { url = "https://files.pythonhosted.org/packages/27/58/6b89a6afd132787d89a362d443a7bddd511b8f41336a1ae47f9e4f000dc4/scipy-1.17.0-cp314-cp314-win_arm64.whl", hash = "sha256:9244608d27eafe02b20558523ba57f15c689357c85bdcfe920b1828750aa26eb", size = 24951312, upload-time = "2026-01-10T21:30:56.771Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/01/f58916b9d9ae0112b86d7c3b10b9e685625ce6e8248df139d0fcb17f7397/scipy-1.17.0-cp314-cp314t-macosx_10_14_x86_64.whl", hash = "sha256:2b531f57e09c946f56ad0b4a3b2abee778789097871fc541e267d2eca081cff1", size = 31706502, upload-time = "2026-01-10T21:29:56.326Z" },
+    { url = "https://files.pythonhosted.org/packages/59/8e/2912a87f94a7d1f8b38aabc0faf74b82d3b6c9e22be991c49979f0eceed8/scipy-1.17.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:13e861634a2c480bd237deb69333ac79ea1941b94568d4b0efa5db5e263d4fd1", size = 28380854, upload-time = "2026-01-10T21:30:01.554Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/1c/874137a52dddab7d5d595c1887089a2125d27d0601fce8c0026a24a92a0b/scipy-1.17.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:eb2651271135154aa24f6481cbae5cc8af1f0dd46e6533fb7b56aa9727b6a232", size = 20552752, upload-time = "2026-01-10T21:30:05.93Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/f0/7518d171cb735f6400f4576cf70f756d5b419a07fe1867da34e2c2c9c11b/scipy-1.17.0-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:c5e8647f60679790c2f5c76be17e2e9247dc6b98ad0d3b065861e082c56e078d", size = 22803972, upload-time = "2026-01-10T21:30:10.651Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/74/3498563a2c619e8a3ebb4d75457486c249b19b5b04a30600dfd9af06bea5/scipy-1.17.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5fb10d17e649e1446410895639f3385fd2bf4c3c7dfc9bea937bddcbc3d7b9ba", size = 32829770, upload-time = "2026-01-10T21:30:16.359Z" },
+    { url = "https://files.pythonhosted.org/packages/48/d1/7b50cedd8c6c9d6f706b4b36fa8544d829c712a75e370f763b318e9638c1/scipy-1.17.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8547e7c57f932e7354a2319fab613981cde910631979f74c9b542bb167a8b9db", size = 35051093, upload-time = "2026-01-10T21:30:22.987Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/82/a2d684dfddb87ba1b3ea325df7c3293496ee9accb3a19abe9429bce94755/scipy-1.17.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:33af70d040e8af9d5e7a38b5ed3b772adddd281e3062ff23fec49e49681c38cf", size = 34909905, upload-time = "2026-01-10T21:30:28.704Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/5e/e565bd73991d42023eb82bb99e51c5b3d9e2c588ca9d4b3e2cc1d3ca62a6/scipy-1.17.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f9eb55bb97d00f8b7ab95cb64f873eb0bf54d9446264d9f3609130381233483f", size = 37457743, upload-time = "2026-01-10T21:30:34.819Z" },
+    { url = "https://files.pythonhosted.org/packages/58/a8/a66a75c3d8f1fb2b83f66007d6455a06a6f6cf5618c3dc35bc9b69dd096e/scipy-1.17.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1ff269abf702f6c7e67a4b7aad981d42871a11b9dd83c58d2d2ea624efbd1088", size = 37098574, upload-time = "2026-01-10T21:30:40.782Z" },
+    { url = "https://files.pythonhosted.org/packages/56/a5/df8f46ef7da168f1bc52cd86e09a9de5c6f19cc1da04454d51b7d4f43408/scipy-1.17.0-cp314-cp314t-win_arm64.whl", hash = "sha256:031121914e295d9791319a1875444d55079885bbae5bdc9c5e0f2ee5f09d34ff", size = 25246266, upload-time = "2026-01-10T21:30:45.923Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request introduces a statistical backend abstraction for IRB (Internal Ratings-Based) formulas, enabling automatic selection between a native Polars backend (`polars-normal-stats`) and a universal fallback (`scipy`). It refactors IRB formula scalar functions to delegate to vectorized Polars expressions, ensuring consistency and maintainability. The dependency management is updated to make `scipy` a default requirement and `polars-normal-stats` an optional, performance-optimized dependency. Comprehensive tests are added to verify backend detection and the correctness of the new scalar wrappers.

**Statistical backend abstraction and integration:**

* Added a new module `stats_backend.py` that provides `normal_cdf` and `normal_ppf` as Polars expressions, with automatic backend detection and fallback to `scipy` if `polars-normal-stats` is not available. Also exposes `get_backend()` for diagnostics.
* Updated imports and public API in `__init__.py` to expose `get_backend` and ensure all IRB formula functions use the new backend abstraction. [[1]](diffhunk://#diff-bb646a6d816f085b03a0e636a249078edc4bae8c086f84bb7f60eb1e6a1f27b1R35-R43) [[2]](diffhunk://#diff-bb646a6d816f085b03a0e636a249078edc4bae8c086f84bb7f60eb1e6a1f27b1R57-R58)

**IRB formula refactoring:**

* Refactored scalar IRB formula functions (e.g., `calculate_k`, `calculate_correlation`, `calculate_maturity_adjustment`) to become thin wrappers around their vectorized Polars expressions, ensuring identical logic for both scalar and batch calculations. Removed custom implementations and rational approximations for normal CDF/PPF in favor of backend-provided functions. [[1]](diffhunk://#diff-92acd6b8b81c0e78bcda7f4438ee89c4afcd4024ee3fb1922069a70a7db00721L12-R19) [[2]](diffhunk://#diff-92acd6b8b81c0e78bcda7f4438ee89c4afcd4024ee3fb1922069a70a7db00721L31-R36) [[3]](diffhunk://#diff-92acd6b8b81c0e78bcda7f4438ee89c4afcd4024ee3fb1922069a70a7db00721L44-L67) [[4]](diffhunk://#diff-92acd6b8b81c0e78bcda7f4438ee89c4afcd4024ee3fb1922069a70a7db00721L360-R408) [[5]](diffhunk://#diff-92acd6b8b81c0e78bcda7f4438ee89c4afcd4024ee3fb1922069a70a7db00721R421-R423) [[6]](diffhunk://#diff-92acd6b8b81c0e78bcda7f4438ee89c4afcd4024ee3fb1922069a70a7db00721L412-R473) [[7]](diffhunk://#diff-92acd6b8b81c0e78bcda7f4438ee89c4afcd4024ee3fb1922069a70a7db00721L463-R506) [[8]](diffhunk://#diff-92acd6b8b81c0e78bcda7f4438ee89c4afcd4024ee3fb1922069a70a7db00721L482-R538) [[9]](diffhunk://#diff-92acd6b8b81c0e78bcda7f4438ee89c4afcd4024ee3fb1922069a70a7db00721L513-R572)

**Dependency management improvements:**

* Made `scipy` a default dependency as a universal stats backend, and moved `polars-normal-stats` to an optional `fast-stats` extra for users who want native Polars performance. Updated the `all` extra to include `fast-stats`. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L33-R33) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R47-R49) [[3]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L64-R67)

**Testing and validation:**

* Added a new test class to verify backend detection, ensure scalar wrappers match vectorized calculations, and validate formula consistency across backends.
* Updated imports in tests to include new and refactored functions.