### PR TITLE
feat(crr): implement provision adjustments for CCF calculation

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -10,7 +10,11 @@
       "Bash(python:*)",
       "WebFetch(domain:www.eba.europa.eu)",
       "WebFetch(domain:www.legislation.gov.uk)",
-      "WebSearch"
+      "WebSearch",
+      "WebFetch(domain:www.bankofengland.co.uk)",
+      "WebFetch(domain:www.katalysys.com)",
+      "WebFetch(domain:www.grantthornton.co.uk)",
+      "WebFetch(domain:eur-lex.europa.eu)"
     ]
   },
   "enabledMcpjsonServers": [

--- a/src/rwa_calc/engine/crm/processor.py
+++ b/src/rwa_calc/engine/crm/processor.py
@@ -164,20 +164,27 @@ class CRMProcessor:
         # Start with all exposures
         exposures = data.all_exposures
 
-        # Step 1: Apply CCF to calculate EAD for contingents
+        # Step 1: Resolve provisions BEFORE CCF (CRR Art. 111(2))
+        # This adds provision_on_drawn, provision_on_nominal, nominal_after_provision
+        # so CCF can use the provision-adjusted nominal amount
+        if self._is_valid_for_processing(data.provisions, self.PROVISION_REQUIRED_COLUMNS):
+            exposures = self.resolve_provisions(exposures, data.provisions, config)
+
+        # Step 2: Apply CCF to calculate EAD for contingents
+        # Uses nominal_after_provision when available
         exposures = self._apply_ccf(exposures, config)
 
-        # Step 2: Initialize EAD columns
+        # Step 3: Initialize EAD columns
         exposures = self._initialize_ead(exposures)
 
-        # Step 3: Apply collateral (if available and valid)
+        # Step 4: Apply collateral (if available and valid)
         if self._is_valid_for_processing(data.collateral, self.COLLATERAL_REQUIRED_COLUMNS):
             exposures = self.apply_collateral(exposures, data.collateral, config)
         else:
             # No collateral: still need to set F-IRB supervisory LGD based on seniority
             exposures = self._apply_firb_supervisory_lgd_no_collateral(exposures)
 
-        # Step 4: Apply guarantees (if available and valid)
+        # Step 5: Apply guarantees (if available and valid)
         if (
             self._is_valid_for_processing(data.guarantees, self.GUARANTEE_REQUIRED_COLUMNS)
             and data.counterparty_lookup is not None
@@ -190,11 +197,8 @@ class CRMProcessor:
                 data.counterparty_lookup.rating_inheritance,
             )
 
-        # Step 5: Apply provisions (if available and valid)
-        if self._is_valid_for_processing(data.provisions, self.PROVISION_REQUIRED_COLUMNS):
-            exposures = self.apply_provisions(exposures, data.provisions, config)
-
         # Step 6: Calculate final EAD after all CRM adjustments
+        # Provisions already baked into ead_pre_crm — no double deduction
         exposures = self._finalize_ead(exposures)
 
         # Step 7: Add CRM audit trail
@@ -259,6 +263,22 @@ class CRMProcessor:
         - pre_crm_counterparty_reference: Original borrower reference
         - pre_crm_exposure_class: Original exposure class before substitution
         """
+        schema = exposures.collect_schema()
+        has_provision_cols = "provision_allocated" in schema.names()
+
+        # Provision columns: preserve if already set by resolve_provisions,
+        # otherwise initialize to zero
+        if has_provision_cols:
+            provision_cols = [
+                pl.col("provision_allocated"),
+                pl.col("provision_deducted"),
+            ]
+        else:
+            provision_cols = [
+                pl.lit(0.0).alias("provision_allocated"),
+                pl.lit(0.0).alias("provision_deducted"),
+            ]
+
         return exposures.with_columns([
             # Pre-CRM attributes for regulatory reporting
             # These capture the original (pre-CRM) state before any substitution
@@ -282,9 +302,8 @@ class CRMProcessor:
             pl.lit(None).cast(pl.String).alias("guarantor_reference"),
             pl.lit(None).cast(pl.Float64).alias("substitute_rw"),
 
-            # Initialize provision-related columns
-            pl.lit(0.0).alias("provision_allocated"),
-            pl.lit(0.0).alias("provision_deducted"),
+            # Provision-related columns
+            *provision_cols,
 
             # LGD for IRB (may be adjusted by collateral)
             pl.col("lgd").fill_null(0.45).alias("lgd_pre_crm"),
@@ -316,19 +335,13 @@ class CRMProcessor:
         """
         Finalize EAD after all CRM adjustments.
 
-        Sets ead_final based on the CRM waterfall:
-        - ead_after_collateral (after collateral reduction)
-        - minus provision deduction
+        Provisions are already baked into ead_pre_crm (deducted before CCF),
+        so finalize_ead does NOT subtract provision_deducted again.
 
-        Also updates ead_after_guarantee for audit trail.
+        Sets ead_final = ead_after_collateral floored at 0.
         """
-        # Use ead_after_collateral if it exists, otherwise ead_gross
         return exposures.with_columns([
-            # Set final EAD after provisions
-            (
-                pl.col("ead_after_collateral") - pl.col("provision_deducted")
-            ).clip(lower_bound=0).alias("ead_final"),
-            # Copy to ead_after_guarantee for audit
+            pl.col("ead_after_collateral").clip(lower_bound=0).alias("ead_final"),
             pl.col("ead_after_collateral").alias("ead_after_guarantee"),
         ])
 
@@ -1266,12 +1279,33 @@ class CRMProcessor:
         ])
 
         # Recalculate EAD with split CCFs when cross-approach substitution applies
-        on_bal = on_balance_ead() if has_interest else drawn_for_ead()
+        # Use provision-adjusted on-balance and nominal when available
+        has_provision_cols = "provision_on_drawn" in schema.names()
+
+        if has_provision_cols and has_interest:
+            on_bal = (
+                drawn_for_ead() - pl.col("provision_on_drawn")
+            ).clip(lower_bound=0.0) + pl.col("interest").fill_null(0.0)
+        elif has_provision_cols:
+            on_bal = (
+                drawn_for_ead() - pl.col("provision_on_drawn")
+            ).clip(lower_bound=0.0)
+        elif has_interest:
+            on_bal = on_balance_ead()
+        else:
+            on_bal = drawn_for_ead()
+
+        # Use nominal_after_provision if available, else nominal_amount
+        nominal_col = (
+            pl.col("nominal_after_provision")
+            if "nominal_after_provision" in schema.names()
+            else pl.col("nominal_amount")
+        )
         ratio = pl.col("guarantee_ratio")
 
-        new_guaranteed = (on_bal * ratio) + (pl.col("nominal_amount") * ratio * pl.col("ccf_guaranteed"))
+        new_guaranteed = (on_bal * ratio) + (nominal_col * ratio * pl.col("ccf_guaranteed"))
         new_unguaranteed = (on_bal * (pl.lit(1.0) - ratio)) + (
-            pl.col("nominal_amount") * (pl.lit(1.0) - ratio) * pl.col("ccf_unguaranteed")
+            nominal_col * (pl.lit(1.0) - ratio) * pl.col("ccf_unguaranteed")
         )
 
         exposures = exposures.with_columns([
@@ -1295,12 +1329,262 @@ class CRMProcessor:
 
             pl.when(needs_ccf_sub)
             .then(
-                pl.col("nominal_amount") * ratio * pl.col("ccf_guaranteed")
-                + pl.col("nominal_amount") * (pl.lit(1.0) - ratio) * pl.col("ccf_unguaranteed")
+                nominal_col * ratio * pl.col("ccf_guaranteed")
+                + nominal_col * (pl.lit(1.0) - ratio) * pl.col("ccf_unguaranteed")
             )
             .otherwise(pl.col("ead_from_ccf"))
             .alias("ead_from_ccf"),
         ])
+
+        return exposures
+
+    def resolve_provisions(
+        self,
+        exposures: pl.LazyFrame,
+        provisions: pl.LazyFrame,
+        config: CalculationConfig,
+    ) -> pl.LazyFrame:
+        """
+        Resolve provisions with multi-level beneficiary and drawn-first deduction.
+
+        This is called *before* CCF so that nominal_after_provision feeds into
+        the CCF calculation: ``ead_from_ccf = nominal_after_provision * ccf``.
+
+        Resolution levels (based on beneficiary_type):
+        1. Direct (loan/exposure/contingent): join on exposure_reference
+        2. Facility: join on parent_facility_reference, pro-rata by exposure weight
+        3. Counterparty: join on counterparty_reference, pro-rata by exposure weight
+
+        SA drawn-first deduction (CRR Art. 111(2)):
+        - ``floored_drawn = max(0, drawn_amount)``
+        - ``provision_on_drawn = min(provision_allocated, floored_drawn)``
+        - ``provision_on_nominal = min(remainder, nominal_amount)``
+        - Interest is never reduced by provision.
+
+        IRB/Slotting: provision_on_drawn=0, provision_on_nominal=0 (provisions
+        feed into EL shortfall/excess instead). provision_allocated is tracked.
+
+        Args:
+            exposures: Exposures with drawn_amount, interest, nominal_amount, approach
+            provisions: Provision data with beneficiary_reference, amount,
+                        and optionally beneficiary_type
+            config: Calculation configuration
+
+        Returns:
+            Exposures with provision_allocated, provision_on_drawn,
+            provision_on_nominal, provision_deducted, nominal_after_provision
+        """
+        prov_schema = provisions.collect_schema()
+        exp_schema = exposures.collect_schema()
+        has_beneficiary_type = "beneficiary_type" in prov_schema.names()
+        has_parent_facility = "parent_facility_reference" in exp_schema.names()
+
+        if has_beneficiary_type:
+            exposures = self._resolve_provisions_multi_level(
+                exposures, provisions, has_parent_facility
+            )
+        else:
+            # Fallback: direct-only join (backward compat)
+            provisions_agg = provisions.group_by("beneficiary_reference").agg(
+                pl.col("amount").sum().alias("provision_allocated"),
+            )
+            exposures = exposures.join(
+                provisions_agg,
+                left_on="exposure_reference",
+                right_on="beneficiary_reference",
+                how="left",
+            ).with_columns(
+                pl.col("provision_allocated").fill_null(0.0),
+            )
+
+        # --- SA drawn-first deduction; IRB/Slotting: no deduction ---
+        is_sa = pl.col("approach") == ApproachType.SA.value
+
+        floored_drawn = pl.col("drawn_amount").clip(lower_bound=0.0)
+
+        # provision_on_drawn: min(allocated, floored_drawn) for SA; 0 for IRB
+        provision_on_drawn = (
+            pl.when(is_sa)
+            .then(pl.min_horizontal("provision_allocated", floored_drawn))
+            .otherwise(pl.lit(0.0))
+        )
+
+        exposures = exposures.with_columns(
+            provision_on_drawn.alias("provision_on_drawn"),
+        )
+
+        # provision_on_nominal: min(remaining, nominal) for SA; 0 for IRB
+        remaining = (pl.col("provision_allocated") - pl.col("provision_on_drawn")).clip(lower_bound=0.0)
+        provision_on_nominal = (
+            pl.when(is_sa)
+            .then(pl.min_horizontal(remaining, pl.col("nominal_amount")))
+            .otherwise(pl.lit(0.0))
+        )
+
+        exposures = exposures.with_columns(
+            provision_on_nominal.alias("provision_on_nominal"),
+        )
+
+        # provision_deducted = on_drawn + on_nominal
+        exposures = exposures.with_columns(
+            (pl.col("provision_on_drawn") + pl.col("provision_on_nominal"))
+            .alias("provision_deducted"),
+        )
+
+        # nominal_after_provision for CCF: nominal - provision_on_nominal
+        exposures = exposures.with_columns(
+            (pl.col("nominal_amount") - pl.col("provision_on_nominal"))
+            .alias("nominal_after_provision"),
+        )
+
+        return exposures
+
+    def _resolve_provisions_multi_level(
+        self,
+        exposures: pl.LazyFrame,
+        provisions: pl.LazyFrame,
+        has_parent_facility: bool,
+    ) -> pl.LazyFrame:
+        """
+        Resolve provisions from direct, facility, and counterparty levels.
+
+        For facility and counterparty levels, provisions are allocated pro-rata
+        based on ``max(0, drawn) + interest + nominal`` as the weight proxy.
+
+        Args:
+            exposures: Exposures LazyFrame
+            provisions: Provisions with beneficiary_type column
+            has_parent_facility: Whether exposures have parent_facility_reference
+
+        Returns:
+            Exposures with provision_allocated column added
+        """
+        bt_lower = pl.col("beneficiary_type").str.to_lowercase()
+
+        # --- 1. Direct-level provisions ---
+        direct_types = ["loan", "exposure", "contingent"]
+        direct_provs = (
+            provisions
+            .filter(bt_lower.is_in(direct_types))
+            .group_by("beneficiary_reference")
+            .agg(pl.col("amount").sum().alias("_prov_direct"))
+        )
+
+        exposures = exposures.join(
+            direct_provs,
+            left_on="exposure_reference",
+            right_on="beneficiary_reference",
+            how="left",
+        ).with_columns(pl.col("_prov_direct").fill_null(0.0))
+
+        # --- Compute exposure weight for pro-rata allocation ---
+        weight_expr = (
+            pl.col("drawn_amount").clip(lower_bound=0.0)
+            + pl.col("interest").fill_null(0.0)
+            + pl.col("nominal_amount")
+        )
+        exposures = exposures.with_columns(weight_expr.alias("_exp_weight"))
+
+        # --- 2. Facility-level provisions ---
+        if has_parent_facility:
+            fac_provs = (
+                provisions
+                .filter(bt_lower == "facility")
+                .group_by("beneficiary_reference")
+                .agg(pl.col("amount").sum().alias("_prov_facility"))
+            )
+
+            fac_totals = (
+                exposures
+                .filter(pl.col("parent_facility_reference").is_not_null())
+                .group_by("parent_facility_reference")
+                .agg(pl.col("_exp_weight").sum().alias("_fac_total_weight"))
+            )
+
+            exposures = (
+                exposures
+                .join(
+                    fac_provs,
+                    left_on="parent_facility_reference",
+                    right_on="beneficiary_reference",
+                    how="left",
+                )
+                .join(fac_totals, on="parent_facility_reference", how="left")
+                .with_columns([
+                    pl.col("_prov_facility").fill_null(0.0),
+                    pl.col("_fac_total_weight").fill_null(0.0),
+                ])
+                .with_columns(
+                    pl.when(pl.col("_fac_total_weight") > 0)
+                    .then(
+                        pl.col("_prov_facility")
+                        * pl.col("_exp_weight")
+                        / pl.col("_fac_total_weight")
+                    )
+                    .otherwise(pl.lit(0.0))
+                    .alias("_prov_facility_alloc"),
+                )
+            )
+        else:
+            exposures = exposures.with_columns(pl.lit(0.0).alias("_prov_facility_alloc"))
+
+        # --- 3. Counterparty-level provisions ---
+        cp_provs = (
+            provisions
+            .filter(bt_lower == "counterparty")
+            .group_by("beneficiary_reference")
+            .agg(pl.col("amount").sum().alias("_prov_cp"))
+        )
+
+        cp_totals = (
+            exposures
+            .group_by("counterparty_reference")
+            .agg(pl.col("_exp_weight").sum().alias("_cp_total_weight"))
+        )
+
+        exposures = (
+            exposures
+            .join(
+                cp_provs,
+                left_on="counterparty_reference",
+                right_on="beneficiary_reference",
+                how="left",
+            )
+            .join(cp_totals, on="counterparty_reference", how="left")
+            .with_columns([
+                pl.col("_prov_cp").fill_null(0.0),
+                pl.col("_cp_total_weight").fill_null(0.0),
+            ])
+            .with_columns(
+                pl.when(pl.col("_cp_total_weight") > 0)
+                .then(
+                    pl.col("_prov_cp")
+                    * pl.col("_exp_weight")
+                    / pl.col("_cp_total_weight")
+                )
+                .otherwise(pl.lit(0.0))
+                .alias("_prov_cp_alloc"),
+            )
+        )
+
+        # --- Combine all levels ---
+        exposures = exposures.with_columns(
+            (
+                pl.col("_prov_direct")
+                + pl.col("_prov_facility_alloc")
+                + pl.col("_prov_cp_alloc")
+            ).alias("provision_allocated"),
+        )
+
+        # --- Drop temporary columns ---
+        drop_cols = [
+            "_prov_direct", "_exp_weight",
+            "_prov_facility_alloc", "_prov_cp_alloc",
+            "_prov_cp", "_cp_total_weight",
+        ]
+        if has_parent_facility:
+            drop_cols.extend(["_prov_facility", "_fac_total_weight"])
+        exposures = exposures.drop(drop_cols)
 
         return exposures
 
@@ -1311,10 +1595,10 @@ class CRMProcessor:
         config: CalculationConfig,
     ) -> pl.LazyFrame:
         """
-        Apply provision deduction from EAD.
+        Apply provision deduction from EAD (legacy method).
 
-        For SA, specific provisions are deducted from EAD.
-        For IRB, provisions are compared to EL for shortfall/excess.
+        Delegates to resolve_provisions for the full multi-level resolution
+        and drawn-first deduction logic.
 
         Args:
             exposures: Exposures with EAD
@@ -1324,36 +1608,7 @@ class CRMProcessor:
         Returns:
             Exposures with provision effects applied
         """
-        # Aggregate provisions by beneficiary (exposure)
-        provisions_by_exposure = provisions.group_by(
-            "beneficiary_reference"
-        ).agg([
-            pl.col("amount").sum().alias("total_provision"),
-            pl.col("provision_type").first().alias("primary_provision_type"),
-        ])
-
-        # Join provisions to exposures
-        exposures = exposures.join(
-            provisions_by_exposure,
-            left_on="exposure_reference",
-            right_on="beneficiary_reference",
-            how="left",
-        )
-
-        # Fill nulls and update provision columns
-        exposures = exposures.with_columns([
-            pl.col("total_provision").fill_null(0.0).alias("provision_allocated"),
-        ])
-
-        # Calculate provision deduction (for SA, deduct from EAD)
-        exposures = exposures.with_columns([
-            pl.when(pl.col("approach") == ApproachType.SA.value)
-            .then(pl.col("provision_allocated"))
-            .otherwise(pl.lit(0.0))
-            .alias("provision_deducted"),
-        ])
-
-        return exposures
+        return self.resolve_provisions(exposures, provisions, config)
 
     def _add_crm_audit(
         self,

--- a/tests/unit/crm/test_provisions.py
+++ b/tests/unit/crm/test_provisions.py
@@ -1,0 +1,548 @@
+"""Unit tests for provision resolution in CRM processor.
+
+Tests cover:
+- Direct-level provision (loan → exposure_reference match)
+- Facility-level pro-rata allocation across child exposures
+- Counterparty-level pro-rata allocation
+- Drawn-first deduction (on-balance only loan: provision fully absorbed by drawn)
+- OBS-only deduction (contingent with drawn=0)
+- Mixed drawn+undrawn where provision spills from drawn to nominal
+- Provision exceeding total exposure (capped)
+- Negative drawn amount handling
+- IRB provisions: provision_deducted=0 but provision_allocated tracked
+- SA-only deduction: mixed SA/IRB exposures
+- No beneficiary_type column fallback (backward compat)
+
+References:
+- CRR Art. 110: Specific provisions reduce exposure value
+- CRR Art. 111(2): SCRAs deducted from nominal *before* CCF
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import polars as pl
+import pytest
+
+from rwa_calc.contracts.config import CalculationConfig, IRBPermissions
+from rwa_calc.domain.enums import ApproachType
+from rwa_calc.engine.crm.processor import CRMProcessor
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def crr_config() -> CalculationConfig:
+    """Return a CRR configuration with SA-only permissions."""
+    return CalculationConfig.crr(
+        reporting_date=date(2024, 12, 31),
+        irb_permissions=IRBPermissions.sa_only(),
+    )
+
+
+@pytest.fixture
+def irb_config() -> CalculationConfig:
+    """Return a CRR configuration with full IRB permissions."""
+    return CalculationConfig.crr(
+        reporting_date=date(2024, 12, 31),
+        irb_permissions=IRBPermissions.full_irb(),
+    )
+
+
+@pytest.fixture
+def processor() -> CRMProcessor:
+    """Return a CRM processor instance."""
+    return CRMProcessor()
+
+
+def _make_exposures(**overrides) -> pl.LazyFrame:
+    """Helper to create a single-row exposure LazyFrame with sensible defaults."""
+    defaults = {
+        "exposure_reference": "EXP001",
+        "counterparty_reference": "CP001",
+        "parent_facility_reference": "FAC001",
+        "drawn_amount": 500_000.0,
+        "interest": 5_000.0,
+        "nominal_amount": 500_000.0,
+        "approach": ApproachType.SA.value,
+        "risk_type": "MR",
+        "exposure_class": "corporate",
+        "lgd": 0.45,
+        "seniority": "senior",
+    }
+    defaults.update(overrides)
+
+    # Support lists for multi-row
+    if isinstance(defaults["exposure_reference"], list):
+        return pl.LazyFrame(defaults)
+    return pl.LazyFrame({k: [v] for k, v in defaults.items()})
+
+
+def _make_provisions(rows: list[dict]) -> pl.LazyFrame:
+    """Helper to create provisions LazyFrame."""
+    return pl.LazyFrame(rows)
+
+
+# =============================================================================
+# Direct-level provision tests
+# =============================================================================
+
+
+class TestDirectLevelProvision:
+    """Provisions that reference an exposure directly (beneficiary_type=loan)."""
+
+    def test_direct_provision_allocates_to_matching_exposure(
+        self, processor: CRMProcessor, crr_config: CalculationConfig
+    ) -> None:
+        """Direct provision should match on exposure_reference."""
+        exposures = _make_exposures(
+            drawn_amount=1_000_000.0, interest=0.0, nominal_amount=0.0
+        )
+        provisions = _make_provisions([{
+            "provision_reference": "P1",
+            "beneficiary_reference": "EXP001",
+            "beneficiary_type": "loan",
+            "amount": 50_000.0,
+            "provision_type": "SCRA",
+        }])
+
+        result = processor.resolve_provisions(exposures, provisions, crr_config).collect()
+
+        assert result["provision_allocated"][0] == pytest.approx(50_000.0)
+        assert result["provision_deducted"][0] == pytest.approx(50_000.0)
+
+    def test_direct_provision_drawn_first_deduction(
+        self, processor: CRMProcessor, crr_config: CalculationConfig
+    ) -> None:
+        """Provision should reduce drawn first before touching nominal."""
+        exposures = _make_exposures(
+            drawn_amount=800_000.0, interest=10_000.0, nominal_amount=200_000.0
+        )
+        provisions = _make_provisions([{
+            "provision_reference": "P1",
+            "beneficiary_reference": "EXP001",
+            "beneficiary_type": "loan",
+            "amount": 50_000.0,
+            "provision_type": "SCRA",
+        }])
+
+        result = processor.resolve_provisions(exposures, provisions, crr_config).collect()
+
+        # 50k fully absorbed by drawn (800k available)
+        assert result["provision_on_drawn"][0] == pytest.approx(50_000.0)
+        assert result["provision_on_nominal"][0] == pytest.approx(0.0)
+        assert result["nominal_after_provision"][0] == pytest.approx(200_000.0)
+
+    def test_provision_spills_from_drawn_to_nominal(
+        self, processor: CRMProcessor, crr_config: CalculationConfig
+    ) -> None:
+        """When provision exceeds drawn, remainder reduces nominal."""
+        exposures = _make_exposures(
+            drawn_amount=30_000.0, interest=5_000.0, nominal_amount=200_000.0
+        )
+        provisions = _make_provisions([{
+            "provision_reference": "P1",
+            "beneficiary_reference": "EXP001",
+            "beneficiary_type": "loan",
+            "amount": 50_000.0,
+            "provision_type": "SCRA",
+        }])
+
+        result = processor.resolve_provisions(exposures, provisions, crr_config).collect()
+
+        # 30k absorbed by drawn, 20k spills to nominal
+        assert result["provision_on_drawn"][0] == pytest.approx(30_000.0)
+        assert result["provision_on_nominal"][0] == pytest.approx(20_000.0)
+        assert result["nominal_after_provision"][0] == pytest.approx(180_000.0)
+
+
+# =============================================================================
+# OBS-only deduction tests
+# =============================================================================
+
+
+class TestOBSOnlyProvision:
+    """Provisions applied to off-balance-sheet (contingent) items with drawn=0."""
+
+    def test_obs_only_provision_reduces_nominal(
+        self, processor: CRMProcessor, crr_config: CalculationConfig
+    ) -> None:
+        """Contingent with drawn=0: provision goes entirely to nominal."""
+        exposures = _make_exposures(
+            drawn_amount=0.0, interest=0.0, nominal_amount=500_000.0
+        )
+        provisions = _make_provisions([{
+            "provision_reference": "P1",
+            "beneficiary_reference": "EXP001",
+            "beneficiary_type": "loan",
+            "amount": 20_000.0,
+            "provision_type": "SCRA",
+        }])
+
+        result = processor.resolve_provisions(exposures, provisions, crr_config).collect()
+
+        assert result["provision_on_drawn"][0] == pytest.approx(0.0)
+        assert result["provision_on_nominal"][0] == pytest.approx(20_000.0)
+        assert result["nominal_after_provision"][0] == pytest.approx(480_000.0)
+
+
+# =============================================================================
+# Provision capping tests
+# =============================================================================
+
+
+class TestProvisionCapping:
+    """Provisions exceeding total exposure should be capped."""
+
+    def test_provision_exceeding_total_exposure_is_capped(
+        self, processor: CRMProcessor, crr_config: CalculationConfig
+    ) -> None:
+        """Provision cannot exceed drawn + nominal."""
+        exposures = _make_exposures(
+            drawn_amount=50_000.0, interest=0.0, nominal_amount=50_000.0
+        )
+        provisions = _make_provisions([{
+            "provision_reference": "P1",
+            "beneficiary_reference": "EXP001",
+            "beneficiary_type": "loan",
+            "amount": 200_000.0,
+            "provision_type": "SCRA",
+        }])
+
+        result = processor.resolve_provisions(exposures, provisions, crr_config).collect()
+
+        # Capped: 50k on drawn + 50k on nominal = 100k total
+        assert result["provision_on_drawn"][0] == pytest.approx(50_000.0)
+        assert result["provision_on_nominal"][0] == pytest.approx(50_000.0)
+        assert result["provision_deducted"][0] == pytest.approx(100_000.0)
+        assert result["nominal_after_provision"][0] == pytest.approx(0.0)
+
+
+# =============================================================================
+# Negative drawn amount tests
+# =============================================================================
+
+
+class TestNegativeDrawnAmount:
+    """Negative drawn (credit balance) should not absorb provision."""
+
+    def test_negative_drawn_provision_goes_to_nominal(
+        self, processor: CRMProcessor, crr_config: CalculationConfig
+    ) -> None:
+        """Negative drawn floored to 0 → provision reduces nominal only."""
+        exposures = _make_exposures(
+            drawn_amount=-50_000.0, interest=5_000.0, nominal_amount=200_000.0
+        )
+        provisions = _make_provisions([{
+            "provision_reference": "P1",
+            "beneficiary_reference": "EXP001",
+            "beneficiary_type": "loan",
+            "amount": 30_000.0,
+            "provision_type": "SCRA",
+        }])
+
+        result = processor.resolve_provisions(exposures, provisions, crr_config).collect()
+
+        # Floored drawn is 0 → no absorption
+        assert result["provision_on_drawn"][0] == pytest.approx(0.0)
+        assert result["provision_on_nominal"][0] == pytest.approx(30_000.0)
+        assert result["nominal_after_provision"][0] == pytest.approx(170_000.0)
+
+
+# =============================================================================
+# IRB provision tests
+# =============================================================================
+
+
+class TestIRBProvisions:
+    """IRB provisions: allocated but NOT deducted from EAD."""
+
+    def test_irb_provision_not_deducted(
+        self, processor: CRMProcessor, irb_config: CalculationConfig
+    ) -> None:
+        """F-IRB exposure: provision_deducted=0, provision_allocated tracked."""
+        exposures = _make_exposures(
+            approach=ApproachType.FIRB.value,
+            drawn_amount=1_000_000.0, interest=0.0, nominal_amount=0.0
+        )
+        provisions = _make_provisions([{
+            "provision_reference": "P1",
+            "beneficiary_reference": "EXP001",
+            "beneficiary_type": "loan",
+            "amount": 50_000.0,
+            "provision_type": "SCRA",
+        }])
+
+        result = processor.resolve_provisions(exposures, provisions, irb_config).collect()
+
+        assert result["provision_allocated"][0] == pytest.approx(50_000.0)
+        assert result["provision_deducted"][0] == pytest.approx(0.0)
+        assert result["provision_on_drawn"][0] == pytest.approx(0.0)
+        assert result["provision_on_nominal"][0] == pytest.approx(0.0)
+        assert result["nominal_after_provision"][0] == pytest.approx(0.0)  # nominal stays 0
+
+    def test_slotting_provision_not_deducted(
+        self, processor: CRMProcessor, irb_config: CalculationConfig
+    ) -> None:
+        """Slotting exposure: provision_deducted=0."""
+        exposures = _make_exposures(
+            approach=ApproachType.SLOTTING.value,
+            drawn_amount=1_000_000.0, interest=0.0, nominal_amount=500_000.0
+        )
+        provisions = _make_provisions([{
+            "provision_reference": "P1",
+            "beneficiary_reference": "EXP001",
+            "beneficiary_type": "loan",
+            "amount": 100_000.0,
+            "provision_type": "SCRA",
+        }])
+
+        result = processor.resolve_provisions(exposures, provisions, irb_config).collect()
+
+        assert result["provision_allocated"][0] == pytest.approx(100_000.0)
+        assert result["provision_deducted"][0] == pytest.approx(0.0)
+        assert result["nominal_after_provision"][0] == pytest.approx(500_000.0)
+
+
+# =============================================================================
+# Mixed SA/IRB tests
+# =============================================================================
+
+
+class TestMixedSAIRBProvisions:
+    """Mixed SA/IRB exposures: only SA gets provision_deducted > 0."""
+
+    def test_sa_irb_mixed_deduction(
+        self, processor: CRMProcessor, irb_config: CalculationConfig
+    ) -> None:
+        """Only SA exposure gets deduction; IRB gets allocated but not deducted."""
+        exposures = _make_exposures(
+            exposure_reference=["EXP_SA", "EXP_IRB"],
+            counterparty_reference=["CP001", "CP002"],
+            parent_facility_reference=["FAC001", "FAC002"],
+            drawn_amount=[500_000.0, 500_000.0],
+            interest=[0.0, 0.0],
+            nominal_amount=[0.0, 0.0],
+            approach=[ApproachType.SA.value, ApproachType.FIRB.value],
+            risk_type=["MR", "MR"],
+            exposure_class=["corporate", "corporate"],
+            lgd=[0.45, 0.45],
+            seniority=["senior", "senior"],
+        )
+        provisions = _make_provisions([
+            {
+                "provision_reference": "P1",
+                "beneficiary_reference": "EXP_SA",
+                "beneficiary_type": "loan",
+                "amount": 50_000.0,
+                "provision_type": "SCRA",
+            },
+            {
+                "provision_reference": "P2",
+                "beneficiary_reference": "EXP_IRB",
+                "beneficiary_type": "loan",
+                "amount": 50_000.0,
+                "provision_type": "SCRA",
+            },
+        ])
+
+        result = processor.resolve_provisions(exposures, provisions, irb_config).collect()
+
+        sa_row = result.filter(pl.col("exposure_reference") == "EXP_SA")
+        irb_row = result.filter(pl.col("exposure_reference") == "EXP_IRB")
+
+        assert sa_row["provision_deducted"][0] == pytest.approx(50_000.0)
+        assert irb_row["provision_deducted"][0] == pytest.approx(0.0)
+        assert irb_row["provision_allocated"][0] == pytest.approx(50_000.0)
+
+
+# =============================================================================
+# Facility-level provision tests
+# =============================================================================
+
+
+class TestFacilityLevelProvision:
+    """Provisions referencing a facility, pro-rata allocated to child exposures."""
+
+    def test_facility_provision_allocated_pro_rata(
+        self, processor: CRMProcessor, crr_config: CalculationConfig
+    ) -> None:
+        """Facility-level provision should be allocated pro-rata by exposure weight."""
+        # Two exposures under the same facility
+        exposures = _make_exposures(
+            exposure_reference=["EXP_A", "EXP_B"],
+            counterparty_reference=["CP001", "CP001"],
+            parent_facility_reference=["FAC001", "FAC001"],
+            drawn_amount=[600_000.0, 400_000.0],  # 60:40 ratio
+            interest=[0.0, 0.0],
+            nominal_amount=[0.0, 0.0],
+            approach=[ApproachType.SA.value, ApproachType.SA.value],
+            risk_type=["MR", "MR"],
+            exposure_class=["corporate", "corporate"],
+            lgd=[0.45, 0.45],
+            seniority=["senior", "senior"],
+        )
+        provisions = _make_provisions([{
+            "provision_reference": "P1",
+            "beneficiary_reference": "FAC001",
+            "beneficiary_type": "facility",
+            "amount": 100_000.0,
+            "provision_type": "SCRA",
+        }])
+
+        result = processor.resolve_provisions(exposures, provisions, crr_config).collect()
+
+        exp_a = result.filter(pl.col("exposure_reference") == "EXP_A")
+        exp_b = result.filter(pl.col("exposure_reference") == "EXP_B")
+
+        # Pro-rata: 60% of 100k = 60k; 40% of 100k = 40k
+        assert exp_a["provision_allocated"][0] == pytest.approx(60_000.0)
+        assert exp_b["provision_allocated"][0] == pytest.approx(40_000.0)
+
+
+# =============================================================================
+# Counterparty-level provision tests
+# =============================================================================
+
+
+class TestCounterpartyLevelProvision:
+    """Provisions referencing a counterparty, pro-rata allocated."""
+
+    def test_counterparty_provision_allocated_pro_rata(
+        self, processor: CRMProcessor, crr_config: CalculationConfig
+    ) -> None:
+        """Counterparty-level provision should be pro-rata allocated."""
+        exposures = _make_exposures(
+            exposure_reference=["EXP_A", "EXP_B"],
+            counterparty_reference=["CP001", "CP001"],
+            parent_facility_reference=["FAC001", "FAC002"],
+            drawn_amount=[700_000.0, 300_000.0],  # 70:30 ratio
+            interest=[0.0, 0.0],
+            nominal_amount=[0.0, 0.0],
+            approach=[ApproachType.SA.value, ApproachType.SA.value],
+            risk_type=["MR", "MR"],
+            exposure_class=["corporate", "corporate"],
+            lgd=[0.45, 0.45],
+            seniority=["senior", "senior"],
+        )
+        provisions = _make_provisions([{
+            "provision_reference": "P1",
+            "beneficiary_reference": "CP001",
+            "beneficiary_type": "counterparty",
+            "amount": 100_000.0,
+            "provision_type": "SCRA",
+        }])
+
+        result = processor.resolve_provisions(exposures, provisions, crr_config).collect()
+
+        exp_a = result.filter(pl.col("exposure_reference") == "EXP_A")
+        exp_b = result.filter(pl.col("exposure_reference") == "EXP_B")
+
+        assert exp_a["provision_allocated"][0] == pytest.approx(70_000.0)
+        assert exp_b["provision_allocated"][0] == pytest.approx(30_000.0)
+
+
+# =============================================================================
+# No beneficiary_type fallback (backward compat)
+# =============================================================================
+
+
+class TestNoBeneficiaryTypeFallback:
+    """When beneficiary_type column is absent, fall back to direct join only."""
+
+    def test_no_beneficiary_type_direct_join(
+        self, processor: CRMProcessor, crr_config: CalculationConfig
+    ) -> None:
+        """Provisions without beneficiary_type column use direct exposure join."""
+        exposures = _make_exposures(
+            drawn_amount=1_000_000.0, interest=0.0, nominal_amount=0.0
+        )
+        # No beneficiary_type column
+        provisions = _make_provisions([{
+            "provision_reference": "P1",
+            "beneficiary_reference": "EXP001",
+            "amount": 50_000.0,
+            "provision_type": "SCRA",
+        }])
+
+        result = processor.resolve_provisions(exposures, provisions, crr_config).collect()
+
+        assert result["provision_allocated"][0] == pytest.approx(50_000.0)
+        assert result["provision_deducted"][0] == pytest.approx(50_000.0)
+
+
+# =============================================================================
+# Exposure with no matching provision
+# =============================================================================
+
+
+class TestNoMatchingProvision:
+    """Exposures without matching provisions should get zeros."""
+
+    def test_no_provision_all_zeros(
+        self, processor: CRMProcessor, crr_config: CalculationConfig
+    ) -> None:
+        """Exposure with no matching provision gets all-zero provision columns."""
+        exposures = _make_exposures(
+            drawn_amount=500_000.0, interest=0.0, nominal_amount=200_000.0
+        )
+        provisions = _make_provisions([{
+            "provision_reference": "P1",
+            "beneficiary_reference": "NO_MATCH",
+            "beneficiary_type": "loan",
+            "amount": 50_000.0,
+            "provision_type": "SCRA",
+        }])
+
+        result = processor.resolve_provisions(exposures, provisions, crr_config).collect()
+
+        assert result["provision_allocated"][0] == pytest.approx(0.0)
+        assert result["provision_deducted"][0] == pytest.approx(0.0)
+        assert result["provision_on_drawn"][0] == pytest.approx(0.0)
+        assert result["provision_on_nominal"][0] == pytest.approx(0.0)
+        assert result["nominal_after_provision"][0] == pytest.approx(200_000.0)
+
+
+# =============================================================================
+# Multiple provisions combining
+# =============================================================================
+
+
+class TestMultipleProvisions:
+    """Multiple provisions for the same exposure should sum."""
+
+    def test_multiple_provisions_summed(
+        self, processor: CRMProcessor, crr_config: CalculationConfig
+    ) -> None:
+        """Two direct provisions should sum before drawn-first deduction."""
+        exposures = _make_exposures(
+            drawn_amount=100_000.0, interest=0.0, nominal_amount=200_000.0
+        )
+        provisions = _make_provisions([
+            {
+                "provision_reference": "P1",
+                "beneficiary_reference": "EXP001",
+                "beneficiary_type": "loan",
+                "amount": 60_000.0,
+                "provision_type": "SCRA",
+            },
+            {
+                "provision_reference": "P2",
+                "beneficiary_reference": "EXP001",
+                "beneficiary_type": "loan",
+                "amount": 80_000.0,
+                "provision_type": "SCRA",
+            },
+        ])
+
+        result = processor.resolve_provisions(exposures, provisions, crr_config).collect()
+
+        # Total = 140k. Drawn=100k absorbs 100k, remaining 40k → nominal
+        assert result["provision_allocated"][0] == pytest.approx(140_000.0)
+        assert result["provision_on_drawn"][0] == pytest.approx(100_000.0)
+        assert result["provision_on_nominal"][0] == pytest.approx(40_000.0)
+        assert result["nominal_after_provision"][0] == pytest.approx(160_000.0)


### PR DESCRIPTION
This pull request implements a significant change to the Credit Risk Mitigation (CRM) pipeline: provisions are now resolved and deducted before Credit Conversion Factor (CCF) application, in line with CRR Article 111(2). This ensures that provisioned amounts are excluded from CCF calculations, preventing double deduction and improving regulatory compliance. The CRM namespace API is updated to reflect this new flow, and legacy provision application is retained for backward compatibility. Additional improvements include enhanced handling of provision columns and updates to documentation.

**CRM pipeline and provision handling:**

- Provisions are now resolved and deducted before CCF is applied, ensuring that `nominal_after_provision` is used in the CCF calculation and that provisions are not double-counted. This affects both the namespace (`src/rwa_calc/engine/crm/namespace.py`) and processor (`src/rwa_calc/engine/crm/processor.py`) logic. [[1]](diffhunk://#diff-9ea68eb315ecb7107d703b8dc1d1288d5075a272e577ce102ee3fe11677a9ba4R222-R255) [[2]](diffhunk://#diff-cca92be6729e59c6b591fe143dbcab378481b8338a33ed574fd1841f307b3d4eL483-R564) [[3]](diffhunk://#diff-5dec8ac5620ec081b2d95fdf70da54c896e5febcfba6e9c6d626e524753f9950L167-R187) [[4]](diffhunk://#diff-5dec8ac5620ec081b2d95fdf70da54c896e5febcfba6e9c6d626e524753f9950L193-R201)
- The CRM pipeline order is updated: provisions are resolved first, followed by EAD initialization, collateral, guarantees, and finalization. Provision deduction is no longer performed in the finalization step, as it is already included in `ead_pre_crm`. [[1]](diffhunk://#diff-cca92be6729e59c6b591fe143dbcab378481b8338a33ed574fd1841f307b3d4eL599-R616) [[2]](diffhunk://#diff-cca92be6729e59c6b591fe143dbcab378481b8338a33ed574fd1841f307b3d4eL616-L626) [[3]](diffhunk://#diff-cca92be6729e59c6b591fe143dbcab378481b8338a33ed574fd1841f307b3d4eL551-R575) [[4]](diffhunk://#diff-cca92be6729e59c6b591fe143dbcab378481b8338a33ed574fd1841f307b3d4eL568-R591) [[5]](diffhunk://#diff-5dec8ac5620ec081b2d95fdf70da54c896e5febcfba6e9c6d626e524753f9950L319-R344)

**Provision column management:**

- Provision-related columns (`provision_allocated`, `provision_deducted`) are now preserved if already set, or initialized to zero otherwise, both in the CRM namespace and processor. This ensures correct propagation of provision data throughout the pipeline. [[1]](diffhunk://#diff-cca92be6729e59c6b591fe143dbcab378481b8338a33ed574fd1841f307b3d4eR92-R123) [[2]](diffhunk://#diff-cca92be6729e59c6b591fe143dbcab378481b8338a33ed574fd1841f307b3d4eR137-R146) [[3]](diffhunk://#diff-cca92be6729e59c6b591fe143dbcab378481b8338a33ed574fd1841f307b3d4eL125-R167) [[4]](diffhunk://#diff-5dec8ac5620ec081b2d95fdf70da54c896e5febcfba6e9c6d626e524753f9950R266-R281) [[5]](diffhunk://#diff-5dec8ac5620ec081b2d95fdf70da54c896e5febcfba6e9c6d626e524753f9950L285-R306)
- The cross-approach CCF logic is updated to use provision-adjusted drawn and nominal amounts when available, ensuring correct EAD calculation in complex guarantee scenarios.

**API and documentation updates:**

- The CRM namespace API is updated to introduce `resolve_provisions` (the new method for provision handling) and clarify that `apply_provisions` is now a legacy method delegating to the new logic. Documentation is updated to reflect these changes and the new CRM pipeline order. [[1]](diffhunk://#diff-cca92be6729e59c6b591fe143dbcab378481b8338a33ed574fd1841f307b3d4eR5-R9) [[2]](diffhunk://#diff-cca92be6729e59c6b591fe143dbcab378481b8338a33ed574fd1841f307b3d4eL483-R564) [[3]](diffhunk://#diff-cca92be6729e59c6b591fe143dbcab378481b8338a33ed574fd1841f307b3d4eL599-R616)

**Other:**

- Additional web fetch domains are enabled in `.claude/settings.local.json` to support new data sources.