### PR TITLE
fix(supporting_factors): adjust SME factor calculation for drawn amounts

### DIFF
--- a/tests/unit/test_supporting_factors.py
+++ b/tests/unit/test_supporting_factors.py
@@ -1,10 +1,12 @@
 """
-Unit tests for Buy-to-Let (BTL) flag in supporting factors.
+Unit tests for supporting factors (CRR2 Art. 501).
 
-BTL exposures must NOT receive the SME supporting factor discount,
-but they still contribute to total counterparty EAD for the tiered
-threshold calculation. This ensures non-BTL exposures to the same
-counterparty get the correct blended factor.
+Tests cover:
+- BTL exclusion from SME factor (BTL still counts toward total_cp_drawn)
+- Drawn-only tier weighting: tier calculation uses drawn_amount + interest,
+  NOT ead_final (which includes CCF-adjusted undrawn commitments)
+- Infrastructure factor interaction with BTL
+- Backward compatibility when drawn_amount column is missing
 """
 
 from datetime import date
@@ -30,8 +32,14 @@ def crr_config() -> CalculationConfig:
 def _make_exposures(
     rows: list[dict],
     include_btl: bool = True,
+    include_drawn: bool = True,
 ) -> pl.LazyFrame:
-    """Build a LazyFrame of exposures for supporting factor tests."""
+    """Build a LazyFrame of exposures for supporting factor tests.
+
+    Each row dict supports keys:
+        ref, cp, ead, rwa, drawn (defaults to ead), interest (defaults to 0),
+        is_sme (True), is_infra (False), is_btl (False).
+    """
     data = {
         "exposure_reference": [r["ref"] for r in rows],
         "counterparty_reference": [r["cp"] for r in rows],
@@ -40,27 +48,26 @@ def _make_exposures(
         "is_sme": [r.get("is_sme", True) for r in rows],
         "is_infrastructure": [r.get("is_infra", False) for r in rows],
     }
+    if include_drawn:
+        data["drawn_amount"] = [r.get("drawn", r["ead"]) for r in rows]
+        data["interest"] = [r.get("interest", 0.0) for r in rows]
     if include_btl:
         data["is_buy_to_let"] = [r.get("is_btl", False) for r in rows]
     return pl.LazyFrame(data)
 
 
 class TestBTLExcludedFromSMEFactor:
-    """BTL exposures get supporting_factor=1.0 but still count toward total_cp_ead."""
+    """BTL exposures get supporting_factor=1.0 but still count toward total_cp_drawn."""
 
     def test_btl_excluded_non_btl_gets_blended(
         self, calculator: SupportingFactorCalculator, crr_config: CalculationConfig,
     ) -> None:
         """
-        CP with 1.5m non-BTL + 1.0m BTL:
-        - total_cp_ead = 2.5m (includes BTL)
+        CP with 1.5m non-BTL + 1.0m BTL (all drawn):
+        - total_cp_drawn = 2.5m (includes BTL)
         - Non-BTL gets the tiered blended factor (all within tier 1 threshold)
         - BTL gets 1.0
         """
-        threshold_gbp = float(
-            crr_config.supporting_factors.sme_exposure_threshold_eur
-            * crr_config.eur_gbp_rate
-        )
         exposures = _make_exposures([
             {"ref": "E1", "cp": "CP1", "ead": 1_500_000, "rwa": 600_000, "is_btl": False},
             {"ref": "E2", "cp": "CP1", "ead": 1_000_000, "rwa": 400_000, "is_btl": True},
@@ -68,9 +75,9 @@ class TestBTLExcludedFromSMEFactor:
 
         result = calculator.apply_factors(exposures, crr_config).collect()
 
-        # Both exposures should see total_cp_ead = 2.5m (BTL included)
-        assert result.filter(pl.col("exposure_reference") == "E1")["total_cp_ead"][0] == 2_500_000
-        assert result.filter(pl.col("exposure_reference") == "E2")["total_cp_ead"][0] == 2_500_000
+        # Both exposures should see total_cp_drawn = 2.5m (BTL included)
+        assert result.filter(pl.col("exposure_reference") == "E1")["total_cp_drawn"][0] == 2_500_000
+        assert result.filter(pl.col("exposure_reference") == "E2")["total_cp_drawn"][0] == 2_500_000
 
         # Non-BTL (E1) gets the SME factor < 1.0
         sf_e1 = result.filter(pl.col("exposure_reference") == "E1")["supporting_factor"][0]
@@ -88,10 +95,10 @@ class TestBTLExcludedFromSMEFactor:
         rwa_e2 = result.filter(pl.col("exposure_reference") == "E2")["rwa_post_factor"][0]
         assert rwa_e2 == pytest.approx(400_000)
 
-    def test_btl_contributes_to_total_cp_ead(
+    def test_btl_contributes_to_total_cp_drawn(
         self, calculator: SupportingFactorCalculator, crr_config: CalculationConfig,
     ) -> None:
-        """total_cp_ead = 3.0m (includes 2.0m BTL)."""
+        """total_cp_drawn = 3.0m (includes 2.0m BTL)."""
         exposures = _make_exposures([
             {"ref": "E1", "cp": "CP1", "ead": 1_000_000, "rwa": 400_000, "is_btl": False},
             {"ref": "E2", "cp": "CP1", "ead": 2_000_000, "rwa": 800_000, "is_btl": True},
@@ -99,8 +106,8 @@ class TestBTLExcludedFromSMEFactor:
 
         result = calculator.apply_factors(exposures, crr_config).collect()
 
-        # total_cp_ead should include BTL
-        total_cp = result["total_cp_ead"][0]
+        # total_cp_drawn should include BTL
+        total_cp = result["total_cp_drawn"][0]
         assert total_cp == pytest.approx(3_000_000)
 
     def test_all_btl_no_factor(
@@ -117,7 +124,7 @@ class TestBTLExcludedFromSMEFactor:
         assert result["supporting_factor"].to_list() == pytest.approx([1.0, 1.0])
         assert result["rwa_post_factor"].to_list() == pytest.approx([400_000, 200_000])
 
-    def test_missing_column_defaults_false(
+    def test_missing_btl_column_defaults_false(
         self, calculator: SupportingFactorCalculator, crr_config: CalculationConfig,
     ) -> None:
         """No is_buy_to_let column -> same as all False (backward compat)."""
@@ -175,3 +182,168 @@ class TestBTLExcludedFromSMEFactor:
         sf = result["supporting_factor"][0]
         assert sf == pytest.approx(0.75), "Infrastructure factor should still apply to BTL"
         assert result["rwa_post_factor"][0] == pytest.approx(300_000)
+
+
+class TestDrawnOnlyTierWeighting:
+    """SME tier threshold uses drawn_amount + interest, not ead_final."""
+
+    def test_drawn_only_determines_tier(
+        self, calculator: SupportingFactorCalculator, crr_config: CalculationConfig,
+    ) -> None:
+        """
+        Counterparty with 1m drawn + 2m undrawn:
+        - ead_final = 3m (includes CCF-adjusted undrawn)
+        - drawn_amount = 1m → tier based on 1m (all tier 1) → factor = 0.7619
+        - NOT based on 3m (which would produce blended factor)
+        """
+        exposures = _make_exposures([
+            {"ref": "E1", "cp": "CP1",
+             "drawn": 1_000_000, "interest": 0.0,
+             "ead": 3_000_000,  # includes undrawn via CCF
+             "rwa": 3_000_000},
+        ])
+
+        result = calculator.apply_factors(exposures, crr_config).collect()
+
+        sf = result["supporting_factor"][0]
+        assert sf == pytest.approx(0.7619, rel=0.001), (
+            f"Factor should be pure tier 1 (0.7619) based on 1m drawn, got {sf}"
+        )
+
+    def test_mixed_drawn_undrawn_counterparty(
+        self, calculator: SupportingFactorCalculator, crr_config: CalculationConfig,
+    ) -> None:
+        """
+        Two exposures to same counterparty, total drawn = 4m.
+        E1: 2m drawn, 3m ead (has undrawn)
+        E2: 2m drawn, 2m ead (fully drawn)
+        Total drawn = 4m → blended factor based on 4m, NOT 5m.
+        """
+        threshold_gbp = float(
+            crr_config.supporting_factors.sme_exposure_threshold_eur
+            * crr_config.eur_gbp_rate
+        )
+
+        exposures = _make_exposures([
+            {"ref": "E1", "cp": "CP1", "drawn": 2_000_000, "ead": 3_000_000, "rwa": 3_000_000},
+            {"ref": "E2", "cp": "CP1", "drawn": 2_000_000, "ead": 2_000_000, "rwa": 2_000_000},
+        ])
+
+        result = calculator.apply_factors(exposures, crr_config).collect()
+
+        # total_cp_drawn = 4m (not 5m)
+        assert result["total_cp_drawn"][0] == pytest.approx(4_000_000)
+
+        # Blended factor for 4m drawn
+        expected_factor = (
+            min(4_000_000, threshold_gbp) * 0.7619
+            + max(4_000_000 - threshold_gbp, 0) * 0.85
+        ) / 4_000_000
+        sf = result["supporting_factor"][0]
+        assert sf == pytest.approx(expected_factor, rel=0.001), (
+            f"Factor based on 4m drawn should be {expected_factor:.4f}, got {sf}"
+        )
+
+    def test_zero_drawn_undrawn_only_gets_tier1(
+        self, calculator: SupportingFactorCalculator, crr_config: CalculationConfig,
+    ) -> None:
+        """
+        Counterparty with zero drawn (only undrawn commitments):
+        - drawn_amount = 0 → falls within tier 1 → factor = 0.7619
+        """
+        exposures = _make_exposures([
+            {"ref": "E1", "cp": "CP1",
+             "drawn": 0.0, "interest": 0.0,
+             "ead": 2_000_000,  # all from undrawn via CCF
+             "rwa": 2_000_000},
+        ])
+
+        result = calculator.apply_factors(exposures, crr_config).collect()
+
+        sf = result["supporting_factor"][0]
+        assert sf == pytest.approx(0.7619, rel=0.001), (
+            f"Zero drawn should get pure tier 1 factor 0.7619, got {sf}"
+        )
+
+    def test_interest_included_in_drawn_total(
+        self, calculator: SupportingFactorCalculator, crr_config: CalculationConfig,
+    ) -> None:
+        """
+        drawn_amount + interest = on-balance-sheet total for tiering.
+        2m drawn + 0.2m interest = 2.2m → near threshold.
+        """
+        threshold_gbp = float(
+            crr_config.supporting_factors.sme_exposure_threshold_eur
+            * crr_config.eur_gbp_rate
+        )
+
+        exposures = _make_exposures([
+            {"ref": "E1", "cp": "CP1",
+             "drawn": 2_000_000, "interest": 200_000.0,
+             "ead": 2_500_000,
+             "rwa": 2_500_000},
+        ])
+
+        result = calculator.apply_factors(exposures, crr_config).collect()
+
+        # total_cp_drawn = 2.2m (drawn + interest)
+        total = result["total_cp_drawn"][0]
+        assert total == pytest.approx(2_200_000)
+
+        # Factor based on 2.2m drawn+interest
+        drawn_total = 2_200_000
+        expected_factor = (
+            min(drawn_total, threshold_gbp) * 0.7619
+            + max(drawn_total - threshold_gbp, 0) * 0.85
+        ) / drawn_total
+        sf = result["supporting_factor"][0]
+        assert sf == pytest.approx(expected_factor, rel=0.001)
+
+    def test_fallback_to_ead_when_drawn_missing(
+        self, calculator: SupportingFactorCalculator, crr_config: CalculationConfig,
+    ) -> None:
+        """Without drawn_amount column, falls back to ead_final (backward compat)."""
+        exposures = _make_exposures(
+            [
+                {"ref": "E1", "cp": "CP1", "ead": 1_000_000, "rwa": 400_000},
+            ],
+            include_drawn=False,
+        )
+
+        result = calculator.apply_factors(exposures, crr_config).collect()
+
+        # Should still get SME factor based on ead_final
+        sf = result["supporting_factor"][0]
+        assert sf < 1.0, "Fallback to ead_final should still apply SME factor"
+        assert sf == pytest.approx(0.7619, rel=0.001)
+
+    def test_large_drawn_small_ead_uses_drawn_for_tier(
+        self, calculator: SupportingFactorCalculator, crr_config: CalculationConfig,
+    ) -> None:
+        """
+        Edge case: drawn > ead (possible after collateral deductions).
+        Tier should still be based on drawn amount.
+        """
+        threshold_gbp = float(
+            crr_config.supporting_factors.sme_exposure_threshold_eur
+            * crr_config.eur_gbp_rate
+        )
+
+        exposures = _make_exposures([
+            {"ref": "E1", "cp": "CP1",
+             "drawn": 5_000_000, "interest": 0.0,
+             "ead": 1_000_000,  # reduced by collateral
+             "rwa": 1_000_000},
+        ])
+
+        result = calculator.apply_factors(exposures, crr_config).collect()
+
+        # Factor based on 5m drawn (blended), not 1m ead
+        expected_factor = (
+            min(5_000_000, threshold_gbp) * 0.7619
+            + max(5_000_000 - threshold_gbp, 0) * 0.85
+        ) / 5_000_000
+        sf = result["supporting_factor"][0]
+        assert sf == pytest.approx(expected_factor, rel=0.001), (
+            f"Factor should be based on 5m drawn ({expected_factor:.4f}), got {sf}"
+        )


### PR DESCRIPTION
This pull request updates the SME supporting factor calculation logic to comply with CRR2 Article 501 by ensuring the tier threshold is applied to drawn (on-balance-sheet) amounts only, not the full post-CRM EAD. The changes affect both the implementation and the unit tests, improving accuracy and clarity in how supporting factors are applied, especially for SME exposures and Buy-to-Let (BTL) exclusions. Backward compatibility is maintained for cases where the `drawn_amount` column is missing.

**Supporting factor calculation logic updates:**

* The SME tier threshold and blended factor calculation now use `drawn_amount + interest` (on-balance-sheet owed) instead of `ead_final`, ensuring only drawn exposures are considered for tiering. [[1]](diffhunk://#diff-1215e62bdbca864817f6304a6e4b78f7b0a98114d0ba81eac9d5942799a1c344L12-R18) [[2]](diffhunk://#diff-1215e62bdbca864817f6304a6e4b78f7b0a98114d0ba81eac9d5942799a1c344L159-R186) [[3]](diffhunk://#diff-1215e62bdbca864817f6304a6e4b78f7b0a98114d0ba81eac9d5942799a1c344R217-R253)
* Counterparty-level aggregation for SME factor uses total drawn amounts (including BTL exposures) for tier calculation, and the resulting blended factor is applied to each exposure's full RWA. [[1]](diffhunk://#diff-1215e62bdbca864817f6304a6e4b78f7b0a98114d0ba81eac9d5942799a1c344L159-R186) [[2]](diffhunk://#diff-1215e62bdbca864817f6304a6e4b78f7b0a98114d0ba81eac9d5942799a1c344R217-R253) [[3]](diffhunk://#diff-1215e62bdbca864817f6304a6e4b78f7b0a98114d0ba81eac9d5942799a1c344L240-R274)
* BTL exposures are excluded from receiving the SME supporting factor but still contribute to the counterparty's total drawn amount for tier calculation.

**Documentation and function interface updates:**

* Docstrings and comments in `supporting_factors.py` have been updated to clarify that tiering is based on drawn-only amounts, and to reflect the new aggregation logic. [[1]](diffhunk://#diff-1215e62bdbca864817f6304a6e4b78f7b0a98114d0ba81eac9d5942799a1c344L60-R69) [[2]](diffhunk://#diff-1215e62bdbca864817f6304a6e4b78f7b0a98114d0ba81eac9d5942799a1c344L130-R136) [[3]](diffhunk://#diff-1215e62bdbca864817f6304a6e4b78f7b0a98114d0ba81eac9d5942799a1c344L159-R186)

**Unit test enhancements:**

* Unit tests now cover drawn-only tier weighting, BTL exclusion, infrastructure factor interactions, and fallback behavior for missing `drawn_amount`. New test cases validate edge scenarios such as zero drawn, mixed drawn/undrawn, and drawn greater than EAD. [[1]](diffhunk://#diff-c5e4ca11f7e7a2ec5822701fffe440923c24198e19f21b2c5f358898cc674c6bL2-R9) [[2]](diffhunk://#diff-c5e4ca11f7e7a2ec5822701fffe440923c24198e19f21b2c5f358898cc674c6bR51-R80) [[3]](diffhunk://#diff-c5e4ca11f7e7a2ec5822701fffe440923c24198e19f21b2c5f358898cc674c6bR185-R349)
* Test helper `_make_exposures` supports both drawn and EAD columns, and test assertions have been updated to use `total_cp_drawn` instead of `total_cp_ead`. [[1]](diffhunk://#diff-c5e4ca11f7e7a2ec5822701fffe440923c24198e19f21b2c5f358898cc674c6bR35-R42) [[2]](diffhunk://#diff-c5e4ca11f7e7a2ec5822701fffe440923c24198e19f21b2c5f358898cc674c6bR51-R80) [[3]](diffhunk://#diff-c5e4ca11f7e7a2ec5822701fffe440923c24198e19f21b2c5f358898cc674c6bL91-R110)

**Backward compatibility:**

* When `drawn_amount` is missing, the calculation falls back to using `ead_final` for tiering, ensuring compatibility with legacy data. [[1]](diffhunk://#diff-1215e62bdbca864817f6304a6e4b78f7b0a98114d0ba81eac9d5942799a1c344R217-R253) [[2]](diffhunk://#diff-c5e4ca11f7e7a2ec5822701fffe440923c24198e19f21b2c5f358898cc674c6bR185-R349)

**Test and naming consistency:**

* Test and variable names have been updated for clarity, replacing references to `total_cp_ead` with `total_cp_drawn` throughout. [[1]](diffhunk://#diff-c5e4ca11f7e7a2ec5822701fffe440923c24198e19f21b2c5f358898cc674c6bR51-R80) [[2]](diffhunk://#diff-c5e4ca11f7e7a2ec5822701fffe440923c24198e19f21b2c5f358898cc674c6bL91-R110) [[3]](diffhunk://#diff-c5e4ca11f7e7a2ec5822701fffe440923c24198e19f21b2c5f358898cc674c6bL120-R127)

---

[[1]](diffhunk://#diff-1215e62bdbca864817f6304a6e4b78f7b0a98114d0ba81eac9d5942799a1c344L12-R18) [[2]](diffhunk://#diff-1215e62bdbca864817f6304a6e4b78f7b0a98114d0ba81eac9d5942799a1c344L60-R69) [[3]](diffhunk://#diff-1215e62bdbca864817f6304a6e4b78f7b0a98114d0ba81eac9d5942799a1c344L130-R136) [[4]](diffhunk://#diff-1215e62bdbca864817f6304a6e4b78f7b0a98114d0ba81eac9d5942799a1c344L159-R186) [[5]](diffhunk://#diff-1215e62bdbca864817f6304a6e4b78f7b0a98114d0ba81eac9d5942799a1c344R217-R253) [[6]](diffhunk://#diff-1215e62bdbca864817f6304a6e4b78f7b0a98114d0ba81eac9d5942799a1c344L240-R274) [[7]](diffhunk://#diff-c5e4ca11f7e7a2ec5822701fffe440923c24198e19f21b2c5f358898cc674c6bL2-R9) [[8]](diffhunk://#diff-c5e4ca11f7e7a2ec5822701fffe440923c24198e19f21b2c5f358898cc674c6bR35-R42) [[9]](diffhunk://#diff-c5e4ca11f7e7a2ec5822701fffe440923c24198e19f21b2c5f358898cc674c6bR51-R80) [[10]](diffhunk://#diff-c5e4ca11f7e7a2ec5822701fffe440923c24198e19f21b2c5f358898cc674c6bL91-R110) [[11]](diffhunk://#diff-c5e4ca11f7e7a2ec5822701fffe440923c24198e19f21b2c5f358898cc674c6bL120-R127) [[12]](diffhunk://#diff-c5e4ca11f7e7a2ec5822701fffe440923c24198e19f21b2c5f358898cc674c6bR185-R349)