### PR TITLE
feat(protocols): update aggregation method with new bundles

### DIFF
--- a/src/rwa_calc/contracts/protocols.py
+++ b/src/rwa_calc/contracts/protocols.py
@@ -26,8 +26,11 @@ if TYPE_CHECKING:
         AggregatedResultBundle,
         ClassifiedExposuresBundle,
         CRMAdjustedBundle,
+        IRBResultBundle,
         RawDataBundle,
         ResolvedHierarchyBundle,
+        SAResultBundle,
+        SlottingResultBundle,
     )
     from rwa_calc.contracts.config import CalculationConfig
     from rwa_calc.contracts.errors import LazyFrameResult
@@ -331,16 +334,18 @@ class OutputAggregatorProtocol(Protocol):
 
     def aggregate_with_audit(
         self,
-        sa_results: pl.LazyFrame,
-        irb_results: pl.LazyFrame,
+        sa_bundle: SAResultBundle | None,
+        irb_bundle: IRBResultBundle | None,
+        slotting_bundle: SlottingResultBundle | None,
         config: CalculationConfig,
     ) -> AggregatedResultBundle:
         """
         Aggregate with full audit trail.
 
         Args:
-            sa_results: Standardised Approach calculations
-            irb_results: IRB approach calculations
+            sa_bundle: SA calculation results bundle
+            irb_bundle: IRB calculation results bundle
+            slotting_bundle: Slotting calculation results bundle
             config: Calculation configuration
 
         Returns:


### PR DESCRIPTION
This pull request updates the contract protocols to improve type safety and clarity when aggregating calculation results. The most important changes are:

**Type and API Improvements:**

* Changed the `aggregate_with_audit` method to accept strongly-typed result bundles (`SAResultBundle`, `IRBResultBundle`, `SlottingResultBundle`) instead of generic `pl.LazyFrame` objects, making the interface clearer and less error-prone.
* Updated the imports to include the new result bundle types: `IRBResultBundle`, `SAResultBundle`, and `SlottingResultBundle`.