### PR TITLE
feat(ccf): add on_balance_ead() helper for EAD calculations

### DIFF
--- a/src/rwa_calc/engine/crm/processor.py
+++ b/src/rwa_calc/engine/crm/processor.py
@@ -31,7 +31,7 @@ from rwa_calc.contracts.bundles import (
 )
 from rwa_calc.contracts.errors import LazyFrameResult
 from rwa_calc.domain.enums import ApproachType, ExposureClass
-from rwa_calc.engine.ccf import CCFCalculator, drawn_for_ead, sa_ccf_expression
+from rwa_calc.engine.ccf import CCFCalculator, drawn_for_ead, on_balance_ead, sa_ccf_expression
 from rwa_calc.engine.classifier import ENTITY_TYPE_TO_SA_CLASS
 from rwa_calc.engine.crm.haircuts import HaircutCalculator
 from rwa_calc.data.tables.crr_firb_lgd import get_firb_lgd_table
@@ -1152,9 +1152,7 @@ class CRMProcessor:
         ])
 
         # Recalculate EAD with split CCFs when cross-approach substitution applies
-        on_bal = drawn_for_ead() + (
-            pl.col("interest").fill_null(0.0) if has_interest else pl.lit(0.0)
-        )
+        on_bal = on_balance_ead() if has_interest else drawn_for_ead()
         ratio = pl.col("guarantee_ratio")
 
         new_guaranteed = (on_bal * ratio) + (pl.col("nominal_amount") * ratio * pl.col("ccf_guaranteed"))


### PR DESCRIPTION
This pull request introduces a new helper function, `on_balance_ead`, to consistently handle the calculation of on-balance-sheet Exposure at Default (EAD) by combining floored drawn amounts and accrued interest, with robust handling of null values. The new helper is integrated throughout the codebase to replace ad-hoc calculations, improving maintainability and correctness. Comprehensive unit tests are added to validate the new logic, including edge cases involving negative drawn amounts and null interest.

**EAD Calculation Improvements:**
* Added `on_balance_ead()` helper in `ccf.py` to compute on-balance-sheet EAD as `max(0, drawn_amount) + interest`, treating null interest as zero.
* Refactored EAD calculations in `apply_ccf`, `apply_guarantees`, and `_apply_cross_approach_ccf` to use `on_balance_ead()` instead of manual expressions, ensuring consistency and correct handling of negative drawn amounts and interest. [[1]](diffhunk://#diff-9ea68eb315ecb7107d703b8dc1d1288d5075a272e577ce102ee3fe11677a9ba4L221-R231) [[2]](diffhunk://#diff-cca92be6729e59c6b591fe143dbcab378481b8338a33ed574fd1841f307b3d4eL455-R458) [[3]](diffhunk://#diff-5dec8ac5620ec081b2d95fdf70da54c896e5febcfba6e9c6d626e524753f9950L1155-R1155)
* Updated EAD initialization logic in `initialize_ead_waterfall` to use `on_balance_ead()` when both `drawn_amount` and `interest` columns are present.

**Testing Enhancements:**
* Added a dedicated test class `TestOnBalanceEAD` covering various scenarios for the new helper, including negative drawn amounts, null interest, and batch processing.
* Added a facility undrawn test to ensure that interest does not reduce facility headroom when drawn amount is negative.

**Imports and Code Hygiene:**
* Updated imports in relevant modules to include `on_balance_ead`. [[1]](diffhunk://#diff-cca92be6729e59c6b591fe143dbcab378481b8338a33ed574fd1841f307b3d4eL39-R39) [[2]](diffhunk://#diff-5dec8ac5620ec081b2d95fdf70da54c896e5febcfba6e9c6d626e524753f9950L34-R34) [[3]](diffhunk://#diff-6d18843a03764627f9d6070d285c01004bfde2972661469dddc3116629796956L20-R20)