### PR TITLE
feat(fx_converter): add exposure conversion functionality

### DIFF
--- a/src/rwa_calc/config/fx_rates.py
+++ b/src/rwa_calc/config/fx_rates.py
@@ -94,6 +94,9 @@ def gbp_to_eur(gbp_amount: Decimal) -> Decimal:
 ThresholdKey = Literal[
     "sme_exposure",
     "sme_turnover",
+    "retail_exposure",
+    "qrre_limit",
+    "lfse_total_assets",
 ]
 
 CRR_REGULATORY_THRESHOLDS_EUR: dict[ThresholdKey, Decimal] = {
@@ -105,6 +108,17 @@ CRR_REGULATORY_THRESHOLDS_EUR: dict[ThresholdKey, Decimal] = {
     # SME turnover threshold for eligibility (CRR Art. 501)
     # Counterparties with turnover below this qualify as SME
     "sme_turnover": Decimal("50000000"),  # EUR 50m
+
+    # Retail exposure threshold (CRR Art. 123(c))
+    # Aggregated exposure to lending group must be below this
+    "retail_exposure": Decimal("1000000"),  # EUR 1m
+
+    # QRRE maximum limit per exposure (CRR Art. 123)
+    "qrre_limit": Decimal("100000"),  # EUR 100k
+
+    # Large financial sector entity total assets threshold (CRR Art. 4(1)(146))
+    # Entities with total assets >= this threshold are LFSE
+    "lfse_total_assets": Decimal("70000000000"),  # EUR 70bn
 }
 
 

--- a/src/rwa_calc/contracts/bundles.py
+++ b/src/rwa_calc/contracts/bundles.py
@@ -117,6 +117,7 @@ class ResolvedHierarchyBundle:
     collateral: pl.LazyFrame | None = None
     guarantees: pl.LazyFrame | None = None
     provisions: pl.LazyFrame | None = None
+    equity_exposures: pl.LazyFrame | None = None
     hierarchy_errors: list = field(default_factory=list)
 
 

--- a/src/rwa_calc/contracts/config.py
+++ b/src/rwa_calc/contracts/config.py
@@ -273,11 +273,16 @@ class RetailThresholds:
     qrre_max_limit: Decimal = Decimal("100000")  # GBP 100k limit per exposure
 
     @classmethod
-    def crr(cls) -> RetailThresholds:
-        """CRR retail thresholds (converted from EUR)."""
+    def crr(cls, eur_gbp_rate: Decimal = Decimal("0.8732")) -> RetailThresholds:
+        """
+        CRR retail thresholds (converted from EUR dynamically).
+
+        Args:
+            eur_gbp_rate: EUR/GBP exchange rate for threshold conversion
+        """
         return cls(
-            max_exposure_threshold=Decimal("880000"),  # EUR 1m * 0.88
-            qrre_max_limit=Decimal("88000"),  # EUR 100k * 0.88
+            max_exposure_threshold=Decimal("1000000") * eur_gbp_rate,  # EUR 1m
+            qrre_max_limit=Decimal("100000") * eur_gbp_rate,  # EUR 100k
         )
 
     @classmethod
@@ -507,7 +512,7 @@ class CalculationConfig:
             lgd_floors=LGDFloors.crr(),
             supporting_factors=SupportingFactors.crr(),
             output_floor=OutputFloorConfig.crr(),
-            retail_thresholds=RetailThresholds.crr(),
+            retail_thresholds=RetailThresholds.crr(eur_gbp_rate=eur_gbp_rate),
             irb_permissions=irb_permissions or IRBPermissions.sa_only(),
             scaling_factor=Decimal("1.06"),
             eur_gbp_rate=eur_gbp_rate,

--- a/src/rwa_calc/engine/classifier.py
+++ b/src/rwa_calc/engine/classifier.py
@@ -30,6 +30,7 @@ from rwa_calc.contracts.bundles import (
     ClassifiedExposuresBundle,
     ResolvedHierarchyBundle,
 )
+from rwa_calc.config.fx_rates import CRR_REGULATORY_THRESHOLDS_EUR
 from rwa_calc.domain.enums import (
     ApproachType,
     ExposureClass,
@@ -221,7 +222,7 @@ class ExposureClassifier:
             sa_exposures=sa_exposures,
             irb_exposures=irb_exposures,
             slotting_exposures=slotting_exposures,
-            equity_exposures=None,  # TODO: Add equity exposure handling
+            equity_exposures=data.equity_exposures,
             collateral=data.collateral,
             guarantees=data.guarantees,
             provisions=data.provisions,
@@ -661,8 +662,9 @@ class ExposureClassifier:
         - requires_fi_scalar: Either LFSE or unregulated FSE
         """
         # Large FSE threshold: EUR 70bn (CRR Art. 4(1)(146))
-        lfse_threshold_eur = Decimal("70_000_000_000")
-        lfse_threshold_gbp = float(lfse_threshold_eur * config.eur_gbp_rate)
+        lfse_threshold_gbp = float(
+            CRR_REGULATORY_THRESHOLDS_EUR["lfse_total_assets"] * config.eur_gbp_rate
+        )
 
         return exposures.with_columns([
             # Is this a financial sector entity type?

--- a/src/rwa_calc/engine/fx_converter.py
+++ b/src/rwa_calc/engine/fx_converter.py
@@ -68,7 +68,7 @@ class FXConverter:
             # No FX rates or conversion disabled - add null audit columns
             return exposures.with_columns([
                 pl.col("currency").alias("original_currency"),
-                (pl.col("drawn_amount") + pl.col("nominal_amount")).alias("original_amount"),
+                (pl.col("drawn_amount") + pl.col("interest").fill_null(0.0) + pl.col("nominal_amount")).alias("original_amount"),
                 pl.lit(None).cast(pl.Float64).alias("fx_rate_applied"),
             ])
 
@@ -94,8 +94,8 @@ class FXConverter:
         converted = converted.with_columns([
             # Preserve original currency
             pl.col("currency").alias("original_currency"),
-            # Preserve original total amount
-            (pl.col("drawn_amount") + pl.col("nominal_amount")).alias("original_amount"),
+            # Preserve original total amount (including accrued interest)
+            (pl.col("drawn_amount") + pl.col("interest").fill_null(0.0) + pl.col("nominal_amount")).alias("original_amount"),
             # Track rate applied (null if same currency or no rate)
             pl.when(pl.col("currency") == target_currency)
             .then(pl.lit(None).cast(pl.Float64))
@@ -126,6 +126,16 @@ class FXConverter:
             .then(pl.col("nominal_amount") * pl.col("rate"))
             .otherwise(pl.col("nominal_amount"))
             .alias("nominal_amount"),
+
+            # Convert interest (nullable - preserve nulls through conversion)
+            pl.when(pl.col("interest").is_null())
+            .then(pl.lit(None).cast(pl.Float64))
+            .when(pl.col("currency") == target_currency)
+            .then(pl.col("interest"))
+            .when(pl.col("rate").is_not_null())
+            .then(pl.col("interest") * pl.col("rate"))
+            .otherwise(pl.col("interest"))
+            .alias("interest"),
 
             # Update currency to target where conversion applied
             pl.when(pl.col("currency") == target_currency)
@@ -316,6 +326,75 @@ class FXConverter:
             .then(pl.col("amount") * pl.col("rate"))
             .otherwise(pl.col("amount"))
             .alias("amount"),
+
+            # Update currency to target where conversion applied
+            pl.when(pl.col("currency") == target_currency)
+            .then(pl.col("currency"))
+            .when(pl.col("rate").is_not_null())
+            .then(pl.lit(target_currency))
+            .otherwise(pl.col("currency"))
+            .alias("currency"),
+        ])
+
+        # Drop the temporary rate column from join
+        converted = converted.drop("rate")
+
+        return converted
+
+
+    def convert_equity_exposures(
+        self,
+        equity_exposures: pl.LazyFrame,
+        fx_rates: pl.LazyFrame | None,
+        config: CalculationConfig,
+    ) -> pl.LazyFrame:
+        """
+        Convert equity exposure values to reporting currency.
+
+        Args:
+            equity_exposures: Equity exposures with currency, carrying_value, fair_value
+            fx_rates: FX rates with currency_from, currency_to, rate columns
+            config: Calculation configuration with base_currency
+
+        Returns:
+            Equity exposures with values converted to base currency
+        """
+        if fx_rates is None or not config.apply_fx_conversion:
+            return equity_exposures
+
+        target_currency = config.base_currency
+
+        # Filter FX rates to only those targeting our base currency
+        rates_to_target = fx_rates.filter(
+            pl.col("currency_to") == target_currency
+        ).select([
+            pl.col("currency_from"),
+            pl.col("rate"),
+        ])
+
+        # Join equity exposures with FX rates on currency
+        converted = equity_exposures.join(
+            rates_to_target,
+            left_on="currency",
+            right_on="currency_from",
+            how="left",
+        )
+
+        # Convert amounts where rate is available
+        converted = converted.with_columns([
+            pl.when(pl.col("currency") == target_currency)
+            .then(pl.col("carrying_value"))
+            .when(pl.col("rate").is_not_null())
+            .then(pl.col("carrying_value") * pl.col("rate"))
+            .otherwise(pl.col("carrying_value"))
+            .alias("carrying_value"),
+
+            pl.when(pl.col("currency") == target_currency)
+            .then(pl.col("fair_value"))
+            .when(pl.col("rate").is_not_null())
+            .then(pl.col("fair_value") * pl.col("rate"))
+            .otherwise(pl.col("fair_value"))
+            .alias("fair_value"),
 
             # Update currency to target where conversion applied
             pl.when(pl.col("currency") == target_currency)

--- a/src/rwa_calc/engine/hierarchy.py
+++ b/src/rwa_calc/engine/hierarchy.py
@@ -140,6 +140,7 @@ class HierarchyResolver:
         collateral = data.collateral
         guarantees = data.guarantees
         provisions = data.provisions
+        equity_exposures = data.equity_exposures
 
         if config.apply_fx_conversion and data.fx_rates is not None:
             exposures = fx_converter.convert_exposures(exposures, data.fx_rates, config)
@@ -149,6 +150,8 @@ class HierarchyResolver:
                 guarantees = fx_converter.convert_guarantees(guarantees, data.fx_rates, config)
             if provisions is not None:
                 provisions = fx_converter.convert_provisions(provisions, data.fx_rates, config)
+            if equity_exposures is not None:
+                equity_exposures = fx_converter.convert_equity_exposures(equity_exposures, data.fx_rates, config)
         else:
             # Add audit trail columns with null values when no conversion
             exposures = exposures.with_columns([
@@ -190,6 +193,7 @@ class HierarchyResolver:
             collateral=collateral,
             guarantees=guarantees,
             provisions=provisions,
+            equity_exposures=equity_exposures,
             lending_group_totals=lending_group_totals,
             hierarchy_errors=errors,
         )

--- a/tests/unit/test_classifier.py
+++ b/tests/unit/test_classifier.py
@@ -944,8 +944,10 @@ class TestRetailClassification:
             "is_managed_as_retail": [True, True],
         }).lazy()
 
-        # Lending group total = 2.2m GBP (2.5m EUR)
-        # Adjusted = 880k GBP (1m EUR) after excluding residential
+        # Lending group total = EUR 2.5m in GBP at 0.8732 rate
+        # Member 1: EUR 1m = 873,200 GBP (term loan, no residential)
+        # Member 2: EUR 1.5m = 1,309,800 GBP (mortgage, fully secured by residential RE)
+        # Adjusted = 873,200 GBP (at threshold) after excluding residential
         exposures = pl.DataFrame({
             "exposure_reference": ["LG_EXP_1", "LG_EXP_2"],
             "exposure_type": ["loan", "loan"],
@@ -955,7 +957,7 @@ class TestRetailClassification:
             "value_date": [date(2023, 1, 1), date(2023, 1, 1)],
             "maturity_date": [date(2028, 1, 1), date(2048, 1, 1)],
             "currency": ["GBP", "GBP"],
-            "drawn_amount": [880000.0, 1320000.0],  # 1m EUR + 1.5m EUR
+            "drawn_amount": [873200.0, 1309800.0],  # EUR 1m + EUR 1.5m at 0.8732
             "undrawn_amount": [0.0, 0.0],
             "nominal_amount": [0.0, 0.0],
             "lgd": [0.45, 0.15],
@@ -971,11 +973,11 @@ class TestRetailClassification:
             "ultimate_parent_reference": [None, None],
             "counterparty_hierarchy_depth": [1, 1],
             "lending_group_reference": ["LG_PARENT", "LG_PARENT"],
-            "lending_group_total_exposure": [2200000.0, 2200000.0],  # 2.5m EUR
+            "lending_group_total_exposure": [2183000.0, 2183000.0],  # EUR 2.5m at 0.8732
             # Residential exclusion: mortgage fully secured
-            "residential_collateral_value": [0.0, 1320000.0],
-            "exposure_for_retail_threshold": [880000.0, 0.0],
-            "lending_group_adjusted_exposure": [880000.0, 880000.0],  # At threshold
+            "residential_collateral_value": [0.0, 1309800.0],
+            "exposure_for_retail_threshold": [873200.0, 0.0],
+            "lending_group_adjusted_exposure": [873200.0, 873200.0],  # At threshold
         }).lazy()
 
         bundle = create_resolved_bundle(exposures, counterparties)


### PR DESCRIPTION
This pull request introduces several enhancements and fixes related to regulatory threshold configuration, FX conversion logic, and support for equity exposures. The main improvements include dynamic handling of CRR regulatory thresholds, more accurate FX conversion for exposures (including accrued interest), support for FX conversion of equity exposures, and updates to tests to reflect these changes.

**Regulatory Thresholds and Configuration:**
- Added new regulatory thresholds to `CRR_REGULATORY_THRESHOLDS_EUR` for retail exposure, QRRE limit, and large financial sector entity (LFSE) total assets, and updated the `ThresholdKey` type accordingly. [[1]](diffhunk://#diff-9ec681f5ac2644efaea9d0b84af64d2a7824282cbac53643977cb81463542db9R97-R99) [[2]](diffhunk://#diff-9ec681f5ac2644efaea9d0b84af64d2a7824282cbac53643977cb81463542db9R111-R121)
- Modified the `RetailThresholds.crr()` method to dynamically convert EUR thresholds to GBP using a configurable exchange rate, and ensured this rate is passed through the configuration pipeline. [[1]](diffhunk://#diff-ec392d61300ad7481b768c848d799053fef57c8f97929a21e1b1686f6975945aL276-R285) [[2]](diffhunk://#diff-ec392d61300ad7481b768c848d799053fef57c8f97929a21e1b1686f6975945aL510-R515)
- Updated the classifier to use the new thresholds and dynamic conversion for LFSE classification. [[1]](diffhunk://#diff-9d8857ec8c5b43a597a22861ee415145d73aa94872f034a92def436698bf0183R33) [[2]](diffhunk://#diff-9d8857ec8c5b43a597a22861ee415145d73aa94872f034a92def436698bf0183L664-R667)

**FX Conversion Enhancements:**
- Improved the FX conversion logic for exposures to include accrued interest in the original and converted amounts, and ensured null handling for the interest column. [[1]](diffhunk://#diff-ca7235391495c0cce84f611817c6d98b8cbd0e2af9196cfd93067f661a656473L71-R71) [[2]](diffhunk://#diff-ca7235391495c0cce84f611817c6d98b8cbd0e2af9196cfd93067f661a656473L97-R98) [[3]](diffhunk://#diff-ca7235391495c0cce84f611817c6d98b8cbd0e2af9196cfd93067f661a656473R130-R139)
- Added a new method to the FX converter to support FX conversion of equity exposures (`convert_equity_exposures`), and integrated this into the hierarchy resolution process. [[1]](diffhunk://#diff-ca7235391495c0cce84f611817c6d98b8cbd0e2af9196cfd93067f661a656473R345-R413) [[2]](diffhunk://#diff-054f578a992202e82fb2283dbe871200953301a7eb67f21ff1ca5f24e42a7f7bR143) [[3]](diffhunk://#diff-054f578a992202e82fb2283dbe871200953301a7eb67f21ff1ca5f24e42a7f7bR153-R154) [[4]](diffhunk://#diff-054f578a992202e82fb2283dbe871200953301a7eb67f21ff1ca5f24e42a7f7bR196)

**Equity Exposure Support:**
- Extended the `ResolvedHierarchyBundle` dataclass and the classifier to handle equity exposures throughout the pipeline. [[1]](diffhunk://#diff-3f19d4bf077ab3de07a293d6cc6c17d842b4f933f2dbb41e81fc8d36e27f03e0R120) [[2]](diffhunk://#diff-9d8857ec8c5b43a597a22861ee415145d73aa94872f034a92def436698bf0183L224-R225)

**Test Updates:**
- Updated and extended unit tests to include the new interest column, verify correct calculation of original amounts (including interest), and ensure that regulatory threshold tests use dynamically converted values. [[1]](diffhunk://#diff-f90d97f5439b4f26c65fe9799cae1ff7691c21c17567356f521634046c57b0bcR70) [[2]](diffhunk://#diff-f90d97f5439b4f26c65fe9799cae1ff7691c21c17567356f521634046c57b0bcR84) [[3]](diffhunk://#diff-f90d97f5439b4f26c65fe9799cae1ff7691c21c17567356f521634046c57b0bcR98) [[4]](diffhunk://#diff-f90d97f5439b4f26c65fe9799cae1ff7691c21c17567356f521634046c57b0bcL186-R190) [[5]](diffhunk://#diff-f90d97f5439b4f26c65fe9799cae1ff7691c21c17567356f521634046c57b0bcR392) [[6]](diffhunk://#diff-f90d97f5439b4f26c65fe9799cae1ff7691c21c17567356f521634046c57b0bcR442) [[7]](diffhunk://#diff-6d792efed6b82a27d909b93ce6a229112642e16ae139ad97f40157ff7175d7a5L947-R950) [[8]](diffhunk://#diff-6d792efed6b82a27d909b93ce6a229112642e16ae139ad97f40157ff7175d7a5L958-R960) [[9]](diffhunk://#diff-6d792efed6b82a27d909b93ce6a229112642e16ae139ad97f40157ff7175d7a5L974-R980)