### PR TITLE
feat(ccf): include interest in EAD calculations

### DIFF
--- a/src/rwa_calc/data/schemas.py
+++ b/src/rwa_calc/data/schemas.py
@@ -78,12 +78,13 @@ LOAN_SCHEMA = {
     "maturity_date": pl.Date,
     "currency": pl.String,
     "drawn_amount": pl.Float64,
+    "interest": pl.Float64,  # Accrued interest (adds to on-balance-sheet EAD, not undrawn)
     "lgd": pl.Float64,  # A-IRB modelled LGD (optional)
     "beel": pl.Float64,  # Best estimate expected loss
     "seniority": pl.String,  # senior, subordinated - affects F-IRB LGD (45% vs 75%)
     # Note: CCF fields (risk_type, ccf_modelled, is_short_term_trade_lc) are NOT included
     # because CCF only applies to off-balance sheet items (undrawn commitments, contingents).
-    # Drawn loans are already on-balance sheet, so EAD = drawn_amount directly.
+    # Drawn loans are already on-balance sheet, so EAD = drawn_amount + interest directly.
 }
 
 CONTINGENTS_SCHEMA = {
@@ -363,6 +364,7 @@ RAW_EXPOSURE_SCHEMA = {
     "maturity_date": pl.Date,
     "currency": pl.String,
     "drawn_amount": pl.Float64,  # Drawn balance (0 for facilities without loans)
+    "interest": pl.Float64,  # Accrued interest (adds to on-balance-sheet EAD, not undrawn)
     "undrawn_amount": pl.Float64,  # Undrawn commitment (limit - drawn for facilities)
     "nominal_amount": pl.Float64,  # Total nominal (for contingents)
     "lgd": pl.Float64,  # Internal LGD estimate (if available)
@@ -373,7 +375,7 @@ RAW_EXPOSURE_SCHEMA = {
     "is_short_term_trade_lc": pl.Boolean,  # Short-term LC for goods movement - 20% CCF under F-IRB (Art. 166(9))
     # FX conversion audit trail (populated after FX conversion)
     "original_currency": pl.String,       # Currency before FX conversion
-    "original_amount": pl.Float64,        # Amount before FX conversion (drawn + nominal)
+    "original_amount": pl.Float64,        # Amount before FX conversion (drawn + interest + nominal)
     "fx_rate_applied": pl.Float64,        # Rate used (null if no conversion needed)
 }
 
@@ -389,6 +391,7 @@ RESOLVED_HIERARCHY_SCHEMA = {
     "maturity_date": pl.Date,
     "currency": pl.String,
     "drawn_amount": pl.Float64,
+    "interest": pl.Float64,  # Accrued interest (adds to on-balance-sheet EAD, not undrawn)
     "undrawn_amount": pl.Float64,
     "nominal_amount": pl.Float64,
     "lgd": pl.Float64,
@@ -427,6 +430,7 @@ CLASSIFIED_EXPOSURE_SCHEMA = {
     "counterparty_reference": pl.String,
     "currency": pl.String,
     "drawn_amount": pl.Float64,
+    "interest": pl.Float64,  # Accrued interest (adds to on-balance-sheet EAD, not undrawn)
     "undrawn_amount": pl.Float64,
     "seniority": pl.String,
     "risk_type": pl.String,  # FR, MR, MLR, LR - determines CCF (CRR Art. 111)
@@ -462,6 +466,7 @@ CRM_ADJUSTED_SCHEMA = {
     "seniority": pl.String,
     # EAD calculation
     "drawn_amount": pl.Float64,
+    "interest": pl.Float64,  # Accrued interest (adds to on-balance-sheet EAD, not undrawn)
     "undrawn_amount": pl.Float64,
     "ccf_applied": pl.Float64,  # Credit conversion factor
     "converted_undrawn": pl.Float64,  # undrawn × CCF

--- a/tests/fixtures/exposures/loans.py
+++ b/tests/fixtures/exposures/loans.py
@@ -44,7 +44,7 @@ class Loan:
 
     Note: CCF fields (risk_type, ccf_modelled, is_short_term_trade_lc) are NOT included
     because CCF only applies to off-balance sheet items (undrawn commitments, contingents).
-    Drawn loans are already on-balance sheet, so EAD = drawn_amount directly.
+    Drawn loans are already on-balance sheet, so EAD = drawn_amount + interest directly.
     """
 
     loan_reference: str
@@ -55,6 +55,7 @@ class Loan:
     maturity_date: date
     currency: str
     drawn_amount: float
+    interest: float  # Accrued interest (adds to on-balance-sheet EAD, not undrawn)
     lgd: float  # A-IRB modelled LGD (optional)
     beel: float  # Best estimate expected loss
     seniority: str  # senior, subordinated - affects F-IRB LGD (45% vs 75%)
@@ -69,6 +70,7 @@ class Loan:
             "maturity_date": self.maturity_date,
             "currency": self.currency,
             "drawn_amount": self.drawn_amount,
+            "interest": self.interest,
             "lgd": self.lgd,
             "beel": self.beel,
             "seniority": self.seniority,
@@ -122,6 +124,7 @@ def _sovereign_loans() -> list[Loan]:
             maturity_date=date(2031, 1, 1),
             currency="GBP",
             drawn_amount=1_000_000.0,
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -136,6 +139,7 @@ def _sovereign_loans() -> list[Loan]:
             maturity_date=date(2030, 6, 30),
             currency="USD",
             drawn_amount=5_000_000.0,
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -150,6 +154,7 @@ def _sovereign_loans() -> list[Loan]:
             maturity_date=date(2028, 12, 31),
             currency="USD",
             drawn_amount=2_000_000.0,
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -174,6 +179,7 @@ def _institution_loans() -> list[Loan]:
             maturity_date=date(2028, 1, 1),
             currency="GBP",
             drawn_amount=50_000_000.0,
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -188,6 +194,7 @@ def _institution_loans() -> list[Loan]:
             maturity_date=date(2027, 6, 30),
             currency="GBP",
             drawn_amount=1_000_000.0,
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -202,6 +209,7 @@ def _institution_loans() -> list[Loan]:
             maturity_date=date(2027, 12, 31),
             currency="GBP",
             drawn_amount=10_000_000.0,
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -227,6 +235,7 @@ def _corporate_standalone_loans() -> list[Loan]:
             maturity_date=date(2029, 12, 31),
             currency="GBP",
             drawn_amount=1_000_000.0,
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -241,6 +250,7 @@ def _corporate_standalone_loans() -> list[Loan]:
             maturity_date=date(2028, 6, 30),
             currency="GBP",
             drawn_amount=1_000_000.0,
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -255,6 +265,7 @@ def _corporate_standalone_loans() -> list[Loan]:
             maturity_date=date(2030, 3, 31),
             currency="GBP",
             drawn_amount=25_000_000.0,
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -269,6 +280,7 @@ def _corporate_standalone_loans() -> list[Loan]:
             maturity_date=date(2030, 3, 31),
             currency="GBP",
             drawn_amount=5_000_000.0,
+            interest=0.0,
             lgd=0.75,
             beel=0.0,
             seniority="subordinated",
@@ -283,6 +295,7 @@ def _corporate_standalone_loans() -> list[Loan]:
             maturity_date=date(2028, 12, 31),
             currency="GBP",
             drawn_amount=2_000_000.0,
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -307,6 +320,7 @@ def _corporate_facility_loans() -> list[Loan]:
             maturity_date=date(2031, 1, 1),
             currency="GBP",
             drawn_amount=20_000_000.0,
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -321,6 +335,7 @@ def _corporate_facility_loans() -> list[Loan]:
             maturity_date=date(2029, 6, 30),
             currency="GBP",
             drawn_amount=30_000_000.0,
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -335,6 +350,7 @@ def _corporate_facility_loans() -> list[Loan]:
             maturity_date=date(2028, 12, 31),
             currency="GBP",
             drawn_amount=3_000_000.0,
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -370,6 +386,7 @@ def _firb_scenario_loans() -> list[Loan]:
             maturity_date=date(2029, 1, 1),  # 3 year maturity
             currency="GBP",
             drawn_amount=5_000_000.0,
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -388,6 +405,7 @@ def _firb_scenario_loans() -> list[Loan]:
             maturity_date=date(2030, 1, 1),  # 4 year maturity
             currency="GBP",
             drawn_amount=2_000_000.0,
+            interest=0.0,
             lgd=0.75,  # Subordinated LGD per CRR Art. 161
             beel=0.0,
             seniority="subordinated",
@@ -406,6 +424,7 @@ def _firb_scenario_loans() -> list[Loan]:
             maturity_date=date(2028, 6, 30),  # 2.5 year maturity
             currency="GBP",
             drawn_amount=5_000_000.0,
+            interest=0.0,
             lgd=0.225,  # Blended: 50% × 0% + 50% × 45%
             beel=0.0,
             seniority="senior",
@@ -424,6 +443,7 @@ def _firb_scenario_loans() -> list[Loan]:
             maturity_date=date(2028, 1, 1),  # 2 year maturity
             currency="GBP",
             drawn_amount=1_000_000.0,
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -442,6 +462,7 @@ def _firb_scenario_loans() -> list[Loan]:
             maturity_date=date(2033, 1, 1),  # 7 year maturity (capped at 5)
             currency="GBP",
             drawn_amount=8_000_000.0,
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -469,6 +490,7 @@ def _retail_loans() -> list[Loan]:
             maturity_date=date(2029, 1, 1),
             currency="GBP",
             drawn_amount=50_000.0,
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -483,6 +505,7 @@ def _retail_loans() -> list[Loan]:
             maturity_date=date(2051, 1, 1),
             currency="GBP",
             drawn_amount=500_000.0,  # Property value £833,333, LTV 60%
+            interest=0.0,
             lgd=0.10,
             beel=0.0,
             seniority="senior",
@@ -497,6 +520,7 @@ def _retail_loans() -> list[Loan]:
             maturity_date=date(2051, 1, 1),
             currency="GBP",
             drawn_amount=850_000.0,  # Property value £1,000,000, LTV 85%
+            interest=0.0,
             lgd=0.10,
             beel=0.0,
             seniority="senior",
@@ -511,6 +535,7 @@ def _retail_loans() -> list[Loan]:
             maturity_date=date(2028, 12, 31),
             currency="GBP",
             drawn_amount=500_000.0,
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -525,6 +550,7 @@ def _retail_loans() -> list[Loan]:
             maturity_date=date(2027, 1, 1),
             currency="GBP",
             drawn_amount=5_000.0,
+            interest=0.0,
             lgd=0.85,
             beel=0.0,
             seniority="senior",
@@ -553,6 +579,7 @@ def _hierarchy_test_loans() -> list[Loan]:
             maturity_date=date(2029, 12, 31),
             currency="GBP",
             drawn_amount=1_500_000.0,
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -566,6 +593,7 @@ def _hierarchy_test_loans() -> list[Loan]:
             maturity_date=date(2029, 12, 31),
             currency="GBP",
             drawn_amount=2_000_000.0,
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -579,6 +607,7 @@ def _hierarchy_test_loans() -> list[Loan]:
             maturity_date=date(2029, 12, 31),
             currency="GBP",
             drawn_amount=1_000_000.0,
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -596,6 +625,7 @@ def _hierarchy_test_loans() -> list[Loan]:
             maturity_date=date(2030, 6, 30),
             currency="GBP",
             drawn_amount=5_000_000.0,
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -609,6 +639,7 @@ def _hierarchy_test_loans() -> list[Loan]:
             maturity_date=date(2030, 6, 30),
             currency="GBP",
             drawn_amount=3_000_000.0,
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -626,6 +657,7 @@ def _hierarchy_test_loans() -> list[Loan]:
             maturity_date=date(2028, 6, 30),
             currency="GBP",
             drawn_amount=80_000.0,
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -639,6 +671,7 @@ def _hierarchy_test_loans() -> list[Loan]:
             maturity_date=date(2028, 6, 30),
             currency="GBP",
             drawn_amount=350_000.0,
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -676,6 +709,7 @@ def _airb_scenario_loans() -> list[Loan]:
             maturity_date=date(2028, 6, 30),  # 2.5 year maturity
             currency="GBP",
             drawn_amount=5_000_000.0,
+            interest=0.0,
             lgd=0.35,  # Bank's own LGD estimate (below F-IRB 45%)
             beel=0.0,
             seniority="senior",
@@ -695,6 +729,7 @@ def _airb_scenario_loans() -> list[Loan]:
             maturity_date=date(2029, 1, 1),  # No maturity adjustment for retail
             currency="GBP",
             drawn_amount=100_000.0,
+            interest=0.0,
             lgd=0.15,  # Bank's own LGD estimate (low loss history)
             beel=0.0,
             seniority="senior",
@@ -713,6 +748,7 @@ def _airb_scenario_loans() -> list[Loan]:
             maturity_date=date(2030, 1, 1),  # 4 year maturity
             currency="GBP",
             drawn_amount=10_000_000.0,
+            interest=0.0,
             lgd=0.25,  # Bank's own LGD estimate (strong collateral)
             beel=0.0,
             seniority="senior",
@@ -736,6 +772,7 @@ def _defaulted_loans() -> list[Loan]:
             maturity_date=date(2027, 12, 31),
             currency="GBP",
             drawn_amount=500_000.0,
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -749,6 +786,7 @@ def _defaulted_loans() -> list[Loan]:
             maturity_date=date(2027, 6, 30),
             currency="GBP",
             drawn_amount=25_000.0,
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -780,6 +818,7 @@ def _crm_scenario_loans() -> list[Loan]:
             maturity_date=date(2029, 1, 1),  # 3yr maturity
             currency="GBP",
             drawn_amount=1_000_000.0,
+            interest=0.0,
             lgd=0.45,  # Not used for SA
             beel=0.0,
             seniority="senior",
@@ -794,6 +833,7 @@ def _crm_scenario_loans() -> list[Loan]:
             maturity_date=date(2029, 1, 1),  # 3yr maturity
             currency="GBP",
             drawn_amount=1_000_000.0,
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -808,6 +848,7 @@ def _crm_scenario_loans() -> list[Loan]:
             maturity_date=date(2029, 1, 1),  # 3yr maturity
             currency="GBP",
             drawn_amount=1_000_000.0,
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -822,6 +863,7 @@ def _crm_scenario_loans() -> list[Loan]:
             maturity_date=date(2029, 1, 1),  # 3yr maturity
             currency="GBP",
             drawn_amount=1_000_000.0,
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -836,6 +878,7 @@ def _crm_scenario_loans() -> list[Loan]:
             maturity_date=date(2031, 1, 1),  # 5yr maturity for mismatch test
             currency="GBP",
             drawn_amount=1_000_000.0,
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -850,6 +893,7 @@ def _crm_scenario_loans() -> list[Loan]:
             maturity_date=date(2029, 1, 1),  # 3yr maturity
             currency="GBP",
             drawn_amount=1_000_000.0,
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -894,6 +938,7 @@ def _slotting_scenario_loans() -> list[Loan]:
             maturity_date=date(2031, 1, 1),  # 5yr maturity
             currency="GBP",
             drawn_amount=10_000_000.0,
+            interest=0.0,
             lgd=0.45,  # Not used for slotting
             beel=0.0,
             seniority="senior",
@@ -911,6 +956,7 @@ def _slotting_scenario_loans() -> list[Loan]:
             maturity_date=date(2031, 1, 1),  # 5yr maturity
             currency="GBP",
             drawn_amount=10_000_000.0,
+            interest=0.0,
             lgd=0.45,  # Not used for slotting
             beel=0.0,
             seniority="senior",
@@ -928,6 +974,7 @@ def _slotting_scenario_loans() -> list[Loan]:
             maturity_date=date(2031, 1, 1),  # 5yr maturity
             currency="GBP",
             drawn_amount=5_000_000.0,
+            interest=0.0,
             lgd=0.45,  # Not used for slotting
             beel=0.0,
             seniority="senior",
@@ -946,6 +993,7 @@ def _slotting_scenario_loans() -> list[Loan]:
             maturity_date=date(2031, 1, 1),  # 5yr maturity
             currency="GBP",
             drawn_amount=5_000_000.0,
+            interest=0.0,
             lgd=0.45,  # Not used for slotting
             beel=0.0,
             seniority="senior",
@@ -990,6 +1038,7 @@ def _supporting_factor_scenario_loans() -> list[Loan]:
             maturity_date=date(2031, 1, 1),
             currency="GBP",
             drawn_amount=2_000_000.0,  # £2m
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -1007,6 +1056,7 @@ def _supporting_factor_scenario_loans() -> list[Loan]:
             maturity_date=date(2030, 6, 30),
             currency="GBP",
             drawn_amount=4_000_000.0,  # £4m
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -1024,6 +1074,7 @@ def _supporting_factor_scenario_loans() -> list[Loan]:
             maturity_date=date(2029, 12, 31),
             currency="GBP",
             drawn_amount=10_000_000.0,  # £10m
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -1042,6 +1093,7 @@ def _supporting_factor_scenario_loans() -> list[Loan]:
             maturity_date=date(2028, 1, 1),
             currency="GBP",
             drawn_amount=500_000.0,  # £500k
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -1059,6 +1111,7 @@ def _supporting_factor_scenario_loans() -> list[Loan]:
             maturity_date=date(2040, 1, 1),  # Long-term infrastructure
             currency="GBP",
             drawn_amount=50_000_000.0,  # £50m
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -1076,6 +1129,7 @@ def _supporting_factor_scenario_loans() -> list[Loan]:
             maturity_date=date(2030, 1, 1),
             currency="GBP",
             drawn_amount=20_000_000.0,  # £20m
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -1093,6 +1147,7 @@ def _supporting_factor_scenario_loans() -> list[Loan]:
             maturity_date=date(2029, 6, 30),
             currency="GBP",
             drawn_amount=SME_EXPOSURE_THRESHOLD_GBP,  # Exactly at threshold
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -1135,6 +1190,7 @@ def _provision_scenario_loans() -> list[Loan]:
             maturity_date=date(2029, 1, 1),
             currency="GBP",
             drawn_amount=1_000_000.0,  # £1m gross
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -1155,6 +1211,7 @@ def _provision_scenario_loans() -> list[Loan]:
             maturity_date=date(2028, 6, 30),
             currency="GBP",
             drawn_amount=5_000_000.0,  # £5m gross
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -1176,6 +1233,7 @@ def _provision_scenario_loans() -> list[Loan]:
             maturity_date=date(2028, 6, 30),
             currency="GBP",
             drawn_amount=5_000_000.0,  # £5m gross
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -1217,6 +1275,7 @@ def _complex_scenario_loans() -> list[Loan]:
             maturity_date=date(2029, 12, 31),
             currency="GBP",
             drawn_amount=4_500_000.0,  # £4.5m aggregated EAD
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -1239,6 +1298,7 @@ def _complex_scenario_loans() -> list[Loan]:
             maturity_date=date(2029, 12, 31),
             currency="GBP",
             drawn_amount=5_000_000.0,  # £5m aggregated EAD
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -1257,6 +1317,7 @@ def _complex_scenario_loans() -> list[Loan]:
             maturity_date=date(2029, 12, 31),
             currency="GBP",
             drawn_amount=2_000_000.0,  # £2m
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",
@@ -1277,6 +1338,7 @@ def _complex_scenario_loans() -> list[Loan]:
             maturity_date=date(2029, 12, 31),
             currency="GBP",
             drawn_amount=2_000_000.0,  # £2m gross
+            interest=0.0,
             lgd=0.45,
             beel=0.0,
             seniority="senior",


### PR DESCRIPTION
This pull request introduces support for tracking and including accrued interest in exposure at default (EAD) calculations across the codebase. The main changes ensure that the `interest` field is consistently present in data schemas, EAD calculations, and test fixtures, so that on-balance-sheet exposures (like loans) now correctly include accrued interest in their EAD. This improves the accuracy of risk-weighted asset (RWA) calculations and aligns with regulatory requirements.

**Schema and Data Model Updates:**

* Added an `interest` field (accrued interest) to all relevant exposure schemas in `src/rwa_calc/data/schemas.py`, ensuring it is included in drawn exposures, facilities, and unified exposure records. The field is documented as only affecting on-balance-sheet EAD, not undrawn amounts. [[1]](diffhunk://#diff-04eeea3da0125ae22d7104c692e0f1d41a86209f6fdfcadd5f061376c8092084R81-R87) [[2]](diffhunk://#diff-04eeea3da0125ae22d7104c692e0f1d41a86209f6fdfcadd5f061376c8092084R367) [[3]](diffhunk://#diff-04eeea3da0125ae22d7104c692e0f1d41a86209f6fdfcadd5f061376c8092084R394) [[4]](diffhunk://#diff-04eeea3da0125ae22d7104c692e0f1d41a86209f6fdfcadd5f061376c8092084R433) [[5]](diffhunk://#diff-04eeea3da0125ae22d7104c692e0f1d41a86209f6fdfcadd5f061376c8092084R469)
* Updated the `original_amount` audit trail field to include `interest` in its calculation, reflecting the total exposure before FX conversion. [[1]](diffhunk://#diff-04eeea3da0125ae22d7104c692e0f1d41a86209f6fdfcadd5f061376c8092084L376-R378) [[2]](diffhunk://#diff-054f578a992202e82fb2283dbe871200953301a7eb67f21ff1ca5f24e42a7f7bL156-R156)

**EAD and CCF Calculation Logic:**

* Modified the EAD calculation in `src/rwa_calc/engine/ccf.py` to add `interest` to `drawn_amount` when computing total EAD (`ead_pre_crm`). The logic now handles the presence or absence of the `interest` column for backward compatibility.
* Enhanced the CCF audit trail to display the `interest` component where available, improving transparency in EAD calculations. [[1]](diffhunk://#diff-9ea68eb315ecb7107d703b8dc1d1288d5075a272e577ce102ee3fe11677a9ba4L187-R220) [[2]](diffhunk://#diff-9ea68eb315ecb7107d703b8dc1d1288d5075a272e577ce102ee3fe11677a9ba4R233-R247)
* Updated logic in exposure hierarchy functions to handle the `interest` field, ensuring it is set to zero for undrawn facilities and contingents, and included in unified exposures. [[1]](diffhunk://#diff-054f578a992202e82fb2283dbe871200953301a7eb67f21ff1ca5f24e42a7f7bR542) [[2]](diffhunk://#diff-054f578a992202e82fb2283dbe871200953301a7eb67f21ff1ca5f24e42a7f7bR621) [[3]](diffhunk://#diff-054f578a992202e82fb2283dbe871200953301a7eb67f21ff1ca5f24e42a7f7bL659-R668) [[4]](diffhunk://#diff-054f578a992202e82fb2283dbe871200953301a7eb67f21ff1ca5f24e42a7f7bR678-R687) [[5]](diffhunk://#diff-054f578a992202e82fb2283dbe871200953301a7eb67f21ff1ca5f24e42a7f7bR705)

**Documentation and Test Fixture Updates:**

* Updated code comments and docstrings throughout to clarify that EAD for loans is now `drawn_amount + interest`, not just `drawn_amount`. [[1]](diffhunk://#diff-04eeea3da0125ae22d7104c692e0f1d41a86209f6fdfcadd5f061376c8092084R81-R87) [[2]](diffhunk://#diff-054f578a992202e82fb2283dbe871200953301a7eb67f21ff1ca5f24e42a7f7bL659-R668) [[3]](diffhunk://#diff-0d3f98d8548979bda068fd30aab812d6d380fc93e0265a44386bae946090ba36L47-R47)
* Amended the `Loan` test fixture and all sample loan data in `tests/fixtures/exposures/loans.py` to include the new `interest` field, ensuring tests reflect the updated data model. [[1]](diffhunk://#diff-0d3f98d8548979bda068fd30aab812d6d380fc93e0265a44386bae946090ba36R58) [[2]](diffhunk://#diff-0d3f98d8548979bda068fd30aab812d6d380fc93e0265a44386bae946090ba36R73) [[3]](diffhunk://#diff-0d3f98d8548979bda068fd30aab812d6d380fc93e0265a44386bae946090ba36R127) [[4]](diffhunk://#diff-0d3f98d8548979bda068fd30aab812d6d380fc93e0265a44386bae946090ba36R142) [[5]](diffhunk://#diff-0d3f98d8548979bda068fd30aab812d6d380fc93e0265a44386bae946090ba36R157) [[6]](diffhunk://#diff-0d3f98d8548979bda068fd30aab812d6d380fc93e0265a44386bae946090ba36R182) [[7]](diffhunk://#diff-0d3f98d8548979bda068fd30aab812d6d380fc93e0265a44386bae946090ba36R197) [[8]](diffhunk://#diff-0d3f98d8548979bda068fd30aab812d6d380fc93e0265a44386bae946090ba36R212) [[9]](diffhunk://#diff-0d3f98d8548979bda068fd30aab812d6d380fc93e0265a44386bae946090ba36R238) [[10]](diffhunk://#diff-0d3f98d8548979bda068fd30aab812d6d380fc93e0265a44386bae946090ba36R253) [[11]](diffhunk://#diff-0d3f98d8548979bda068fd30aab812d6d380fc93e0265a44386bae946090ba36R268) [[12]](diffhunk://#diff-0d3f98d8548979bda068fd30aab812d6d380fc93e0265a44386bae946090ba36R283) [[13]](diffhunk://#diff-0d3f98d8548979bda068fd30aab812d6d380fc93e0265a44386bae946090ba36R298) [[14]](diffhunk://#diff-0d3f98d8548979bda068fd30aab812d6d380fc93e0265a44386bae946090ba36R323)

These changes make the treatment of accrued interest explicit and consistent, improving both the accuracy and auditability of RWA calculations.