### PR TITLE
feat(ccf): handle negative drawn amounts in EAD calculations

### DIFF
--- a/src/rwa_calc/engine/crm/processor.py
+++ b/src/rwa_calc/engine/crm/processor.py
@@ -31,7 +31,7 @@ from rwa_calc.contracts.bundles import (
 )
 from rwa_calc.contracts.errors import LazyFrameResult
 from rwa_calc.domain.enums import ApproachType, ExposureClass
-from rwa_calc.engine.ccf import CCFCalculator, sa_ccf_expression
+from rwa_calc.engine.ccf import CCFCalculator, drawn_for_ead, sa_ccf_expression
 from rwa_calc.engine.classifier import ENTITY_TYPE_TO_SA_CLASS
 from rwa_calc.engine.crm.haircuts import HaircutCalculator
 from rwa_calc.data.tables.crr_firb_lgd import get_firb_lgd_table
@@ -1152,7 +1152,7 @@ class CRMProcessor:
         ])
 
         # Recalculate EAD with split CCFs when cross-approach substitution applies
-        on_bal = pl.col("drawn_amount") + (
+        on_bal = drawn_for_ead() + (
             pl.col("interest").fill_null(0.0) if has_interest else pl.lit(0.0)
         )
         ratio = pl.col("guarantee_ratio")

--- a/src/rwa_calc/engine/hierarchy.py
+++ b/src/rwa_calc/engine/hierarchy.py
@@ -872,7 +872,7 @@ class HierarchyResolver:
             # Per CRR Article 147, "total amount owed" = drawn amount only (not undrawn)
             pl.col("residential_collateral_value").fill_null(0.0),
             pl.col("exposure_for_retail_threshold").fill_null(
-                pl.col("drawn_amount")
+                pl.col("drawn_amount").clip(lower_bound=0.0)
             ),
         ])
 
@@ -882,9 +882,9 @@ class HierarchyResolver:
         lending_group_totals = exposures_with_group.filter(
             pl.col("lending_group_reference").is_not_null()
         ).group_by("lending_group_reference").agg([
-            pl.col("drawn_amount").sum().alias("total_drawn"),
+            pl.col("drawn_amount").clip(lower_bound=0.0).sum().alias("total_drawn"),
             pl.col("nominal_amount").sum().alias("total_nominal"),
-            (pl.col("drawn_amount") + pl.col("nominal_amount")).sum().alias("total_exposure"),
+            (pl.col("drawn_amount").clip(lower_bound=0.0) + pl.col("nominal_amount")).sum().alias("total_exposure"),
             pl.col("exposure_for_retail_threshold").sum().alias("adjusted_exposure"),
             pl.col("residential_collateral_value").sum().alias("total_residential_coverage"),
             pl.len().alias("exposure_count"),
@@ -1046,7 +1046,7 @@ class HierarchyResolver:
             pl.col("exposure_reference"),
             pl.col("counterparty_reference"),
             pl.col("parent_facility_reference"),
-            pl.col("drawn_amount").alias("total_exposure_amount"),
+            pl.col("drawn_amount").clip(lower_bound=0.0).alias("total_exposure_amount"),
         ])
 
         # Check if collateral is valid for property coverage calculation
@@ -1375,7 +1375,7 @@ class HierarchyResolver:
             pl.col("residential_collateral_value").fill_null(0.0),
             pl.col("property_collateral_value").fill_null(0.0),
             pl.col("exposure_for_retail_threshold").fill_null(
-                pl.col("drawn_amount")
+                pl.col("drawn_amount").clip(lower_bound=0.0)
             ),
         ]
         # Add has_facility_property_collateral if it exists

--- a/src/rwa_calc/engine/hierarchy_namespace.py
+++ b/src/rwa_calc/engine/hierarchy_namespace.py
@@ -322,13 +322,13 @@ class HierarchyLazyFrame:
             how="left",
         )
 
-        # Determine exposure amount column
+        # Determine exposure amount expression (floor drawn_amount at 0)
         if "drawn_amount" in schema.names():
-            amount_col = "drawn_amount"
+            amount_expr = pl.col("drawn_amount").clip(lower_bound=0.0)
         elif "ead_final" in schema.names():
