### PR TITLE
feat(cache): implement results caching with lazy loading

### DIFF
--- a/src/rwa_calc/api/__init__.py
+++ b/src/rwa_calc/api/__init__.py
@@ -4,13 +4,15 @@ RWA Calculator API Module.
 Public API for RWA calculations providing:
 - RWAService: Main service facade for calculations
 - Request/Response models: Clean interface contracts
+- ResultsCache: Memory-efficient parquet caching
 - Validation utilities: Data path validation
 
 Usage:
     from rwa_calc.api import RWAService, CalculationRequest
     from datetime import date
+    from pathlib import Path
 
-    service = RWAService()
+    service = RWAService(cache_dir=Path(".cache"))
     response = service.calculate(
         CalculationRequest(
             data_path="/path/to/data",
@@ -23,10 +25,7 @@ Usage:
     if response.success:
         print(f"Total RWA: {response.summary.total_rwa:,.0f}")
         print(f"Exposures: {response.summary.exposure_count}")
-        print(response.results)
-    else:
-        for error in response.errors:
-            print(f"{error.code}: {error.message}")
+        results_df = response.collect_results()
 """
 
 from rwa_calc.api.models import (
@@ -34,10 +33,13 @@ from rwa_calc.api.models import (
     CalculationRequest,
     CalculationResponse,
     PerformanceMetrics,
-    SummaryByDimension,
     SummaryStatistics,
     ValidationRequest,
     ValidationResponse,
+)
+from rwa_calc.api.results_cache import (
+    CachedResults,
+    ResultsCache,
 )
 from rwa_calc.api.service import (
     RWAService,
@@ -62,9 +64,11 @@ __all__ = [
     "CalculationResponse",
     "ValidationResponse",
     "SummaryStatistics",
-    "SummaryByDimension",
     "APIError",
     "PerformanceMetrics",
+    # Cache
+    "ResultsCache",
+    "CachedResults",
     # Validation
     "DataPathValidator",
     "validate_data_path",

--- a/src/rwa_calc/api/results_cache.py
+++ b/src/rwa_calc/api/results_cache.py
@@ -1,0 +1,210 @@
+"""
+Results cache for streaming RWA results to parquet.
+
+CachedResults: Frozen dataclass holding paths to parquet files with lazy scan accessors
+ResultsCache: Manages cache directory lifecycle — sink, load, paginate
+
+Eliminates in-memory materialization by sinking results directly to parquet
+and scanning lazily everywhere else. Peak memory drops from ~3x to ~1x dataset size.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+import polars as pl
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Cached Results Handle
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class CachedResults:
+    """
+    Handle to cached parquet results with lazy scan accessors.
+
+    Holds paths to parquet files — no data is loaded until scan methods are called.
+
+    Attributes:
+        results_path: Path to main results parquet file
+        summary_by_class_path: Path to class summary parquet (or None)
+        summary_by_approach_path: Path to approach summary parquet (or None)
+        metadata_path: Path to metadata JSON file
+    """
+
+    results_path: Path
+    summary_by_class_path: Path | None = None
+    summary_by_approach_path: Path | None = None
+    metadata_path: Path | None = None
+
+    def scan_results(self) -> pl.LazyFrame:
+        """Lazy-scan the results parquet file."""
+        return pl.scan_parquet(self.results_path)
+
+    def scan_summary_by_class(self) -> pl.LazyFrame | None:
+        """Lazy-scan the class summary parquet, or None if not available."""
+        if self.summary_by_class_path and self.summary_by_class_path.exists():
+            return pl.scan_parquet(self.summary_by_class_path)
+        return None
+
+    def scan_summary_by_approach(self) -> pl.LazyFrame | None:
+        """Lazy-scan the approach summary parquet, or None if not available."""
+        if self.summary_by_approach_path and self.summary_by_approach_path.exists():
+            return pl.scan_parquet(self.summary_by_approach_path)
+        return None
+
+
+# =============================================================================
+# Results Cache Manager
+# =============================================================================
+
+
+class ResultsCache:
+    """
+    Manages the cache directory lifecycle for RWA results.
+
+    Sinks LazyFrames to parquet via streaming, loads cached handles
+    without reading data, and provides paginated access.
+
+    Usage:
+        cache = ResultsCache(Path(".cache"))
+        cached = cache.sink_results(results_lf, summary_class_lf, summary_approach_lf, metadata)
+        lf = cached.scan_results()
+        page = cache.get_page(lf, offset=0, page_size=100)
+    """
+
+    def __init__(self, cache_dir: Path) -> None:
+        """
+        Initialize cache with directory path, creating it if needed.
+
+        Args:
+            cache_dir: Directory for cached parquet files
+        """
+        self._cache_dir = cache_dir
+        self._cache_dir.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def cache_dir(self) -> Path:
+        """Return the cache directory path."""
+        return self._cache_dir
+
+    def sink_results(
+        self,
+        results: pl.LazyFrame,
+        summary_by_class: pl.LazyFrame | None = None,
+        summary_by_approach: pl.LazyFrame | None = None,
+        metadata: dict | None = None,
+    ) -> CachedResults:
+        """
+        Stream results to parquet, collect small summaries eagerly, write metadata.
+
+        Falls back to collect().write_parquet() if sink_parquet() fails.
+
+        Args:
+            results: Main results LazyFrame (streamed to parquet)
+            summary_by_class: Optional class summary LazyFrame (collected eagerly)
+            summary_by_approach: Optional approach summary LazyFrame (collected eagerly)
+            metadata: Optional metadata dict written as JSON
+
+        Returns:
+            CachedResults handle with paths to all cached files
+        """
+        results_path = self._cache_dir / "last_results.parquet"
+        metadata_path = self._cache_dir / "last_results_meta.json"
+        class_path = self._cache_dir / "last_summary_by_class.parquet"
+        approach_path = self._cache_dir / "last_summary_by_approach.parquet"
+
+        # Sink main results to parquet via streaming
+        self._sink_or_collect(results, results_path)
+
+        # Collect small summary frames eagerly (they're tiny)
+        class_out = None
+        if summary_by_class is not None:
+            try:
+                summary_by_class.collect().write_parquet(class_path)
+                class_out = class_path
+            except Exception:
+                logger.warning("Failed to write summary_by_class parquet")
+
+        approach_out = None
+        if summary_by_approach is not None:
+            try:
+                summary_by_approach.collect().write_parquet(approach_path)
+                approach_out = approach_path
+            except Exception:
+                logger.warning("Failed to write summary_by_approach parquet")
+
+        # Write metadata JSON
+        if metadata is not None:
+            metadata_path.write_text(json.dumps(metadata, indent=2))
+
+        return CachedResults(
+            results_path=results_path,
+            summary_by_class_path=class_out,
+            summary_by_approach_path=approach_out,
+            metadata_path=metadata_path if metadata is not None else None,
+        )
+
+    def load_cached(self) -> CachedResults | None:
+        """
+        Load cached result handles without reading any data.
+
+        Returns:
+            CachedResults if cache exists, None otherwise
+        """
+        results_path = self._cache_dir / "last_results.parquet"
+        if not results_path.exists():
+            return None
+
+        metadata_path = self._cache_dir / "last_results_meta.json"
+        class_path = self._cache_dir / "last_summary_by_class.parquet"
+        approach_path = self._cache_dir / "last_summary_by_approach.parquet"
+
+        return CachedResults(
+            results_path=results_path,
+            summary_by_class_path=class_path if class_path.exists() else None,
+            summary_by_approach_path=approach_path if approach_path.exists() else None,
+            metadata_path=metadata_path if metadata_path.exists() else None,
+        )
+
+    def get_page(
+        self,
+        lazy: pl.LazyFrame,
+        offset: int,
+        page_size: int,
+    ) -> pl.DataFrame:
+        """
+        Materialize a single page of results from a LazyFrame.
+
+        Args:
+            lazy: LazyFrame to paginate
+            offset: Row offset (0-based)
+            page_size: Number of rows to return
+
+        Returns:
+            DataFrame with the requested page of results
+        """
+        return lazy.slice(offset, page_size).collect()
+
+    def _sink_or_collect(self, lf: pl.LazyFrame, path: Path) -> None:
+        """
+        Attempt streaming sink_parquet; fall back to collect + write_parquet.
+
+        Args:
+            lf: LazyFrame to write
+            path: Output parquet file path
+        """
+        try:
+            lf.sink_parquet(path)
+        except Exception:
+            logger.warning(
+                "sink_parquet() failed, falling back to collect().write_parquet()"
+            )
+            lf.collect().write_parquet(path)

--- a/tests/unit/api/test_results_cache.py
+++ b/tests/unit/api/test_results_cache.py
@@ -1,0 +1,195 @@
+"""Unit tests for the ResultsCache module.
+
+Tests cover:
+- ResultsCache: sink_results, load_cached, get_page
+- CachedResults: scan accessors, path validation
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from rwa_calc.api.results_cache import CachedResults, ResultsCache
+
+
+# =============================================================================
+# CachedResults Tests
+# =============================================================================
+
+
+class TestCachedResults:
+    """Tests for CachedResults scan accessors."""
+
+    def test_scan_results_returns_lazyframe(self, tmp_path: Path) -> None:
+        """scan_results should return a LazyFrame."""
+        results_path = tmp_path / "results.parquet"
+        pl.DataFrame({"a": [1, 2, 3]}).write_parquet(results_path)
+
+        cached = CachedResults(results_path=results_path)
+        lf = cached.scan_results()
+
+        assert isinstance(lf, pl.LazyFrame)
+        assert lf.collect().height == 3
+
+    def test_scan_summary_by_class_returns_lazyframe(self, tmp_path: Path) -> None:
+        """scan_summary_by_class should return LazyFrame when path exists."""
+        results_path = tmp_path / "results.parquet"
+        class_path = tmp_path / "class.parquet"
+        pl.DataFrame({"a": [1]}).write_parquet(results_path)
+        pl.DataFrame({"class": ["corporate"], "rwa": [100.0]}).write_parquet(class_path)
+
+        cached = CachedResults(
+            results_path=results_path,
+            summary_by_class_path=class_path,
+        )
+        lf = cached.scan_summary_by_class()
+
+        assert lf is not None
+        assert isinstance(lf, pl.LazyFrame)
+
+    def test_scan_summary_by_class_returns_none_when_no_path(self, tmp_path: Path) -> None:
+        """scan_summary_by_class should return None when path is None."""
+        results_path = tmp_path / "results.parquet"
+        pl.DataFrame({"a": [1]}).write_parquet(results_path)
+
+        cached = CachedResults(results_path=results_path)
+        assert cached.scan_summary_by_class() is None
+
+    def test_scan_summary_by_approach_returns_none_when_file_missing(self, tmp_path: Path) -> None:
+        """scan_summary_by_approach should return None when file doesn't exist."""
+        results_path = tmp_path / "results.parquet"
+        pl.DataFrame({"a": [1]}).write_parquet(results_path)
+
+        cached = CachedResults(
+            results_path=results_path,
+            summary_by_approach_path=tmp_path / "nonexistent.parquet",
+        )
+        assert cached.scan_summary_by_approach() is None
+
+
+# =============================================================================
+# ResultsCache Tests
+# =============================================================================
+
+
+class TestResultsCache:
+    """Tests for ResultsCache sink, load, and pagination."""
+
+    def test_creates_cache_directory(self, tmp_path: Path) -> None:
+        """Should create cache directory if it doesn't exist."""
+        cache_dir = tmp_path / "new_cache"
+        assert not cache_dir.exists()
+
+        ResultsCache(cache_dir)
+        assert cache_dir.exists()
+
+    def test_sink_results_creates_parquet(self, tmp_path: Path) -> None:
+        """sink_results should create a parquet file."""
+        cache = ResultsCache(tmp_path / "cache")
+        lf = pl.LazyFrame({"x": [1, 2, 3], "y": [4.0, 5.0, 6.0]})
+
+        cached = cache.sink_results(results=lf)
+
+        assert cached.results_path.exists()
+        df = pl.read_parquet(cached.results_path)
+        assert df.height == 3
+        assert df.columns == ["x", "y"]
+
+    def test_sink_results_with_summaries(self, tmp_path: Path) -> None:
+        """sink_results should write summary parquet files."""
+        cache = ResultsCache(tmp_path / "cache")
+        results_lf = pl.LazyFrame({"a": [1, 2]})
+        class_lf = pl.LazyFrame({"class": ["corp"], "rwa": [100.0]})
+        approach_lf = pl.LazyFrame({"approach": ["SA"], "rwa": [100.0]})
+
+        cached = cache.sink_results(
+            results=results_lf,
+            summary_by_class=class_lf,
+            summary_by_approach=approach_lf,
+        )
+
+        assert cached.summary_by_class_path is not None
+        assert cached.summary_by_class_path.exists()
+        assert cached.summary_by_approach_path is not None
+        assert cached.summary_by_approach_path.exists()
+
+    def test_sink_results_writes_metadata(self, tmp_path: Path) -> None:
+        """sink_results should write metadata JSON."""
+        cache = ResultsCache(tmp_path / "cache")
+        lf = pl.LazyFrame({"a": [1]})
+        meta = {"framework": "CRR", "total_rwa": 1000.0}
+
+        cached = cache.sink_results(results=lf, metadata=meta)
+
+        assert cached.metadata_path is not None
+        assert cached.metadata_path.exists()
+        loaded_meta = json.loads(cached.metadata_path.read_text())
+        assert loaded_meta["framework"] == "CRR"
+
+    def test_sink_results_no_metadata(self, tmp_path: Path) -> None:
+        """sink_results without metadata should set metadata_path to None."""
+        cache = ResultsCache(tmp_path / "cache")
+        lf = pl.LazyFrame({"a": [1]})
+
+        cached = cache.sink_results(results=lf)
+
+        assert cached.metadata_path is None
+
+    def test_load_cached_returns_handles(self, tmp_path: Path) -> None:
+        """load_cached should return CachedResults after sink."""
+        cache = ResultsCache(tmp_path / "cache")
+        lf = pl.LazyFrame({"a": [1, 2, 3]})
+        class_lf = pl.LazyFrame({"class": ["x"]})
+
+        cache.sink_results(results=lf, summary_by_class=class_lf)
+        loaded = cache.load_cached()
+
+        assert loaded is not None
+        assert loaded.results_path.exists()
+        assert loaded.summary_by_class_path is not None
+
+    def test_load_cached_returns_none_when_empty(self, tmp_path: Path) -> None:
+        """load_cached should return None when no cache exists."""
+        cache = ResultsCache(tmp_path / "empty_cache")
+
+        assert cache.load_cached() is None
+
+    def test_get_page_returns_slice(self, tmp_path: Path) -> None:
+        """get_page should return the requested page of data."""
+        cache = ResultsCache(tmp_path / "cache")
+        lf = pl.LazyFrame({"x": list(range(100))})
+        cached = cache.sink_results(results=lf)
+
+        page = cache.get_page(cached.scan_results(), offset=10, page_size=5)
+
+        assert isinstance(page, pl.DataFrame)
+        assert page.height == 5
+        assert page["x"].to_list() == [10, 11, 12, 13, 14]
+
+    def test_get_page_past_end(self, tmp_path: Path) -> None:
+        """get_page past end of data should return empty or partial."""
+        cache = ResultsCache(tmp_path / "cache")
+        lf = pl.LazyFrame({"x": [1, 2, 3]})
+        cached = cache.sink_results(results=lf)
+
+        page = cache.get_page(cached.scan_results(), offset=10, page_size=5)
+        assert page.height == 0
+
+    def test_sink_empty_lazyframe(self, tmp_path: Path) -> None:
+        """Should handle sinking an empty LazyFrame."""
+        cache = ResultsCache(tmp_path / "cache")
+        lf = pl.LazyFrame({
+            "a": pl.Series([], dtype=pl.String),
+            "b": pl.Series([], dtype=pl.Float64),
+        })
+
+        cached = cache.sink_results(results=lf)
+
+        assert cached.results_path.exists()
+        df = pl.read_parquet(cached.results_path)
+        assert df.height == 0
+        assert df.columns == ["a", "b"]

--- a/tests/unit/api/test_service.py
+++ b/tests/unit/api/test_service.py
@@ -75,9 +75,9 @@ def temp_valid_dir(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
-def service() -> RWAService:
-    """Create an RWAService instance."""
-    return RWAService()
+def service(tmp_path: Path) -> RWAService:
+    """Create an RWAService instance with a temp cache directory."""
+    return RWAService(cache_dir=tmp_path / "service_cache")
 
 
 # =============================================================================
@@ -88,11 +88,12 @@ def service() -> RWAService:
 class TestRWAServiceInit:
     """Tests for RWAService initialization."""
 
-    def test_creates_with_default_components(self) -> None:
+    def test_creates_with_default_components(self, tmp_path: Path) -> None:
         """Should create service with default components."""
-        service = RWAService()
+        service = RWAService(cache_dir=tmp_path / "cache")
         assert service._validator is not None
         assert service._formatter is not None
+        assert service._cache is not None
 
 
 class TestRWAServiceValidateDataPath:
@@ -329,6 +330,7 @@ class TestQuickCalculate:
         response = quick_calculate(
             data_path=tmp_path / "nonexistent",
             framework="CRR",
+            cache_dir=tmp_path / "cache",
         )
 
         assert response.success is False

--- a/tests/unit/test_irb_approach_selection.py
+++ b/tests/unit/test_irb_approach_selection.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from datetime import date
 from decimal import Decimal
+from pathlib import Path
 
 import polars as pl
 import pytest
@@ -109,9 +110,9 @@ class TestServiceCreateConfig:
     """Tests for RWAService._create_config() with different approach selections."""
 
     @pytest.fixture
-    def service(self) -> RWAService:
+    def service(self, tmp_path: Path) -> RWAService:
         """Return an RWAService instance."""
-        return RWAService()
+        return RWAService(cache_dir=tmp_path / "cache")
 
     def test_create_config_sa_only(self, service: RWAService) -> None:
         """_create_config with irb_approach='sa_only' should use sa_only permissions."""


### PR DESCRIPTION
This pull request refactors the RWA Calculator API's result formatting and caching to make result handling more memory-efficient and to streamline summary statistics computation. The main changes remove in-memory DataFrame materialization in favor of lazy aggregation and parquet-based caching, update the API response structure, and simplify the codebase by eliminating unused models and utilities.

**Result formatting and caching improvements:**
- The `ResultFormatter` now streams results and summaries directly to parquet files using `ResultsCache`, removing the need to materialize large DataFrames in memory. The API responses now return paths to these cached files instead of DataFrame objects. [[1]](diffhunk://#diff-6bf4b1bcdd93075493d59949fff011c7eb7928473a8f4047a347314e84165068L39-R49) [[2]](diffhunk://#diff-6bf4b1bcdd93075493d59949fff011c7eb7928473a8f4047a347314e84165068R59-R143) [[3]](diffhunk://#diff-6bf4b1bcdd93075493d59949fff011c7eb7928473a8f4047a347314e84165068L145-R160) [[4]](diffhunk://#diff-6bf4b1bcdd93075493d59949fff011c7eb7928473a8f4047a347314e84165068R169-R170) [[5]](diffhunk://#diff-6bf4b1bcdd93075493d59949fff011c7eb7928473a8f4047a347314e84165068L166-R275) [[6]](diffhunk://#diff-6bf4b1bcdd93075493d59949fff011c7eb7928473a8f4047a347314e84165068L275-L423)
- The summary statistics computation is now performed via lightweight, single-pass lazy aggregations, which avoids full result DataFrame collection and reduces memory usage. [[1]](diffhunk://#diff-6bf4b1bcdd93075493d59949fff011c7eb7928473a8f4047a347314e84165068L166-R275) [[2]](diffhunk://#diff-6bf4b1bcdd93075493d59949fff011c7eb7928473a8f4047a347314e84165068L275-L423)

**API and usage updates:**
- The public API (`rwa_calc.api.__init__`) is updated to expose `ResultsCache` and `CachedResults`, and the example usage now demonstrates initializing `RWAService` with a cache directory. [[1]](diffhunk://#diff-c5b64f93019ad2fc4d84c91eae87a9119915261a4a81e9c10eed588967817eb9R7-R15) [[2]](diffhunk://#diff-c5b64f93019ad2fc4d84c91eae87a9119915261a4a81e9c10eed588967817eb9L26-R43) [[3]](diffhunk://#diff-c5b64f93019ad2fc4d84c91eae87a9119915261a4a81e9c10eed588967817eb9L65-R71)
- The API response model is updated to remove direct DataFrame returns and instead provide parquet file paths for results and summaries.

**Codebase cleanup and simplification:**
- The unused `SummaryByDimension` dataclass and related summary materialization utilities are removed, as all summary breakdowns are now handled via parquet caching and lazy aggregation. [[1]](diffhunk://#diff-1dbf42cf0f5ed967c24d4b0782bea4e51d39c6db84d7f1de7a79ae15133fd472L131-L146) [[2]](diffhunk://#diff-6bf4b1bcdd93075493d59949fff011c7eb7928473a8f4047a347314e84165068L275-L423)
- Type-checking imports and redundant code are cleaned up for clarity and maintainability.

**Documentation updates:**
- Docstrings and usage examples throughout the API and formatter modules are updated to reflect the new memory-efficient, parquet-based result handling. [[1]](diffhunk://#diff-6bf4b1bcdd93075493d59949fff011c7eb7928473a8f4047a347314e84165068L5-R7) [[2]](diffhunk://#diff-6bf4b1bcdd93075493d59949fff011c7eb7928473a8f4047a347314e84165068L39-R49)

Overall, these changes make the RWA Calculator API more scalable and robust for large datasets, while simplifying the interface for downstream consumers.