### PR TITLE
feat(irb): implement defaulted exposure treatment

### DIFF
--- a/src/rwa_calc/engine/hierarchy.py
+++ b/src/rwa_calc/engine/hierarchy.py
@@ -659,6 +659,7 @@ class HierarchyResolver:
                 "undrawn_amount": pl.Float64,
                 "nominal_amount": pl.Float64,
                 "lgd": pl.Float64,
+                "beel": pl.Float64,
                 "seniority": pl.String,
                 "risk_type": pl.String,
                 "ccf_modelled": pl.Float64,
@@ -859,6 +860,7 @@ class HierarchyResolver:
             pl.col("undrawn_amount"),
             pl.col("undrawn_amount").alias("nominal_amount"),  # CCF uses nominal_amount
             pl.col("lgd").cast(pl.Float64, strict=False) if "lgd" in facility_cols else pl.lit(None).cast(pl.Float64).alias("lgd"),
+            pl.col("beel").cast(pl.Float64, strict=False).fill_null(0.0) if "beel" in facility_cols else pl.lit(0.0).alias("beel"),
             pl.col("seniority") if "seniority" in facility_cols else pl.lit(None).cast(pl.String).alias("seniority"),
             pl.col("risk_type") if "risk_type" in facility_cols else pl.lit(None).cast(pl.String).alias("risk_type"),
             pl.col("ccf_modelled").cast(pl.Float64, strict=False) if "ccf_modelled" in facility_cols else pl.lit(None).cast(pl.Float64).alias("ccf_modelled"),
@@ -921,6 +923,7 @@ class HierarchyResolver:
             pl.lit(0.0).alias("undrawn_amount"),
             pl.lit(0.0).alias("nominal_amount"),
             pl.col("lgd").cast(pl.Float64, strict=False),
+            pl.col("beel").cast(pl.Float64, strict=False).fill_null(0.0) if "beel" in loan_cols else pl.lit(0.0).alias("beel"),
             pl.col("seniority"),
             pl.lit(None).cast(pl.String).alias("risk_type"),  # N/A for drawn loans
             pl.lit(None).cast(pl.Float64).alias("ccf_modelled"),  # N/A for drawn loans
@@ -963,6 +966,7 @@ class HierarchyResolver:
                 pl.when(is_drawn).then(pl.lit(0.0))
                 .otherwise(pl.col("nominal_amount")).alias("nominal_amount"),
                 pl.col("lgd").cast(pl.Float64, strict=False),
+                pl.col("beel").cast(pl.Float64, strict=False).fill_null(0.0) if "beel" in cont_cols else pl.lit(0.0).alias("beel"),
                 pl.col("seniority"),
                 pl.when(is_drawn).then(pl.lit(None).cast(pl.String))
                 .otherwise(pl.col("risk_type")).alias("risk_type"),

