### PR TITLE
refactor: Replace `Enum` with `StrEnum` and `IntEnum` and update docstrings

### DIFF
--- a/src/rwa_calc/domain/enums.py
+++ b/src/rwa_calc/domain/enums.py
@@ -334,14 +334,14 @@ class RiskType(StrEnum):
     FR = "full_risk"
     """
     Full Risk - 100% CCF under SA and F-IRB
-    
+
     -- Direct credit substitutes, guarantees, acceptances
     """
 
     MR = "medium_risk"
     """
     Medium Risk - 50% CCF under SA, 75% CCF under F-IRB (CRR Art. 166(8))
-    
+
     -- NIFs, RUFs, standby LCs, committed undrawn facilities
     """
 
@@ -372,7 +372,7 @@ class IRBApproachOption(StrEnum):
     FIRB = "firb"
     """
     Foundation IRB permitted (where regulatory allowed).
-    
+
     - Retail classes fall back to SA (FIRB not permitted for retail)
     - Specialised lending can use FIRB or slotting
     """
@@ -380,21 +380,21 @@ class IRBApproachOption(StrEnum):
     AIRB = "airb"
     """
     Advanced IRB permitted (where regulatory allowed).
-    
+
     - Specialised lending uses slotting (AIRB not permitted)
     """
 
     FULL_IRB = "full_irb"
     """
     Full IRB permissions (FIRB and AIRB).
-    
+
     - AIRB takes precedence when both are permitted
     """
 
     RETAIL_AIRB_CORPORATE_FIRB = "retail_airb_corporate_firb"
     """
     Hybrid approach: AIRB for retail and FIRB for corporate.
-    
+
     Corporates can be reclassified to retail if:
     - Managed as part of retail pool (is_managed_as_retail=True)
     - Aggregated exposure < EUR 1m


### PR DESCRIPTION
## Summary
This PR refactors the codebase to replace the use of `Enum` with `StrEnum` and `IntEnum` as per Python 3.11 standards. Docstrings were also updated to reflect these changes.

## Regulatory Context
<!-- Which Basel 3.1 requirement(s) does this relate to? Reference PS9/24 sections, CRR articles, or Basel standards where relevant -->

## Changes

### Calculation Logic
<!-- Any changes to RWA formulas, risk weights, or regulatory treatments -->
None

### Data Model
<!-- Changes to schemas, Polars DataFrames, or data structures -->
 
### Other
- Refactored enums to use `StrEnum` and `IntEnum`.
- Updated associated docstrings for clarity and compliance with standard formatting.

## Testing
<!-- How was this validated? Include sample calculations if relevant -->
- [ ] Unit tests pass
- [ ] Calculation outputs verified against manual/Excel check
- [ ] Edge cases considered (e.g. missing data, boundary values)

## Assumptions & Interpretations
<!-- Document any regulatory interpretation decisions made - these are valuable for audit trail -->

## Breaking Changes
This PR introduces breaking changes due to the refactoring of `Enum` types to `StrEnum` and `IntEnum`, which may affect usage dependent on the original `Enum` implementation.

## Related
<!-- Link issues, reference PRA/Basel docs consulted -->

## Additional Context
The above removes the requirement to reference `.value` when leveraging enums, as `StrEnum` members are also strings. This provides stricter type safety while allowing for richer documentation of individual enumerations, accessible through IDE tooltips / autocomplete.

**Benefits:**
- **Type safety**: IDE autocomplete and type checking for valid risk types
- **No `.value` calls**: `StrEnum` members can be used directly as strings
- **Self-documenting**: Docstrings provide regulatory context at the point of use
- **Single source of truth**: Enum definition serves as both code and documentation

## Linting / Formatting
<img width="1369" height="99" alt="image" src="https://github.com/user-attachments/assets/722336b9-c540-4e78-816b-15fd818bb44f" />
