### PR TITLE
feat(crr): update slotting risk weights for maturity splits

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -9,7 +9,8 @@
       "WebFetch(domain:www.bis.org)",
       "Bash(python:*)",
       "WebFetch(domain:www.eba.europa.eu)",
-      "WebFetch(domain:www.legislation.gov.uk)"
+      "WebFetch(domain:www.legislation.gov.uk)",
+      "WebSearch"
     ]
   },
   "enabledMcpjsonServers": [

--- a/docs/specifications/basel31/framework-differences.md
+++ b/docs/specifications/basel31/framework-differences.md
@@ -20,7 +20,7 @@ Basel 3.1 (effective 1 January 2027 in the UK) introduces significant changes to
 | Output Floor | None | 72.5% of SA | PRA PS9/24 |
 | PD Floor | 0.03% (all classes) | Differentiated | CRE30.55 |
 | A-IRB LGD Floors | None | Yes (by collateral type) | CRE30.41 |
-| Slotting Risk Weights | Non-differentiated | HVCRE differentiated | PRA PS9/24 |
+| Slotting Risk Weights | Maturity-differentiated | HVCRE + PF pre-op differentiated | PRA PS9/24 |
 
 ## Differentiated PD Floors (Basel 3.1)
 
@@ -37,12 +37,26 @@ Basel 3.1 (effective 1 January 2027 in the UK) introduces significant changes to
 
 | Collateral Type | LGD Floor |
 |----------------|-----------|
-| Unsecured | 25% |
+| Unsecured (Senior) | 25% |
+| Unsecured (Subordinated) | 50% |
 | Financial collateral | 0% |
-| Receivables | 10% |
-| Commercial real estate | 10% |
-| Residential real estate | 5% |
-| Other physical | 15% |
+| Receivables | 10%* |
+| Commercial real estate | 10%* |
+| Residential real estate | 5%* |
+| Other physical | 15%* |
+
+*Values reflect PRA implementation. BCBS standard values differ (Receivables: 15%, CRE: 10%, RRE: 10%, Other Physical: 20%). Verify against PRA PS1/26 final rules.
+
+## F-IRB Supervisory LGD (CRE32)
+
+| Exposure Type | CRR | Basel 3.1 |
+|---------------|-----|-----------|
+| Corporate/Institution (Senior) | 45% | 40% |
+| Corporate/Institution (Subordinated) | 75% | 75% |
+| Secured - Financial Collateral | 0% | 0% |
+| Secured - Receivables | 35% | 20% |
+| Secured - CRE/RRE | 35% | 20% |
+| Secured - Other Physical | 40% | 25% |
 
 ## Output Floor
 
@@ -65,17 +79,47 @@ RWA_final = max(RWA_IRB, floor_percentage x RWA_SA)
 
 ## Slotting Risk Weights (Basel 3.1)
 
-HVCRE exposures receive elevated risk weights under Basel 3.1:
+Basel 3.1 (BCBS CRE33) introduces three distinct slotting weight tables:
 
-| Category | Non-HVCRE | HVCRE |
-|----------|-----------|-------|
-| Strong | 50% | 100% |
-| Good | 70% | 70% |
-| Satisfactory | 100% | 150% |
-| Weak | 150% | 150% |
-| Default | 350% | 350% |
+### Non-HVCRE Operational (OF, CF, IPRE, PF Operational)
+
+| Category | Risk Weight |
+|----------|-------------|
+| Strong | 70% |
+| Good | 90% |
+| Satisfactory | 115% |
+| Weak | 250% |
+| Default | 0% (EL) |
+
+### Project Finance Pre-Operational
+
+| Category | Risk Weight |
+|----------|-------------|
+| Strong | 80% |
+| Good | 100% |
+| Satisfactory | 120% |
+| Weak | 350% |
+| Default | 0% (EL) |
+
+### HVCRE
+
+| Category | Risk Weight |
+|----------|-------------|
+| Strong | 95% |
+| Good | 120% |
+| Satisfactory | 140% |
+| Weak | 250% |
+| Default | 0% (EL) |
 
 Compare with CRR slotting weights in the [Slotting Approach](../crr/slotting-approach.md) specification.
+
+## Large Corporate Correlation Multiplier (CRE31.5)
+
+Large corporates (consolidated revenue > £500m) receive a **1.25x** multiplier on their asset correlation under F-IRB.
+
+## A-IRB CCF Floor (CRE32.27)
+
+A-IRB own-estimate CCFs must be at least **50% of the SA CCF** for the same item type.
 
 ## Configuration
 

--- a/docs/user-guide/regulatory/basel31.md
+++ b/docs/user-guide/regulatory/basel31.md
@@ -85,12 +85,27 @@ New minimum LGD values for Advanced IRB:
 | Unsecured - Senior | 25% |
 | Unsecured - Subordinated | 50% |
 | Secured - Financial Collateral | 0% |
-| Secured - Receivables | 15% |
-| Secured - Commercial Real Estate | 15% |
-| Secured - Residential Real Estate | 10% |
-| Secured - Other Physical | 20% |
+| Secured - Receivables | 10%* |
+| Secured - Commercial Real Estate | 10%* |
+| Secured - Residential Real Estate | 5%* |
+| Secured - Other Physical | 15%* |
 
-### 6. Revised SA Risk Weights
+*Values reflect PRA implementation. BCBS standard values differ (Receivables: 15%, CRE: 10%, RRE: 10%, Other Physical: 20%). Verify against PRA PS1/26 final rules.
+
+### 6. F-IRB Supervisory LGD Changes (CRE32)
+
+Basel 3.1 recalibrates F-IRB supervisory LGD values:
+
+| Exposure Type | CRR | Basel 3.1 |
+|---------------|-----|-----------|
+| Corporate/Institution (Senior) | 45% | **40%** |
+| Corporate/Institution (Subordinated) | 75% | **75%** |
+| Secured - Financial Collateral | 0% | **0%** |
+| Secured - Receivables | 35% | **20%** |
+| Secured - CRE/RRE | 35% | **20%** |
+| Secured - Other Physical | 40% | **25%** |
+
+### 7. Revised SA Risk Weights
 
 Standardised Approach risk weights are recalibrated:
 
@@ -100,11 +115,18 @@ Standardised Approach risk weights are recalibrated:
 |-----|-----|-----------|
 | CQS 1 (AAA to AA-) | 20% | 20% |
 | CQS 2 (A+ to A-) | 50% | 50% |
-| CQS 3 (BBB+ to BBB-) | 75% | 75% |
+| CQS 3 (BBB+ to BBB-) | 100% | **75%** |
 | CQS 4 (BB+ to BB-) | 100% | 100% |
-| CQS 5 (B+ to B-) | 150% | 100% |
+| CQS 5 (B+ to B-) | 150% | **100%** |
 | CQS 6 (CCC+/Below) | 150% | 150% |
 | Unrated | 100% | 100% |
+
+#### New Corporate Sub-Categories (CRE20.47-49)
+
+| Sub-Category | Risk Weight | Criteria |
+|-------------|-------------|----------|
+| Investment Grade | **65%** | Publicly traded + investment grade rating |
+| SME Corporate | **85%** | Turnover ≤ EUR 50m, unrated |
 
 #### Real Estate Exposures
 
@@ -129,19 +151,43 @@ New LTV-based risk weights for real estate:
 | ≤ 60% | 70% |
 | > 60% | 110% |
 
-### 7. Input Floors for IRB
+#### ADC Exposures (CRE20.85)
+
+Acquisition, Development and Construction exposures receive a **150%** risk weight (up from 100% under CRR).
+
+#### Retail Exposures
+
+| Type | CRR | Basel 3.1 |
+|------|-----|-----------|
+| QRRE (Transactors) | 75% | **45%** |
+| QRRE (Revolvers) | 75% | 75% |
+| Retail Other | 75% | 75% |
+
+#### Defaulted Exposures (CRE20.87-90)
+
+| Provision Coverage | Unsecured | RE-Secured |
+|-------------------|-----------|------------|
+| < 20% provisions | 150% | 100% |
+| ≥ 20% provisions | 100% | 50% |
+
+### 8. Input Floors for IRB
 
 Beyond PD and LGD floors, Basel 3.1 introduces:
 
 **EAD Floors:**
 - CCF cannot be lower than SA values for comparable exposures
+- A-IRB CCFs must be at least **50% of the SA CCF** (CRE32.27)
 - Minimum 10% CCF for unconditionally cancellable facilities (vs 0% CRR)
 
 **Maturity:**
 - Effective maturity floor: 1 year
 - Cap remains: 5 years
 
-### 8. Due Diligence Requirements
+### 9. Large Corporate Correlation Multiplier (CRE31.5)
+
+Large corporates (consolidated revenue > £500m) receive a **1.25x** multiplier on their asset correlation under F-IRB. This increases capital requirements for exposures to large financial and non-financial corporates.
+
+### 10. Due Diligence Requirements
 
 Enhanced requirements for unrated exposures:
 - Institutions must perform internal assessment
@@ -242,13 +288,13 @@ from rwa_calc.contracts.config import CalculationConfig
 
 config = CalculationConfig.basel_3_1(
     reporting_date=date(2027, 1, 1),
-
-    # Output floor (72.5% fully phased in, or transitional)
-    output_floor_percentage=0.725,
-
-    # Transitional year (for phase-in calculation)
-    transitional_floor_year=2027,  # 50% in 2027
 )
+
+# Internally sets:
+# - scaling_factor: 1.0 (removed)
+# - output_floor: 72.5% (with transitional schedule)
+# - pd_floors: differentiated by class
+# - lgd_floors: by collateral type
 ```
 
 ## Implementation Timeline
@@ -280,6 +326,8 @@ gantt
 | Real estate | CRE20.70-90 |
 | PD/LGD floors | CRE32 |
 | Specialised lending | CRE33 |
+| Large corporate correlation | CRE31.5 |
+| A-IRB CCF floor | CRE32.27 |
 
 ## Next Steps
 

--- a/docs/user-guide/regulatory/comparison.md
+++ b/docs/user-guide/regulatory/comparison.md
@@ -76,10 +76,23 @@ This page provides a comprehensive comparison between CRR (Basel 3.0) and Basel 
 | Unsecured Senior | None | 25% |
 | Unsecured Subordinated | None | 50% |
 | Financial Collateral | None | 0% |
-| Receivables | None | 15% |
-| Commercial RE | None | 15% |
-| Residential RE | None | 10% |
-| Other Physical | None | 20% |
+| Receivables | None | 10%* |
+| Commercial RE | None | 10%* |
+| Residential RE | None | 5%* |
+| Other Physical | None | 15%* |
+
+*Values reflect PRA implementation. BCBS standard values differ (Receivables: 15%, CRE: 10%, RRE: 10%, Other Physical: 20%). Verify against PRA PS1/26 final rules.
+
+### F-IRB Supervisory LGD
+
+| Exposure Type | CRR | Basel 3.1 | Change |
+|---------------|-----|-----------|--------|
+| Corporate/Institution (Senior) | 45% | **40%** | -5pp |
+| Corporate/Institution (Subordinated) | 75% | **75%** | - |
+| Secured - Financial Collateral | 0% | **0%** | - |
+| Secured - Receivables | 35% | **20%** | -15pp |
+| Secured - CRE/RRE | 35% | **20%** | -15pp |
+| Secured - Other Physical | 40% | **25%** | -15pp |
 
 ### IRB Approach Restrictions
 
@@ -88,6 +101,14 @@ This page provides a comprehensive comparison between CRR (Basel 3.0) and Basel 
 | Large Corporate (>£500m) | F-IRB or A-IRB | **F-IRB only** |
 | Bank/Institution | F-IRB or A-IRB | **F-IRB only** |
 | Equity | IRB | **SA only** |
+
+### Large Corporate Correlation Multiplier
+
+Under Basel 3.1, large corporates (consolidated revenue > £500m) receive a **1.25x** correlation multiplier on their asset correlation (CRE31.5). This increases capital requirements for large corporate exposures treated under F-IRB.
+
+### A-IRB CCF Floor
+
+Under Basel 3.1, A-IRB own-estimate CCFs must be at least **50% of the SA CCF** for the same item type (CRE32.27). This constrains A-IRB benefit from low CCF estimates.
 
 ## Supporting Factors
 
@@ -151,23 +172,30 @@ This page provides a comprehensive comparison between CRR (Basel 3.0) and Basel 
 |-----|-----|-----------|--------|
 | CQS1 (AAA-AA-) | 20% | 20% | - |
 | CQS2 (A+-A-) | 50% | 50% | - |
-| CQS3 (BBB+-BBB-) | 75% | 75% | - |
+| CQS3 (BBB+-BBB-) | 100% | 75% | -25pp |
 | CQS4 (BB+-BB-) | 100% | 100% | - |
 | CQS5 (B+-B-) | 150% | **100%** | -50pp |
 | CQS6 (CCC+/Below) | 150% | 150% | - |
 | Unrated | 100% | 100% | - |
 
+#### New Basel 3.1 Corporate Sub-Categories (CRE20.47-49)
+
+| Sub-Category | Basel 3.1 RW | Criteria |
+|-------------|-------------|----------|
+| Investment Grade | **65%** | Publicly traded + investment grade rating |
+| SME Corporate | **85%** | Turnover ≤ EUR 50m, unrated |
+
 ### Residential Real Estate
 
-| Scenario | CRR | Basel 3.1 |
-|----------|-----|-----------|
-| LTV ≤ 50% | 35% | **20%** |
-| LTV 50-60% | 35% | **25%** |
-| LTV 60-70% | 35% | **30%** |
-| LTV 70-80% | 35% | **40%** |
-| LTV 80-90% | 75% | **50%** |
-| LTV 90-100% | 75% | **70%** |
-| LTV > 100% | Cpty RW | Cpty RW |
+| LTV | CRR | Basel 3.1 (Whole Loan) | Basel 3.1 (Income-Producing) |
+|-----|-----|------------------------|------------------------------|
+| ≤ 50% | 35% | **20%** | **30%** |
+| 50-60% | 35% | **25%** | **35%** |
+| 60-70% | 35% | **30%** | **45%** |
+| 70-80% | 35% | **40%** | **60%** |
+| 80-90% | 75% | **50%** | **75%** |
+| 90-100% | 75% | **70%** | **105%** |
+| > 100% | Cpty RW | Cpty RW | Cpty RW |
 
 ### Commercial Real Estate
 
@@ -176,12 +204,35 @@ This page provides a comprehensive comparison between CRR (Basel 3.0) and Basel 
 | LTV ≤ 60%, Income-Producing | 100% | **70%** |
 | LTV > 60%, Income-Producing | 100% | **110%** |
 
+### ADC Exposures (CRE20.85)
+
+| Type | CRR | Basel 3.1 |
+|------|-----|-----------|
+| Acquisition, Development & Construction | 100% | **150%** |
+
+### Retail Exposures
+
+| Type | CRR | Basel 3.1 |
+|------|-----|-----------|
+| Retail - QRRE (Transactors) | 75% | **45%** |
+| Retail - QRRE (Revolvers) | 75% | 75% |
+| Retail - Other | 75% | 75% |
+
 ### Subordinated Debt
 
 | Type | CRR | Basel 3.1 |
 |------|-----|-----------|
 | Subordinated Debt | 100-150% | **150%** |
 | Equity-like | 150% | **250%** |
+
+### Defaulted Exposures (CRE20.87-90)
+
+| Provision Coverage | CRR | Basel 3.1 |
+|-------------------|-----|-----------|
+| < 20% provisions | 150% | 150% |
+| ≥ 20% provisions | 100% | 100% |
+| RE-secured (< 20%) | 150% | **100%** |
+| RE-secured (≥ 20%) | 100% | **50%** |
 
 ## Credit Conversion Factors
 
@@ -198,32 +249,35 @@ This page provides a comprehensive comparison between CRR (Basel 3.0) and Basel 
 
 ### Project Finance
 
-| Category | CRR | Basel 3.1 (Pre-Op) | Basel 3.1 (Operational) |
-|----------|-----|---------------------|------------------------|
-| Strong | 70% | **80%** | 70% |
-| Good | 70% | **100%** | 70% |
-| Satisfactory | 115% | **120%** | 115% |
-| Weak | 250% | **350%** | 250% |
+| Category | CRR (≥2.5yr) | CRR (<2.5yr) | Basel 3.1 (Pre-Op) | Basel 3.1 (Operational) |
+|----------|--------------|--------------|---------------------|------------------------|
+| Strong | 70% | 50% | **80%** | 70% |
+| Good | 90% | 70% | **100%** | 90% |
+| Satisfactory | 115% | 115% | **120%** | 115% |
+| Weak | 250% | 250% | **350%** | 250% |
+| Default | 0% | 0% | 0% (EL) | 0% (EL) |
 
-### Other Specialised Lending
+### Other Specialised Lending (OF, CF, IPRE)
 
-| Category | CRR | Basel 3.1 |
-|----------|-----|-----------|
-| Strong | 70% | 70% |
-| Good | 70% | 70% |
-| Satisfactory | 115% | 115% |
-| Weak | 250% | 250% |
+| Category | CRR (≥2.5yr) | CRR (<2.5yr) | Basel 3.1 |
+|----------|--------------|--------------|-----------|
+| Strong | 70% | 50% | 70% |
+| Good | 90% | 70% | 90% |
+| Satisfactory | 115% | 115% | 115% |
+| Weak | 250% | 250% | 250% |
+| Default | 0% | 0% | 0% (EL) |
 
 ### HVCRE
 
-| Category | CRR | Basel 3.1 |
-|----------|-----|-----------|
-| Strong | 70% | 95% |
-| Good | 70% | 120% |
-| Satisfactory | 115% | 140% |
-| Weak | 250% | 250% |
+| Category | CRR (≥2.5yr) | CRR (<2.5yr) | Basel 3.1 |
+|----------|--------------|--------------|-----------|
+| Strong | 95% | 70% | 95% |
+| Good | 120% | 95% | 120% |
+| Satisfactory | 140% | 140% | 140% |
+| Weak | 250% | 250% | 250% |
+| Default | 0% | 0% | 0% (EL) |
 
-**Note:** Under CRR, HVCRE uses the same weights as standard specialised lending (Strong=Good=70%).
+**Note:** Under CRR, HVCRE has a separate risk weight table (Art. 153(5) Table 2) with higher weights than non-HVCRE.
 
 ## Impact Analysis
 
@@ -290,8 +344,6 @@ Basel 3.1:
 
     config = CalculationConfig.crr(
         reporting_date=date(2026, 12, 31),
-        apply_sme_supporting_factor=True,
-        apply_infrastructure_factor=True,
     )
 
     # Internally sets:
@@ -309,11 +361,10 @@ Basel 3.1:
 
     config = CalculationConfig.basel_3_1(
         reporting_date=date(2027, 1, 1),
-        output_floor_percentage=0.725,
     )
 
     # Internally sets:
-    # - scaling_factor: 1.0 (none)
+    # - scaling_factor: 1.0 (removed)
     # - output_floor: 72.5%
     # - pd_floors: differentiated by class
     # - lgd_floors: by collateral type

--- a/docs/user-guide/regulatory/crr.md
+++ b/docs/user-guide/regulatory/crr.md
@@ -185,15 +185,29 @@ Where:
 - t = Residual maturity of collateral (years, min 0.25)
 - T = Residual maturity of exposure (years, min 0.25)
 
-## Slotting Risk Weights
+## Slotting Risk Weights (Art. 153(5))
 
-| Category | Strong | Good | Satisfactory | Weak |
-|----------|--------|------|--------------|------|
-| Project Finance | 70% | 90% | 115% | 250% |
-| Object Finance | 70% | 90% | 115% | 250% |
-| Commodities Finance | 70% | 90% | 115% | 250% |
-| IPRE | 70% | 90% | 115% | 250% |
-| HVCRE | 95% | 120% | 140% | 250% |
+CRR Art. 153(5) defines two risk weight tables with maturity-based splits.
+
+### Non-HVCRE (Table 1 — PF, OF, CF, IPRE)
+
+| Category | Remaining Maturity ≥ 2.5yr | Remaining Maturity < 2.5yr |
+|----------|---------------------------|---------------------------|
+| Strong | 70% | 50% |
+| Good | 90% | 70% |
+| Satisfactory | 115% | 115% |
+| Weak | 250% | 250% |
+| Default | 0% | 0% |
+
+### HVCRE (Table 2)
+
+| Category | Remaining Maturity ≥ 2.5yr | Remaining Maturity < 2.5yr |
+|----------|---------------------------|---------------------------|
+| Strong | 95% | 70% |
+| Good | 120% | 95% |
+| Satisfactory | 140% | 140% |
+| Weak | 250% | 250% |
+| Default | 0% | 0% |
 
 ## IRB Formulas
 

--- a/tests/acceptance/crr/conftest.py
+++ b/tests/acceptance/crr/conftest.py
@@ -239,10 +239,10 @@ def crr_ccf() -> dict[str, Decimal]:
 
 @pytest.fixture
 def crr_slotting_rw() -> dict[str, Decimal]:
-    """CRR slotting risk weights."""
+    """CRR slotting risk weights (non-HVCRE, >=2.5yr maturity)."""
     return {
         "strong": Decimal("0.70"),
-        "good": Decimal("0.70"),
+        "good": Decimal("0.90"),
         "satisfactory": Decimal("1.15"),
         "weak": Decimal("2.50"),
         "default": Decimal("0.00"),


### PR DESCRIPTION
This pull request implements major updates to the Basel 3.1 documentation and configuration, aligning the codebase and user/developer guides with the latest PRA implementation of Basel 3.1 (effective 2027 in the UK). The changes cover new and revised risk weights, LGD floors, slotting tables, correlation multipliers, and other regulatory requirements, as well as improvements to the configuration code to support these updates.

**Key changes include:**

### Regulatory and Documentation Updates

* Updated documentation to reflect PRA-specific LGD floors for both Advanced and Foundation IRB, including a new 50% floor for subordinated unsecured exposures and footnotes clarifying differences from BCBS standards. [[1]](diffhunk://#diff-3105b48be9b3b7b35fc33aa8f216cd06c6e10d1beae589b0c824a458d84debe0L40-R59) [[2]](diffhunk://#diff-5a6027638eeac45f8a61f2782af44120c3dbcad0fc4dc2cf7609e9af1672c14bL88-R108) [[3]](diffhunk://#diff-a5ece56ff7ddf68288a12b3d2d127fc87bff95a059448213085d23f3c8efad2aL79-R95)
* Revised and expanded slotting risk weight tables for specialised lending under Basel 3.1, including maturity splits and new tables for HVCRE and project finance, with clear comparison to CRR. [[1]](diffhunk://#diff-3105b48be9b3b7b35fc33aa8f216cd06c6e10d1beae589b0c824a458d84debe0L68-R123) [[2]](diffhunk://#diff-a5ece56ff7ddf68288a12b3d2d127fc87bff95a059448213085d23f3c8efad2aL201-R280) [[3]](diffhunk://#diff-776a365b7e42fab9cb2d35bc4958b25f15cd72761e8f5e82211979703e292f68L188-R210)
* Added new sections for the F-IRB supervisory LGD recalibration, large corporate correlation multiplier (1.25x for >£500m revenue), and A-IRB CCF floor (minimum 50% of SA CCF), updating both user and technical documentation. [[1]](diffhunk://#diff-3105b48be9b3b7b35fc33aa8f216cd06c6e10d1beae589b0c824a458d84debe0L40-R59) [[2]](diffhunk://#diff-5a6027638eeac45f8a61f2782af44120c3dbcad0fc4dc2cf7609e9af1672c14bL88-R108) [[3]](diffhunk://#diff-5a6027638eeac45f8a61f2782af44120c3dbcad0fc4dc2cf7609e9af1672c14bL132-R190) [[4]](diffhunk://#diff-a5ece56ff7ddf68288a12b3d2d127fc87bff95a059448213085d23f3c8efad2aR105-R112)
* Updated SA risk weights, including new corporate sub-categories (investment grade, SME corporate), revised real estate, retail, ADC, and defaulted exposure risk weights, and clarified all changes with detailed tables and references. [[1]](diffhunk://#diff-5a6027638eeac45f8a61f2782af44120c3dbcad0fc4dc2cf7609e9af1672c14bL103-R130) [[2]](diffhunk://#diff-5a6027638eeac45f8a61f2782af44120c3dbcad0fc4dc2cf7609e9af1672c14bL132-R190) [[3]](diffhunk://#diff-a5ece56ff7ddf68288a12b3d2d127fc87bff95a059448213085d23f3c8efad2aL154-R198) [[4]](diffhunk://#diff-a5ece56ff7ddf68288a12b3d2d127fc87bff95a059448213085d23f3c8efad2aR207-R236)

### Codebase and Configuration Enhancements

* Added `subordinated_unsecured` to the `LGDFloors` class in `config.py`, supporting differentiated LGD floors for senior and subordinated unsecured exposures, and updated both `crr` and `basel_3_1` class methods accordingly. [[1]](diffhunk://#diff-ec392d61300ad7481b768c848d799053fef57c8f97929a21e1b1686f6975945aR111) [[2]](diffhunk://#diff-ec392d61300ad7481b768c848d799053fef57c8f97929a21e1b1686f6975945aR134) [[3]](diffhunk://#diff-ec392d61300ad7481b768c848d799053fef57c8f97929a21e1b1686f6975945aL142-R153)
* Updated `CalculationConfig` and related comments to clarify the removal of the 1.06 scaling factor for Basel 3.1 (per PRA CP16/22), and improved documentation of internal settings for output floor and supporting factors. [[1]](diffhunk://#diff-ec392d61300ad7481b768c848d799053fef57c8f97929a21e1b1686f6975945aL444-R453) [[2]](diffhunk://#diff-ec392d61300ad7481b768c848d799053fef57c8f97929a21e1b1686f6975945aL537-R546) [[3]](diffhunk://#diff-5a6027638eeac45f8a61f2782af44120c3dbcad0fc4dc2cf7609e9af1672c14bL245-R297) [[4]](diffhunk://#diff-a5ece56ff7ddf68288a12b3d2d127fc87bff95a059448213085d23f3c8efad2aL293-L294) [[5]](diffhunk://#diff-a5ece56ff7ddf68288a12b3d2d127fc87bff95a059448213085d23f3c8efad2aL312-R367)

### Other Improvements

* Added `"WebSearch"` to the `.claude/settings.local.json` file, enabling broader web search capabilities for the project.

These updates ensure the codebase, documentation, and configuration are fully aligned with the UK PRA's Basel 3.1 implementation, and provide clear guidance and technical support for users and developers.