--- a/tests/acceptance/crr/test_scenario_crr_i_defaulted.py
+++ b/tests/acceptance/crr/test_scenario_crr_i_defaulted.py
@@ -1,0 +1,280 @@
+"""
+CRR Group I: Defaulted Exposure IRB Treatment Acceptance Tests.
+
+These tests validate the production calculator correctly handles defaulted
+exposures under IRB, bypassing the Vasicek formula per CRR Art. 153(1)(ii)
+and Art. 154(1)(i).
+
+Key rules:
+- F-IRB defaulted: K=0, RW=0 (capital requirement addressed via provisions)
+- A-IRB defaulted: K = max(0, LGD_in_default - BEEL)
+- No Vasicek correlation or maturity adjustment for defaulted exposures
+- CRR 1.06 scaling applies to non-retail (even when defaulted)
+
+Regulatory References:
+- CRR Art. 153(1)(ii): Defaulted non-retail IRB risk weights
+- CRR Art. 154(1)(i): Defaulted retail IRB risk weights
+- Basel CRE31.3: Treatment of defaulted exposures
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import polars as pl
+import pytest
+
+from rwa_calc.contracts.config import CalculationConfig, IRBPermissions
+from rwa_calc.domain.enums import ExposureClass, ApproachType
+from rwa_calc.engine.irb import IRBLazyFrame  # noqa: F401 - registers namespace
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def crr_irb_config() -> CalculationConfig:
+    """CRR config with full IRB permissions."""
+    return CalculationConfig.crr(
+        reporting_date=date(2025, 12, 31),
+        irb_permissions=IRBPermissions.full_irb(),
+    )
+
+
+def _build_defaulted_exposure(
+    *,
+    exposure_ref: str,
+    exposure_class: str,
+    approach: str,
+    is_airb: bool,
+    lgd: float,
+    beel: float,
+    ead_final: float,
+    maturity: float = 2.5,
+) -> pl.LazyFrame:
+    """Build a single defaulted exposure for acceptance testing."""
+    return pl.LazyFrame({
+        "exposure_reference": [exposure_ref],
+        "counterparty_reference": [f"CP_{exposure_ref}"],
+        "pd": [1.0],  # Defaulted = PD 100%
+        "lgd": [lgd],
+        "beel": [beel],
+        "ead_final": [ead_final],
+        "exposure_class": [exposure_class],
+        "maturity": [maturity],
+        "approach": [approach],
+        "is_airb": [is_airb],
+        "is_defaulted": [True],
+    })
+
+
+# =============================================================================
+# CRR-I1: F-IRB Corporate Defaulted
+# =============================================================================
+
+
+class TestCRRI1_FIRBCorporateDefaulted:
+    """
+    CRR-I1: F-IRB corporate defaulted exposure.
+
+    Input: Corporate loan, PD=100%, supervisory LGD=45%, EAD=500,000
+    Expected: K=0, RW=0%, RWA=0, EL = LGD × EAD = 225,000
+    """
+
+    def test_crr_i1_k_is_zero(self, crr_irb_config: CalculationConfig) -> None:
+        """F-IRB defaulted corporate: K=0."""
+        lf = _build_defaulted_exposure(
+            exposure_ref="CRR_I1_CORP",
+            exposure_class="CORPORATE",
+            approach="foundation_irb",
+            is_airb=False,
+            lgd=0.45,
+            beel=0.0,
+            ead_final=500_000.0,
+        )
+        result = (lf
+            .irb.prepare_columns(crr_irb_config)
+            .irb.apply_all_formulas(crr_irb_config)
+            .collect()
+        )
+        assert result["k"][0] == pytest.approx(0.0, abs=1e-10)
+
+    def test_crr_i1_rwa_is_zero(self, crr_irb_config: CalculationConfig) -> None:
+        """F-IRB defaulted corporate: RWA=0."""
+        lf = _build_defaulted_exposure(
+            exposure_ref="CRR_I1_CORP",
+            exposure_class="CORPORATE",
+            approach="foundation_irb",
+            is_airb=False,
+            lgd=0.45,
+            beel=0.0,
+            ead_final=500_000.0,
+        )
+        result = (lf
+            .irb.prepare_columns(crr_irb_config)
+            .irb.apply_all_formulas(crr_irb_config)
+            .collect()
+        )
+        assert result["rwa"][0] == pytest.approx(0.0, abs=1e-6)
+        assert result["risk_weight"][0] == pytest.approx(0.0, abs=1e-6)
+
+    def test_crr_i1_expected_loss(self, crr_irb_config: CalculationConfig) -> None:
+        """F-IRB defaulted corporate: EL = LGD × EAD = 0.45 × 500,000 = 225,000."""
+        lf = _build_defaulted_exposure(
+            exposure_ref="CRR_I1_CORP",
+            exposure_class="CORPORATE",
+            approach="foundation_irb",
+            is_airb=False,
+            lgd=0.45,
+            beel=0.0,
+            ead_final=500_000.0,
+        )
+        result = (lf
+            .irb.prepare_columns(crr_irb_config)
+            .irb.apply_all_formulas(crr_irb_config)
+            .collect()
+        )
+        assert result["expected_loss"][0] == pytest.approx(225_000.0, rel=1e-6)
+
+
+# =============================================================================
+# CRR-I2: A-IRB Retail Defaulted
+# =============================================================================
+
+
+class TestCRRI2_AIRBRetailDefaulted:
+    """
+    CRR-I2: A-IRB retail defaulted exposure.
+
+    Input: Retail loan, PD=100%, LGD_in_default=65%, BEEL=50%, EAD=25,000
+    Expected: K=max(0, 0.65-0.50)=0.15, RWA=0.15×12.5×1.0×25,000=46,875
+              EL = BEEL × EAD = 0.50 × 25,000 = 12,500
+    """
+
+    def test_crr_i2_k_lgd_minus_beel(self, crr_irb_config: CalculationConfig) -> None:
+        """A-IRB retail defaulted: K = max(0, 0.65 - 0.50) = 0.15."""
+        lf = _build_defaulted_exposure(
+            exposure_ref="CRR_I2_RTL",
+            exposure_class="RETAIL_OTHER",
+            approach="advanced_irb",
+            is_airb=True,
+            lgd=0.65,
+            beel=0.50,
+            ead_final=25_000.0,
+        )
+        result = (lf
+            .irb.prepare_columns(crr_irb_config)
+            .irb.apply_all_formulas(crr_irb_config)
+            .collect()
+        )
+        assert result["k"][0] == pytest.approx(0.15, abs=1e-10)
+
+    def test_crr_i2_rwa(self, crr_irb_config: CalculationConfig) -> None:
+        """A-IRB retail defaulted CRR: RWA = 0.15 × 12.5 × 1.0 × 25,000 = 46,875."""
+        lf = _build_defaulted_exposure(
+            exposure_ref="CRR_I2_RTL",
+            exposure_class="RETAIL_OTHER",
+            approach="advanced_irb",
+            is_airb=True,
+            lgd=0.65,
+            beel=0.50,
+            ead_final=25_000.0,
+        )
+        result = (lf
+            .irb.prepare_columns(crr_irb_config)
+            .irb.apply_all_formulas(crr_irb_config)
+            .collect()
+        )
+        expected_rwa = 0.15 * 12.5 * 1.0 * 25_000.0  # 46,875
+        assert result["rwa"][0] == pytest.approx(expected_rwa, rel=1e-6)
+
+    def test_crr_i2_expected_loss(self, crr_irb_config: CalculationConfig) -> None:
+        """A-IRB retail defaulted: EL = BEEL × EAD = 0.50 × 25,000 = 12,500."""
+        lf = _build_defaulted_exposure(
+            exposure_ref="CRR_I2_RTL",
+            exposure_class="RETAIL_OTHER",
+            approach="advanced_irb",
+            is_airb=True,
+            lgd=0.65,
+            beel=0.50,
+            ead_final=25_000.0,
+        )
+        result = (lf
+            .irb.prepare_columns(crr_irb_config)
+            .irb.apply_all_formulas(crr_irb_config)
+            .collect()
+        )
+        assert result["expected_loss"][0] == pytest.approx(12_500.0, rel=1e-6)
+
+
+# =============================================================================
+# CRR-I3: A-IRB Corporate Defaulted with CRR Scaling
+# =============================================================================
+
+
+class TestCRRI3_AIRBCorporateDefaultedCRRScaling:
+    """
+    CRR-I3: A-IRB corporate defaulted exposure with CRR 1.06 scaling.
+
+    Input: Corporate loan, PD=100%, LGD_in_default=60%, BEEL=45%, EAD=500,000
+    Expected: K=max(0, 0.60-0.45)=0.15,
+              RWA = 0.15 × 12.5 × 1.06 × 500,000 = 993,750
+              EL = BEEL × EAD = 0.45 × 500,000 = 225,000
+    """
+
+    def test_crr_i3_k(self, crr_irb_config: CalculationConfig) -> None:
+        """A-IRB corporate defaulted: K = 0.15."""
+        lf = _build_defaulted_exposure(
+            exposure_ref="CRR_I3_CORP",
+            exposure_class="CORPORATE",
+            approach="advanced_irb",
+            is_airb=True,
+            lgd=0.60,
+            beel=0.45,
+            ead_final=500_000.0,
+        )
+        result = (lf
+            .irb.prepare_columns(crr_irb_config)
+            .irb.apply_all_formulas(crr_irb_config)
+            .collect()
+        )
+        assert result["k"][0] == pytest.approx(0.15, abs=1e-10)
+
+    def test_crr_i3_rwa_with_scaling(self, crr_irb_config: CalculationConfig) -> None:
+        """A-IRB corporate defaulted CRR: RWA = 0.15 × 12.5 × 1.06 × 500,000 = 993,750."""
+        lf = _build_defaulted_exposure(
+            exposure_ref="CRR_I3_CORP",
+            exposure_class="CORPORATE",
+            approach="advanced_irb",
+            is_airb=True,
+            lgd=0.60,
+            beel=0.45,
+            ead_final=500_000.0,
+        )
+        result = (lf
+            .irb.prepare_columns(crr_irb_config)
+            .irb.apply_all_formulas(crr_irb_config)
+            .collect()
+        )
+        expected_rwa = 0.15 * 12.5 * 1.06 * 500_000.0  # 993,750
+        assert result["rwa"][0] == pytest.approx(expected_rwa, rel=1e-6)
+
+    def test_crr_i3_expected_loss(self, crr_irb_config: CalculationConfig) -> None:
+        """A-IRB corporate defaulted: EL = BEEL × EAD = 0.45 × 500,000 = 225,000."""
+        lf = _build_defaulted_exposure(
+            exposure_ref="CRR_I3_CORP",
+            exposure_class="CORPORATE",
+            approach="advanced_irb",
+            is_airb=True,
+            lgd=0.60,
+            beel=0.45,
+            ead_final=500_000.0,
+        )
+        result = (lf
+            .irb.prepare_columns(crr_irb_config)
+            .irb.apply_all_formulas(crr_irb_config)
+            .collect()
+        )
+        assert result["expected_loss"][0] == pytest.approx(225_000.0, rel=1e-6)

--- a/tests/fixtures/exposures/loans.py
+++ b/tests/fixtures/exposures/loans.py
@@ -808,8 +808,8 @@ def _defaulted_loans() -> list[Loan]:
             currency="GBP",
             drawn_amount=25_000.0,
             interest=0.0,
-            lgd=0.45,
-            beel=0.0,
+            lgd=0.65,  # LGD_in_default (bank's best estimate for defaulted retail)
+            beel=0.50,  # Best estimate expected loss (A-IRB: K = max(0, 0.65 - 0.50) = 0.15)
             seniority="senior",
         ),
     ]

--- a/tests/unit/crr/test_irb_defaulted.py
+++ b/tests/unit/crr/test_irb_defaulted.py
@@ -1,0 +1,387 @@
+"""Unit tests for IRB defaulted exposure treatment.
+
+Tests cover:
+- K calculation: F-IRB K=0, A-IRB K=max(0, LGD-BEEL)
+- RWA calculation: scaling, no correlation, no maturity adjustment
+- Expected loss: F-IRB EL=LGD*EAD, A-IRB EL=BEEL*EAD
+- Pipeline integration: mixed defaulted+performing, missing columns
+- BEEL column flow through hierarchy
+
+References:
+- CRR Art. 153(1)(ii): Defaulted non-retail exposures
+- CRR Art. 154(1)(i): Defaulted retail exposures
+- Basel CRE31.3: Defaulted exposure treatment
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import polars as pl
+import pytest
+
+from rwa_calc.contracts.config import CalculationConfig
+from rwa_calc.engine.irb import IRBLazyFrame, IRBExpr  # noqa: F401
+from rwa_calc.engine.irb.formulas import apply_irb_formulas
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def crr_config() -> CalculationConfig:
+    """CRR configuration."""
+    return CalculationConfig.crr(reporting_date=date(2024, 12, 31))
+
+
+@pytest.fixture
+def basel31_config() -> CalculationConfig:
+    """Basel 3.1 configuration."""
+    return CalculationConfig.basel_3_1(reporting_date=date(2027, 6, 30))
+
+
+def _make_defaulted_lf(
+    *,
+    exposure_class: str = "CORPORATE",
+    approach: str = "foundation_irb",
+    is_airb: bool = False,
+    lgd: float = 0.45,
+    beel: float = 0.0,
+    ead_final: float = 500_000.0,
+    pd: float = 1.0,
+    maturity: float = 2.5,
+    is_defaulted: bool = True,
+) -> pl.LazyFrame:
+    """Create a single-row defaulted exposure LazyFrame."""
+    return pl.LazyFrame({
+        "exposure_reference": ["DEF001"],
+        "pd": [pd],
+        "lgd": [lgd],
+        "ead_final": [ead_final],
+        "exposure_class": [exposure_class],
+        "maturity": [maturity],
+        "approach": [approach],
+        "is_airb": [is_airb],
+        "is_defaulted": [is_defaulted],
+        "beel": [beel],
+    })
+
+
+# =============================================================================
+# TestDefaultedK
+# =============================================================================
+
+
+class TestDefaultedK:
+    """Test capital requirement (K) for defaulted exposures."""
+
+    def test_firb_k_is_zero(self, crr_config: CalculationConfig) -> None:
+        """F-IRB defaulted: K=0."""
+        lf = _make_defaulted_lf(approach="foundation_irb", is_airb=False, lgd=0.45, beel=0.0)
+        result = (lf
+            .irb.prepare_columns(crr_config)
+            .irb.apply_all_formulas(crr_config)
+            .collect()
+        )
+        assert result["k"][0] == pytest.approx(0.0, abs=1e-10)
+
+    def test_airb_k_lgd_minus_beel(self, crr_config: CalculationConfig) -> None:
+        """A-IRB defaulted: K = max(0, LGD - BEEL) = max(0, 0.65 - 0.50) = 0.15."""
+        lf = _make_defaulted_lf(
+            approach="advanced_irb", is_airb=True,
+            lgd=0.65, beel=0.50, exposure_class="RETAIL_OTHER",
+        )
+        result = (lf
+            .irb.prepare_columns(crr_config)
+            .irb.apply_all_formulas(crr_config)
+            .collect()
+        )
+        assert result["k"][0] == pytest.approx(0.15, abs=1e-10)
+
+    def test_airb_k_floored_at_zero_when_beel_exceeds_lgd(self, crr_config: CalculationConfig) -> None:
+        """A-IRB defaulted: K floored at 0 when BEEL > LGD."""
+        lf = _make_defaulted_lf(
+            approach="advanced_irb", is_airb=True,
+            lgd=0.40, beel=0.55, exposure_class="RETAIL_OTHER",
+        )
+        result = (lf
+            .irb.prepare_columns(crr_config)
+            .irb.apply_all_formulas(crr_config)
+            .collect()
+        )
+        assert result["k"][0] == pytest.approx(0.0, abs=1e-10)
+
+    def test_airb_k_with_zero_beel(self, crr_config: CalculationConfig) -> None:
+        """A-IRB defaulted with BEEL=0: K = LGD."""
+        lf = _make_defaulted_lf(
+            approach="advanced_irb", is_airb=True,
+            lgd=0.60, beel=0.0, exposure_class="CORPORATE",
+        )
+        result = (lf
+            .irb.prepare_columns(crr_config)
+            .irb.apply_all_formulas(crr_config)
+            .collect()
+        )
+        assert result["k"][0] == pytest.approx(0.60, abs=1e-10)
+
+
+# =============================================================================
+# TestDefaultedRWA
+# =============================================================================
+
+
+class TestDefaultedRWA:
+    """Test RWA calculation for defaulted exposures."""
+
+    def test_firb_rwa_is_zero(self, crr_config: CalculationConfig) -> None:
+        """F-IRB defaulted: RWA=0."""
+        lf = _make_defaulted_lf(approach="foundation_irb", is_airb=False, ead_final=500_000.0)
+        result = (lf
+            .irb.prepare_columns(crr_config)
+            .irb.apply_all_formulas(crr_config)
+            .collect()
+        )
+        assert result["rwa"][0] == pytest.approx(0.0, abs=1e-6)
+        assert result["risk_weight"][0] == pytest.approx(0.0, abs=1e-6)
+
+    def test_airb_retail_rwa_no_scaling(self, crr_config: CalculationConfig) -> None:
+        """A-IRB retail defaulted CRR: no 1.06 scaling (retail never gets scaling)."""
+        lf = _make_defaulted_lf(
+            approach="advanced_irb", is_airb=True,
+            lgd=0.65, beel=0.50, ead_final=25_000.0,
+            exposure_class="RETAIL_OTHER",
+        )
+        result = (lf
+            .irb.prepare_columns(crr_config)
+            .irb.apply_all_formulas(crr_config)
+            .collect()
+        )
+        # K=0.15, scaling=1.0 (retail), RWA = 0.15 * 12.5 * 1.0 * 25000 = 46,875
+        expected_rwa = 0.15 * 12.5 * 1.0 * 25_000.0
+        assert result["rwa"][0] == pytest.approx(expected_rwa, rel=1e-6)
+
+    def test_airb_corporate_rwa_crr_scaling(self, crr_config: CalculationConfig) -> None:
+        """A-IRB corporate defaulted CRR: 1.06 scaling applies."""
+        lf = _make_defaulted_lf(
+            approach="advanced_irb", is_airb=True,
+            lgd=0.60, beel=0.45, ead_final=500_000.0,
+            exposure_class="CORPORATE",
+        )
+        result = (lf
+            .irb.prepare_columns(crr_config)
+            .irb.apply_all_formulas(crr_config)
+            .collect()
+        )
+        # K=0.15, scaling=1.06, RWA = 0.15 * 12.5 * 1.06 * 500000 = 993,750
+        expected_rwa = 0.15 * 12.5 * 1.06 * 500_000.0
+        assert result["rwa"][0] == pytest.approx(expected_rwa, rel=1e-6)
+
+    def test_airb_corporate_rwa_basel31_no_scaling(self, basel31_config: CalculationConfig) -> None:
+        """A-IRB corporate defaulted Basel 3.1: no scaling."""
+        lf = _make_defaulted_lf(
+            approach="advanced_irb", is_airb=True,
+            lgd=0.60, beel=0.45, ead_final=500_000.0,
+            exposure_class="CORPORATE",
+        )
+        result = (lf
+            .irb.prepare_columns(basel31_config)
+            .irb.apply_all_formulas(basel31_config)
+            .collect()
+        )
+        # K=0.15, scaling=1.0 (Basel 3.1), RWA = 0.15 * 12.5 * 1.0 * 500000 = 937,500
+        expected_rwa = 0.15 * 12.5 * 1.0 * 500_000.0
+        assert result["rwa"][0] == pytest.approx(expected_rwa, rel=1e-6)
+
+    def test_defaulted_correlation_is_zero(self, crr_config: CalculationConfig) -> None:
+        """Defaulted exposures bypass Vasicek: correlation=0."""
+        lf = _make_defaulted_lf(approach="foundation_irb", is_airb=False)
+        result = (lf
+            .irb.prepare_columns(crr_config)
+            .irb.apply_all_formulas(crr_config)
+            .collect()
+        )
+        assert result["correlation"][0] == pytest.approx(0.0, abs=1e-10)
+
+    def test_defaulted_maturity_adjustment_is_one(self, crr_config: CalculationConfig) -> None:
+        """Defaulted exposures: maturity adjustment=1.0 (not applicable)."""
+        lf = _make_defaulted_lf(approach="foundation_irb", is_airb=False)
+        result = (lf
+            .irb.prepare_columns(crr_config)
+            .irb.apply_all_formulas(crr_config)
+            .collect()
+        )
+        assert result["maturity_adjustment"][0] == pytest.approx(1.0, abs=1e-10)
+
+
+# =============================================================================
+# TestDefaultedExpectedLoss
+# =============================================================================
+
+
+class TestDefaultedExpectedLoss:
+    """Test expected loss for defaulted exposures."""
+
+    def test_firb_el_lgd_times_ead(self, crr_config: CalculationConfig) -> None:
+        """F-IRB defaulted: EL = LGD × EAD."""
+        lf = _make_defaulted_lf(
+            approach="foundation_irb", is_airb=False,
+            lgd=0.45, ead_final=500_000.0,
+        )
+        result = (lf
+            .irb.prepare_columns(crr_config)
+            .irb.apply_all_formulas(crr_config)
+            .collect()
+        )
+        # lgd_floored = 0.45 (CRR no LGD floor), EL = 0.45 * 500000 = 225,000
+        assert result["expected_loss"][0] == pytest.approx(0.45 * 500_000.0, rel=1e-6)
+
+    def test_airb_el_beel_times_ead(self, crr_config: CalculationConfig) -> None:
+        """A-IRB defaulted: EL = BEEL × EAD."""
+        lf = _make_defaulted_lf(
+            approach="advanced_irb", is_airb=True,
+            lgd=0.65, beel=0.50, ead_final=25_000.0,
+            exposure_class="RETAIL_OTHER",
+        )
+        result = (lf
+            .irb.prepare_columns(crr_config)
+            .irb.apply_all_formulas(crr_config)
+            .collect()
+        )
+        # EL = BEEL * EAD = 0.50 * 25000 = 12,500
+        assert result["expected_loss"][0] == pytest.approx(0.50 * 25_000.0, rel=1e-6)
+
+
+# =============================================================================
+# TestDefaultedPipeline
+# =============================================================================
+
+
+class TestDefaultedPipeline:
+    """Test defaulted treatment in mixed pipelines."""
+
+    def test_mixed_defaulted_and_performing(self, crr_config: CalculationConfig) -> None:
+        """Mixed rows: defaulted rows get treatment, performing rows unchanged."""
+        lf = pl.LazyFrame({
+            "exposure_reference": ["PERF001", "DEF001"],
+            "pd": [0.01, 1.0],
+            "lgd": [0.45, 0.45],
+            "ead_final": [1_000_000.0, 500_000.0],
+            "exposure_class": ["CORPORATE", "CORPORATE"],
+            "maturity": [2.5, 2.5],
+            "approach": ["foundation_irb", "foundation_irb"],
+            "is_airb": [False, False],
+            "is_defaulted": [False, True],
+            "beel": [0.0, 0.0],
+        })
+        result = (lf
+            .irb.prepare_columns(crr_config)
+            .irb.apply_all_formulas(crr_config)
+            .collect()
+        )
+        # Performing row should have non-zero K
+        assert result["k"][0] > 0.0
+        assert result["rwa"][0] > 0.0
+
+        # Defaulted F-IRB row should have K=0, RWA=0
+        assert result["k"][1] == pytest.approx(0.0, abs=1e-10)
+        assert result["rwa"][1] == pytest.approx(0.0, abs=1e-6)
+
+    def test_missing_is_defaulted_column_is_noop(self, crr_config: CalculationConfig) -> None:
+        """No is_defaulted column → defaulted treatment is a no-op."""
+        lf = pl.LazyFrame({
+            "exposure_reference": ["EXP001"],
+            "pd": [0.01],
+            "lgd": [0.45],
+            "ead_final": [1_000_000.0],
+            "exposure_class": ["CORPORATE"],
+            "maturity": [2.5],
+            "approach": ["foundation_irb"],
+        })
+        # Should run without errors (prepare_columns adds is_defaulted=False)
+        result = (lf
+            .irb.prepare_columns(crr_config)
+            .irb.apply_all_formulas(crr_config)
+            .collect()
+        )
+        assert result["k"][0] > 0.0
+        assert result["rwa"][0] > 0.0
+
+    def test_missing_beel_column_defaults_to_zero(self, crr_config: CalculationConfig) -> None:
+        """Missing beel column defaults to 0.0."""
+        lf = pl.LazyFrame({
+            "exposure_reference": ["DEF001"],
+            "pd": [1.0],
+            "lgd": [0.45],
+            "ead_final": [500_000.0],
+            "exposure_class": ["CORPORATE"],
+            "maturity": [2.5],
+            "approach": ["advanced_irb"],
+            "is_airb": [True],
+            "is_defaulted": [True],
+        })
+        # prepare_columns adds beel=0.0
+        result = (lf
+            .irb.prepare_columns(crr_config)
+            .irb.apply_all_formulas(crr_config)
+            .collect()
+        )
+        # A-IRB with BEEL=0: K = max(0, 0.45 - 0) = 0.45
+        assert result["k"][0] == pytest.approx(0.45, abs=1e-10)
+
+    def test_apply_irb_formulas_standalone_with_defaulted(self, crr_config: CalculationConfig) -> None:
+        """apply_irb_formulas() standalone function also handles defaulted rows."""
+        lf = pl.LazyFrame({
+            "exposure_reference": ["DEF001"],
+            "pd": [1.0],
+            "lgd": [0.45],
+            "ead_final": [500_000.0],
+            "exposure_class": ["CORPORATE"],
+            "maturity": [2.5],
+            "is_airb": [False],
+            "is_defaulted": [True],
+            "beel": [0.0],
+        })
+        result = apply_irb_formulas(lf, crr_config).collect()
+        assert result["k"][0] == pytest.approx(0.0, abs=1e-10)
+        assert result["rwa"][0] == pytest.approx(0.0, abs=1e-6)
+
+
+# =============================================================================
+# TestDefaultedAudit
+# =============================================================================
+
+
+class TestDefaultedAudit:
+    """Test audit trail for defaulted exposures."""
+
+    def test_firb_defaulted_audit_string(self, crr_config: CalculationConfig) -> None:
+        """F-IRB defaulted audit string indicates K=0."""
+        lf = _make_defaulted_lf(approach="foundation_irb", is_airb=False)
+        result = (lf
+            .irb.prepare_columns(crr_config)
+            .irb.apply_all_formulas(crr_config)
+            .irb.build_audit()
+            .collect()
+        )
+        audit_str = result["irb_calculation"][0]
+        assert "DEFAULTED" in audit_str
+        assert "F-IRB" in audit_str
+
+    def test_airb_defaulted_audit_string(self, crr_config: CalculationConfig) -> None:
+        """A-IRB defaulted audit string shows K=max(0, LGD-BEEL)."""
+        lf = _make_defaulted_lf(
+            approach="advanced_irb", is_airb=True,
+            lgd=0.65, beel=0.50, exposure_class="RETAIL_OTHER",
+        )
+        result = (lf
+            .irb.prepare_columns(crr_config)
+            .irb.apply_all_formulas(crr_config)
+            .irb.build_audit()
+            .collect()
+        )
+        audit_str = result["irb_calculation"][0]
+        assert "DEFAULTED" in audit_str
+        assert "A-IRB" in audit_str
+        assert "BEEL" in audit_str