-            amount_col = "ead_final"
+            amount_expr = pl.col("ead_final")
         elif "ead" in schema.names():
-            amount_col = "ead"
+            amount_expr = pl.col("ead")
         else:
             return self._lf.with_columns([pl.lit(0.0).alias("lending_group_total")])
 
@@ -336,7 +336,7 @@ class HierarchyLazyFrame:
         lending_group_totals = exposures_with_group.filter(
             pl.col("lending_group_reference").is_not_null()
         ).group_by("lending_group_reference").agg([
-            pl.col(amount_col).sum().alias("total_exposure"),
+            amount_expr.sum().alias("total_exposure"),
             pl.len().alias("exposure_count"),
         ])
 


### PR DESCRIPTION
This pull request updates the EAD (Exposure at Default) calculation logic across the codebase to ensure that negative `drawn_amount` values (i.e., credit balances) are consistently floored at zero, in line with regulatory requirements. This prevents negative balances from reducing EAD unless a netting agreement is present. The change is implemented via a new helper function and is thoroughly tested with new unit tests.

The most important changes are:

**EAD Calculation Logic Improvements:**

* Introduced the `drawn_for_ead()` helper function in `ccf.py` to floor negative `drawn_amount` values at zero for EAD calculations, ensuring regulatory compliance.
* Replaced all relevant instances of `pl.col("drawn_amount")` with `drawn_for_ead()` in EAD and CCF calculations across `ccf.py`, `crm/namespace.py`, `crm/processor.py`, and related aggregation logic in `hierarchy.py` and `hierarchy_namespace.py`. [[1]](diffhunk://#diff-9ea68eb315ecb7107d703b8dc1d1288d5075a272e577ce102ee3fe11677a9ba4L213-R228) [[2]](diffhunk://#diff-cca92be6729e59c6b591fe143dbcab378481b8338a33ed574fd1841f307b3d4eL97-R98) [[3]](diffhunk://#diff-cca92be6729e59c6b591fe143dbcab378481b8338a33ed574fd1841f307b3d4eL454-R455) [[4]](diffhunk://#diff-5dec8ac5620ec081b2d95fdf70da54c896e5febcfba6e9c6d626e524753f9950L1155-R1155) [[5]](diffhunk://#diff-054f578a992202e82fb2283dbe871200953301a7eb67f21ff1ca5f24e42a7f7bL875-R875) [[6]](diffhunk://#diff-054f578a992202e82fb2283dbe871200953301a7eb67f21ff1ca5f24e42a7f7bL885-R887) [[7]](diffhunk://#diff-054f578a992202e82fb2283dbe871200953301a7eb67f21ff1ca5f24e42a7f7bL1049-R1049) [[8]](diffhunk://#diff-054f578a992202e82fb2283dbe871200953301a7eb67f21ff1ca5f24e42a7f7bL1378-R1378) [[9]](diffhunk://#diff-30e2be11bbbe340ef6d44bcf44aed4ce14e6bcce8494c7663c9f9557d3ddace3L325-R339)

**Imports and Refactoring:**

* Updated imports to include the new `drawn_for_ead` helper where needed. [[1]](diffhunk://#diff-cca92be6729e59c6b591fe143dbcab378481b8338a33ed574fd1841f307b3d4eL39-R39) [[2]](diffhunk://#diff-5dec8ac5620ec081b2d95fdf70da54c896e5febcfba6e9c6d626e524753f9950L34-R34) [[3]](diffhunk://#diff-6d18843a03764627f9d6070d285c01004bfde2972661469dddc3116629796956L20-R20)

**Testing Enhancements:**

* Added comprehensive unit tests for negative `drawn_amount` scenarios in both `test_ccf.py` and `test_cross_approach_ccf.py`, verifying that negative values are correctly floored and do not reduce EAD. [[1]](diffhunk://#diff-6d18843a03764627f9d6070d285c01004bfde2972661469dddc3116629796956R905-R1007) [[2]](diffhunk://#diff-c11c1aecd5a86776acbb4598e4b248ef0102bed2d43dc048f88e80ad70231a46R586-R613)

These changes ensure that EAD calculations are robust against negative drawn balances, improving both correctness and regulatory compliance.