### PR TITLE
refactor(loans): update loan schema and documentation

### DIFF
--- a/src/rwa_calc/data/schemas.py
+++ b/src/rwa_calc/data/schemas.py
@@ -65,7 +65,7 @@ FACILITY_SCHEMA = {
     "is_revolving": pl.Boolean,
     "seniority": pl.String,  # senior, subordinated - affects F-IRB LGD (45% vs 75%)
     "risk_type": pl.String,  # Mandatory: FR, MR, MLR, LR - determines CCF (CRR Art. 111)
-    "ccf_modelled": pl.Float64,  # Optional: A-IRB modelled CCF (0.0-1.0)
+    "ccf_modelled": pl.Float64,  # Optional: A-IRB modelled CCF (0.0-1.5, can exceed 100% for retail)
     "is_short_term_trade_lc": pl.Boolean,  # Short-term LC for goods movement - 20% CCF under F-IRB (Art. 166(9))
 }
 
@@ -78,12 +78,12 @@ LOAN_SCHEMA = {
     "maturity_date": pl.Date,
     "currency": pl.String,
     "drawn_amount": pl.Float64,
-    "lgd": pl.Float64,
-    "beel": pl.Float64,
+    "lgd": pl.Float64,  # A-IRB modelled LGD (optional)
+    "beel": pl.Float64,  # Best estimate expected loss
     "seniority": pl.String,  # senior, subordinated - affects F-IRB LGD (45% vs 75%)
-    "risk_type": pl.String,  # Mandatory: FR, MR, MLR, LR - determines CCF (CRR Art. 111)
-    "ccf_modelled": pl.Float64,  # Optional: A-IRB modelled CCF (0.0-1.0)
-    "is_short_term_trade_lc": pl.Boolean,  # N/A for loans (null), included for unified schema
+    # Note: CCF fields (risk_type, ccf_modelled, is_short_term_trade_lc) are NOT included
+    # because CCF only applies to off-balance sheet items (undrawn commitments, contingents).
+    # Drawn loans are already on-balance sheet, so EAD = drawn_amount directly.
 }
 
 CONTINGENTS_SCHEMA = {
@@ -99,7 +99,7 @@ CONTINGENTS_SCHEMA = {
     "beel": pl.Float64,
     "seniority": pl.String,  # senior, subordinated - affects F-IRB LGD (45% vs 75%)
     "risk_type": pl.String,  # Mandatory: FR, MR, MLR, LR - determines CCF (CRR Art. 111)
-    "ccf_modelled": pl.Float64,  # Optional: A-IRB modelled CCF (0.0-1.0)
+    "ccf_modelled": pl.Float64,  # Optional: A-IRB modelled CCF (0.0-1.5, can exceed 100% for retail)
     "is_short_term_trade_lc": pl.Boolean,  # Short-term LC for goods movement - 20% CCF under F-IRB (Art. 166(9))
 }
 
@@ -369,7 +369,7 @@ RAW_EXPOSURE_SCHEMA = {
     "beel": pl.Float64,  # Best estimate expected loss
     "seniority": pl.String,  # senior, subordinated
     "risk_type": pl.String,  # FR, MR, MLR, LR - determines CCF (CRR Art. 111)
-    "ccf_modelled": pl.Float64,  # A-IRB modelled CCF (0.0-1.0)
+    "ccf_modelled": pl.Float64,  # A-IRB modelled CCF (0.0-1.5, can exceed 100% for retail)
     "is_short_term_trade_lc": pl.Boolean,  # Short-term LC for goods movement - 20% CCF under F-IRB (Art. 166(9))
     # FX conversion audit trail (populated after FX conversion)
     "original_currency": pl.String,       # Currency before FX conversion
@@ -394,7 +394,7 @@ RESOLVED_HIERARCHY_SCHEMA = {
     "lgd": pl.Float64,
     "seniority": pl.String,
     "risk_type": pl.String,  # FR, MR, MLR, LR - determines CCF (CRR Art. 111)
-    "ccf_modelled": pl.Float64,  # A-IRB modelled CCF (0.0-1.0)
+    "ccf_modelled": pl.Float64,  # A-IRB modelled CCF (0.0-1.5, can exceed 100% for retail)
     "is_short_term_trade_lc": pl.Boolean,  # Short-term LC for goods movement - 20% CCF under F-IRB (Art. 166(9))
     # Counterparty hierarchy additions
     "counterparty_has_parent": pl.Boolean,
@@ -430,7 +430,7 @@ CLASSIFIED_EXPOSURE_SCHEMA = {
     "undrawn_amount": pl.Float64,
     "seniority": pl.String,
     "risk_type": pl.String,  # FR, MR, MLR, LR - determines CCF (CRR Art. 111)
-    "ccf_modelled": pl.Float64,  # A-IRB modelled CCF (0.0-1.0)
+    "ccf_modelled": pl.Float64,  # A-IRB modelled CCF (0.0-1.5, can exceed 100% for retail)
     "is_short_term_trade_lc": pl.Boolean,  # Short-term LC for goods movement - 20% CCF under F-IRB (Art. 166(9))
     # Classification additions
     "exposure_class": pl.String,  # sovereign, institution, corporate, retail, etc.

--- a/src/rwa_calc/engine/hierarchy.py
+++ b/src/rwa_calc/engine/hierarchy.py
@@ -468,6 +468,8 @@ class HierarchyResolver:
         errors: list[HierarchyError] = []
 
         # Standardize loan columns
+        # Note: Loans are drawn exposures - CCF fields are N/A since EAD = drawn_amount directly.
+        # CCF only applies to off-balance sheet items (undrawn commitments, contingents).
         loans_unified = loans.select([
             pl.col("loan_reference").alias("exposure_reference"),
             pl.lit("loan").alias("exposure_type"),
@@ -482,9 +484,9 @@ class HierarchyResolver:
             pl.lit(0.0).alias("nominal_amount"),
             pl.col("lgd"),
             pl.col("seniority"),
-            pl.col("risk_type"),
-            pl.col("ccf_modelled"),
-            pl.lit(None).cast(pl.Boolean).alias("is_short_term_trade_lc"),  # N/A for loans
+            pl.lit(None).cast(pl.String).alias("risk_type"),  # N/A for drawn loans
+            pl.lit(None).cast(pl.Float64).alias("ccf_modelled"),  # N/A for drawn loans
+            pl.lit(None).cast(pl.Boolean).alias("is_short_term_trade_lc"),  # N/A for drawn loans
         ])
 
         # If contingents is None, use only loans

--- a/tests/fixtures/exposures/loans.py
+++ b/tests/fixtures/exposures/loans.py
@@ -35,7 +35,13 @@ def main() -> None:
 
 @dataclass(frozen=True)
 class Loan:
-    """A drawn loan exposure."""
+    """
+    A drawn loan exposure.
+
+    Note: CCF fields (risk_type, ccf_modelled, is_short_term_trade_lc) are NOT included
+    because CCF only applies to off-balance sheet items (undrawn commitments, contingents).
+    Drawn loans are already on-balance sheet, so EAD = drawn_amount directly.
+    """
 
     loan_reference: str
     product_type: str
@@ -45,12 +51,9 @@ class Loan:
     maturity_date: date
     currency: str
     drawn_amount: float
-    lgd: float
-    beel: float
-    seniority: str
-    risk_type: str = "FR"  # FR for drawn loans (full_risk = 100% CCF, already drawn)
-    ccf_modelled: float | None = None  # Optional: A-IRB modelled CCF (0.0-1.5, Retail can exceed 100%)
-    is_short_term_trade_lc: bool | None = None  # N/A for loans, included for unified schema
+    lgd: float  # A-IRB modelled LGD (optional)
+    beel: float  # Best estimate expected loss
+    seniority: str  # senior, subordinated - affects F-IRB LGD (45% vs 75%)
 
     def to_dict(self) -> dict:
         return {
@@ -65,9 +68,6 @@ class Loan:
             "lgd": self.lgd,
             "beel": self.beel,
             "seniority": self.seniority,
-            "risk_type": self.risk_type,
-            "ccf_modelled": self.ccf_modelled,
-            "is_short_term_trade_lc": self.is_short_term_trade_lc,
         }
 
 


### PR DESCRIPTION
This pull request clarifies and enforces the distinction between drawn loans and off-balance sheet items regarding Credit Conversion Factor (CCF) fields in the RWA calculation codebase. It updates data schemas, test fixtures, and data unification logic to ensure that CCF-related fields are only present where applicable (i.e., not for drawn loans), and provides clearer documentation and comments throughout.

**Schema and field corrections:**

* Updated all relevant schemas in `src/rwa_calc/data/schemas.py` to document that `ccf_modelled` can exceed 100% (up to 1.5) for retail exposures, and clarified that CCF fields are not included for drawn loans because CCF only applies to off-balance sheet items. [[1]](diffhunk://#diff-04eeea3da0125ae22d7104c692e0f1d41a86209f6fdfcadd5f061376c8092084L68-R68) [[2]](diffhunk://#diff-04eeea3da0125ae22d7104c692e0f1d41a86209f6fdfcadd5f061376c8092084L81-R86) [[3]](diffhunk://#diff-04eeea3da0125ae22d7104c692e0f1d41a86209f6fdfcadd5f061376c8092084L102-R102) [[4]](diffhunk://#diff-04eeea3da0125ae22d7104c692e0f1d41a86209f6fdfcadd5f061376c8092084L372-R372) [[5]](diffhunk://#diff-04eeea3da0125ae22d7104c692e0f1d41a86209f6fdfcadd5f061376c8092084L397-R397) [[6]](diffhunk://#diff-04eeea3da0125ae22d7104c692e0f1d41a86209f6fdfcadd5f061376c8092084L433-R433)

**Data unification logic:**

* Modified `_unify_exposures` in `src/rwa_calc/engine/hierarchy.py` to set CCF-related fields (`risk_type`, `ccf_modelled`, `is_short_term_trade_lc`) to `None` for drawn loans, with comments explaining that these fields are not applicable. [[1]](diffhunk://#diff-054f578a992202e82fb2283dbe871200953301a7eb67f21ff1ca5f24e42a7f7bR471-R472) [[2]](diffhunk://#diff-054f578a992202e82fb2283dbe871200953301a7eb67f21ff1ca5f24e42a7f7bL485-R489)

**Test fixtures and documentation:**

* Updated the `Loan` fixture and its docstring in `tests/fixtures/exposures/loans.py` to clarify that CCF fields are omitted for drawn loans, and removed these fields from the class and its `to_dict` method. [[1]](diffhunk://#diff-0d3f98d8548979bda068fd30aab812d6d380fc93e0265a44386bae946090ba36L38-R44) [[2]](diffhunk://#diff-0d3f98d8548979bda068fd30aab812d6d380fc93e0265a44386bae946090ba36L48-R56) [[3]](diffhunk://#diff-0d3f98d8548979bda068fd30aab812d6d380fc93e0265a44386bae946090ba36L68-L70)