### PR DESCRIPTION
This pull request implements comprehensive support for the regulatory treatment of defaulted exposures under the IRB (Internal Ratings-Based) approach, in line with CRR and Basel requirements. The changes ensure that defaulted exposures bypass the Vasicek formula, apply the correct capital and expected loss calculations for both Foundation IRB (F-IRB) and Advanced IRB (A-IRB), and introduce full test coverage for these scenarios. The implementation also standardizes the handling of the `beel` (best estimate of expected loss) column throughout the pipeline.

**IRB Defaulted Exposure Treatment:**

* Added a new method `apply_defaulted_treatment` to the IRB calculation pipeline, which applies the correct regulatory formulas for defaulted exposures, including setting K, risk weight, RWA, and expected loss according to F-IRB and A-IRB rules, and applies the CRR 1.06 scaling for non-retail exposures. [[1]](diffhunk://#diff-00843201e4d795c7909479e7fa791b56fedfc5884754fa713a871b4f9fe588ffR468-R556) [[2]](diffhunk://#diff-00843201e4d795c7909479e7fa791b56fedfc5884754fa713a871b4f9fe588ffR788) [[3]](diffhunk://#diff-92acd6b8b81c0e78bcda7f4438ee89c4afcd4024ee3fb1922069a70a7db00721R142-R189)

* Ensured the `beel` column is present and correctly propagated in all relevant dataframes, defaulting to 0.0 when missing, and added it to the schema in all exposure unification and preparation steps. [[1]](diffhunk://#diff-00843201e4d795c7909479e7fa791b56fedfc5884754fa713a871b4f9fe588ffR291-R299) [[2]](diffhunk://#diff-054f578a992202e82fb2283dbe871200953301a7eb67f21ff1ca5f24e42a7f7bR662) [[3]](diffhunk://#diff-054f578a992202e82fb2283dbe871200953301a7eb67f21ff1ca5f24e42a7f7bR863) [[4]](diffhunk://#diff-054f578a992202e82fb2283dbe871200953301a7eb67f21ff1ca5f24e42a7f7bR926) [[5]](diffhunk://#diff-054f578a992202e82fb2283dbe871200953301a7eb67f21ff1ca5f24e42a7f7bR969)

**Audit and Traceability Improvements:**

* Enhanced the audit output to include `is_defaulted`, `is_airb`, and `beel` columns, and updated the audit string to clearly indicate the defaulted treatment and the formulas used for both A-IRB and F-IRB exposures. [[1]](diffhunk://#diff-00843201e4d795c7909479e7fa791b56fedfc5884754fa713a871b4f9fe588ffR824-R826) [[2]](diffhunk://#diff-00843201e4d795c7909479e7fa791b56fedfc5884754fa713a871b4f9fe588ffR846-R895)

**Testing:**

* Added a new acceptance test suite (`test_scenario_crr_i_defaulted.py`) covering F-IRB and A-IRB defaulted exposures for both corporate and retail, including checks for K, RWA, and expected loss calculations, and ensuring correct application of CRR scaling.

**Test Fixtures:**

* Updated test fixtures to reflect correct LGD and BEEL values for defaulted retail loans, ensuring test data matches regulatory requirements.