### PR TITLE
feat(netting): implement on-balance sheet netting support

### DIFF
--- a/docs/appendix/changelog.md
+++ b/docs/appendix/changelog.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### On-Balance Sheet Netting (CRR Article 195)
+Support for on-balance sheet netting of mutual claims when a legally enforceable netting agreement exists:
+
+- **New field**: `has_netting_agreement` on `LOAN_SCHEMA` and `Loan` fixture
+- **Synthetic cash collateral**: Negative-drawn netting-eligible loans generate cash collateral that reduces sibling exposures pro-rata within the same facility
+- **SA**: EAD reduced by netting pool (cash = 0% haircut)
+- **F-IRB**: LGD reduced via cash collateral path (0% LGD)
+- **FX mismatch**: 8% haircut applied when currencies differ
+- **Backward compatible**: Optional column; existing data unaffected
+
 #### Service API Documentation
 Restructured user-facing documentation to promote the high-level Service API (`quick_calculate`, `RWAService`) as the primary entry point:
 

--- a/docs/user-guide/methodology/crm.md
+++ b/docs/user-guide/methodology/crm.md
@@ -311,6 +311,45 @@ adjustment = (3 - 0.25) / (5 - 0.25) = 2.75 / 4.75 = 0.579
 # £4m guarantee provides £2.32m effective protection
 ```
 
+## On-Balance Sheet Netting (CRR Art. 195)
+
+When a legally enforceable netting agreement exists, mutual claims between the firm and the counterparty can be netted. In practice, this means a negative drawn amount (credit balance / deposit) on one loan can reduce sibling exposures within the same facility.
+
+### How It Works
+
+The calculator implements netting as **synthetic cash collateral**:
+
+1. Loans with `has_netting_agreement = True` and `drawn_amount < 0` contribute their absolute drawn amount to a **netting pool** per `(parent_facility_reference, currency)`
+2. The pool is allocated **pro-rata by `ead_gross`** to positive-drawn netting-eligible siblings in the same facility
+3. Each allocation becomes a synthetic cash collateral row fed into the existing collateral pipeline
+
+This reuses the full collateral mechanics:
+
+- **SA**: Cash collateral (0% haircut) directly reduces EAD
+- **F-IRB**: Cash collateral has 0% LGD → weighted LGD reduction
+- **FX mismatch**: 8% haircut if the negative-drawn loan's currency differs from the positive sibling's
+
+### No Double-Counting
+
+- The negative-drawn loan's own EAD is already floored to 0 by `drawn_for_ead()` — it never self-reduces
+- The synthetic collateral only benefits positive-drawn siblings — distinct mechanism
+
+### Input Data
+
+Set `has_netting_agreement = True` on the loan record to enable netting. The loan must be under a facility (`parent_facility_reference` is not null) for netting to apply.
+
+### Example
+
+```python
+# Facility FAC_01 with two loans:
+# Loan A: drawn = -200 (credit balance), has_netting_agreement = True
+# Loan B: drawn = 1000, has_netting_agreement = True
+
+# Result (SA):
+# Loan A EAD = 0 (floored)
+# Loan B EAD = 1000 - 200 = 800 (reduced by synthetic cash collateral)
+```
+
 ## Cross-Approach CCF Substitution
 
 When an IRB exposure is guaranteed by a counterparty that falls under the Standardised Approach, the guaranteed portion uses **SA CCFs** instead of the IRB supervisory CCFs. This reflects the principle that the risk of the guaranteed portion should be treated consistently with the guarantor's approach.
@@ -587,6 +626,7 @@ provision = {
 
 | Topic | CRR Article | BCBS CRE |
 |-------|-------------|----------|
+| On-balance sheet netting | Art. 195 | CRE22.11-14 |
 | CRM overview | Art. 192-194 | CRE22.1-10 |
 | Financial collateral | Art. 197-200 | CRE22.35-70 |
 | Haircuts | Art. 224-227 | CRE22.50-55 |

--- a/src/rwa_calc/data/schemas.py
+++ b/src/rwa_calc/data/schemas.py
@@ -88,6 +88,7 @@ LOAN_SCHEMA = {
     "beel": pl.Float64,  # Best estimate expected loss
     "seniority": pl.String,  # senior, subordinated - affects F-IRB LGD (45% vs 75%)
     "is_buy_to_let": pl.Boolean,  # BTL property lending - excluded from SME supporting factor (CRR Art. 501)
+    "has_netting_agreement": pl.Boolean,  # CRR Art. 195: on-balance sheet netting
     # Note: CCF fields (risk_type, ccf_modelled, is_short_term_trade_lc) are NOT included
     # because CCF only applies to off-balance sheet items (undrawn commitments, contingents).
     # Drawn loans are already on-balance sheet, so EAD = drawn_amount + interest directly.

--- a/src/rwa_calc/engine/crm/processor.py
+++ b/src/rwa_calc/engine/crm/processor.py
@@ -366,9 +366,22 @@ class CRMProcessor:
         # Step 3: Initialize EAD columns
         exposures = self._initialize_ead(exposures)
 
+        # Step 3.5: Generate synthetic collateral from netting (CRR Art. 195)
+        netting_collateral = self._generate_netting_collateral(exposures)
+        collateral: pl.LazyFrame | None = data.collateral
+        if netting_collateral is not None:
+            if collateral is not None and has_required_columns(
+                collateral, self.COLLATERAL_REQUIRED_COLUMNS
+            ):
+                collateral = pl.concat(
+                    [collateral, netting_collateral], how="diagonal"
+                )
+            else:
+                collateral = netting_collateral
+
         # Step 4: Apply collateral (if available and valid)
-        if has_required_columns(data.collateral, self.COLLATERAL_REQUIRED_COLUMNS):
-            exposures = self.apply_collateral(exposures, data.collateral, config)
+        if has_required_columns(collateral, self.COLLATERAL_REQUIRED_COLUMNS):
+            exposures = self.apply_collateral(exposures, collateral, config)
         else:
             # No collateral: still need to set F-IRB supervisory LGD based on seniority
             exposures = self._apply_firb_supervisory_lgd_no_collateral(exposures)
@@ -456,8 +469,21 @@ class CRMProcessor:
         # (collateral, guarantees, finalize, audit) work on materialised data.
         exposures = exposures.collect().lazy()
 
-        if has_required_columns(data.collateral, self.COLLATERAL_REQUIRED_COLUMNS):
-            exposures = self.apply_collateral(exposures, data.collateral, config)
+        # Generate synthetic collateral from netting (CRR Art. 195)
+        netting_collateral = self._generate_netting_collateral(exposures)
+        collateral: pl.LazyFrame | None = data.collateral
+        if netting_collateral is not None:
+            if collateral is not None and has_required_columns(
+                collateral, self.COLLATERAL_REQUIRED_COLUMNS
+            ):
+                collateral = pl.concat(
+                    [collateral, netting_collateral], how="diagonal"
+                )
+            else:
+                collateral = netting_collateral
+
+        if has_required_columns(collateral, self.COLLATERAL_REQUIRED_COLUMNS):
+            exposures = self.apply_collateral(exposures, collateral, config)
         else:
             exposures = self._apply_firb_supervisory_lgd_no_collateral(exposures)
 
@@ -597,6 +623,121 @@ class CRMProcessor:
                 pl.col("ead_after_collateral").alias("ead_after_guarantee"),
             ]
         )
+
+    def _generate_netting_collateral(
+        self,
+        exposures: pl.LazyFrame,
+    ) -> pl.LazyFrame | None:
+        """
+        Generate synthetic cash collateral from negative-drawn netting-eligible loans.
+
+        When a loan has a negative drawn amount (credit balance) and is covered by a
+        netting agreement (CRR Art. 195), the absolute value of that negative balance
+        can reduce sibling exposures in the same facility — treated as cash collateral.
+
+        The synthetic collateral rows are allocated pro-rata by ead_gross to positive-drawn
+        netting-eligible siblings within the same facility. Netting pools are grouped by
+        (facility, currency) so the haircut pipeline can apply FX haircuts when the pool
+        currency differs from the sibling's currency.
+
+        Args:
+            exposures: Exposures with ead_gross initialised
+
+        Returns:
+            LazyFrame of synthetic collateral rows, or None if no netting applies
+        """
+        schema = exposures.collect_schema()
+        if "has_netting_agreement" not in schema.names():
+            return None
+        if "parent_facility_reference" not in schema.names():
+            return None
+
+        netting_eligible = exposures.filter(
+            pl.col("has_netting_agreement") == True  # noqa: E712
+        )
+
+        # Negative-drawn loans: these provide the netting pool
+        negative_loans = netting_eligible.filter(
+            (pl.col("drawn_amount") < 0)
+            & pl.col("parent_facility_reference").is_not_null()
+        )
+
+        # Sum abs(drawn_amount) per (facility, currency) → netting pool
+        # Currency is kept so the synthetic collateral carries the source currency,
+        # allowing the haircut pipeline to apply FX haircuts when currencies differ.
+        netting_pool = negative_loans.group_by(
+            ["parent_facility_reference", "currency"]
+        ).agg(
+            pl.col("drawn_amount").abs().sum().alias("netting_pool"),
+        ).rename({"currency": "_pool_currency"})
+
+        # Positive-drawn netting-eligible siblings in same facilities
+        positive_siblings = netting_eligible.filter(
+            (pl.col("ead_gross") > 0)
+            & pl.col("parent_facility_reference").is_not_null()
+        ).select(
+            "exposure_reference",
+            "parent_facility_reference",
+            "currency",
+            "ead_gross",
+            "maturity_date",
+        )
+
+        # Total EAD per facility for pro-rata allocation
+        facility_totals = positive_siblings.group_by(
+            "parent_facility_reference"
+        ).agg(
+            pl.col("ead_gross").sum().alias("_facility_total_ead"),
+        )
+
+        # Join: siblings × pool (cross-join on facility — one row per sibling per currency pool)
+        allocated = (
+            positive_siblings.join(
+                netting_pool,
+                on="parent_facility_reference",
+                how="inner",
+            )
+            .join(
+                facility_totals,
+                on="parent_facility_reference",
+                how="left",
+            )
+            .filter(pl.col("_facility_total_ead") > 0)
+        )
+
+        # Pro-rata market_value per sibling
+        allocated = allocated.with_columns(
+            (pl.col("netting_pool") * pl.col("ead_gross") / pl.col("_facility_total_ead")).alias(
+                "market_value"
+            ),
+        )
+
+        # Build synthetic collateral rows — currency from the pool (source of funds)
+        synthetic = allocated.select(
+            (pl.lit("NETTING_") + pl.col("exposure_reference")).alias("collateral_reference"),
+            pl.lit("cash").alias("collateral_type"),
+            pl.col("_pool_currency").alias("currency"),
+            pl.col("maturity_date"),
+            pl.col("market_value"),
+            pl.lit(None).cast(pl.Float64).alias("nominal_value"),
+            pl.lit(None).cast(pl.Float64).alias("pledge_percentage"),
+            pl.lit("loan").alias("beneficiary_type"),
+            pl.col("exposure_reference").alias("beneficiary_reference"),
+            pl.lit(None).cast(pl.Int8).alias("issuer_cqs"),
+            pl.lit(None).cast(pl.String).alias("issuer_type"),
+            pl.lit(None).cast(pl.Float64).alias("residual_maturity_years"),
+            pl.lit(True).alias("is_eligible_financial_collateral"),
+            pl.lit(True).alias("is_eligible_irb_collateral"),
+            pl.lit(None).cast(pl.Date).alias("valuation_date"),
+            pl.lit(None).cast(pl.String).alias("valuation_type"),
+            pl.lit(None).cast(pl.String).alias("property_type"),
+            pl.lit(None).cast(pl.Float64).alias("property_ltv"),
+            pl.lit(None).cast(pl.Boolean).alias("is_income_producing"),
+            pl.lit(None).cast(pl.Boolean).alias("is_adc"),
+            pl.lit(None).cast(pl.Boolean).alias("is_presold"),
+        )
+
+        return synthetic
 
     def apply_collateral(
         self,

--- a/src/rwa_calc/engine/hierarchy.py
+++ b/src/rwa_calc/engine/hierarchy.py
@@ -622,6 +622,7 @@ class HierarchyResolver:
                     "ccf_modelled": pl.Float64,
                     "is_short_term_trade_lc": pl.Boolean,
                     "is_buy_to_let": pl.Boolean,
+                    "has_netting_agreement": pl.Boolean,
                     "is_revolving": pl.Boolean,
                     "is_qrre_transactor": pl.Boolean,
                     "facility_limit": pl.Float64,
@@ -898,6 +899,7 @@ class HierarchyResolver:
                 if "is_buy_to_let" in facility_cols
                 else pl.lit(False).alias("is_buy_to_let")
             ),
+            pl.lit(False).alias("has_netting_agreement"),
             # QRRE classification fields (CRR Art. 147(5), CRE30.55)
             (
                 pl.col("is_revolving").fill_null(False)
@@ -983,6 +985,11 @@ class HierarchyResolver:
                 if "is_buy_to_let" in loan_cols
                 else pl.lit(False).alias("is_buy_to_let")
             ),
+            (
+                pl.col("has_netting_agreement").fill_null(False)
+                if "has_netting_agreement" in loan_cols
+                else pl.lit(False).alias("has_netting_agreement")
+            ),
         ]
         loans_unified = loans.select(loan_select_exprs)
 
@@ -1043,6 +1050,7 @@ class HierarchyResolver:
                     pl.lit(False).alias(
                         "is_buy_to_let"
                     ),  # BTL is a property lending characteristic, not for contingents
+                    pl.lit(False).alias("has_netting_agreement"),
                 ]
             )
             exposure_frames.append(contingents_unified)

--- a/tests/fixtures/exposures/loans.py
+++ b/tests/fixtures/exposures/loans.py
@@ -59,6 +59,7 @@ class Loan:
     lgd: float  # A-IRB modelled LGD (optional)
     beel: float  # Best estimate expected loss
     seniority: str  # senior, subordinated - affects F-IRB LGD (45% vs 75%)
+    has_netting_agreement: bool = False  # CRR Art. 195: on-balance sheet netting
 
     def to_dict(self) -> dict:
         return {
@@ -74,6 +75,7 @@ class Loan:
             "lgd": self.lgd,
             "beel": self.beel,
             "seniority": self.seniority,
+            "has_netting_agreement": self.has_netting_agreement,
         }
 
 

--- a/tests/unit/crm/test_netting.py
+++ b/tests/unit/crm/test_netting.py
@@ -1,0 +1,466 @@
+"""
+Tests for on-balance sheet netting (CRR Article 195).
+
+When a loan has a negative drawn amount (credit balance / deposit) and is
+covered by a netting agreement, the absolute value of that negative balance
+generates synthetic cash collateral that reduces sibling exposures in the
+same facility — pro-rata by EAD.
+
+Covers:
+- No netting flag → no synthetic collateral generated
+- SA: single negative + single positive loan in same facility → EAD reduced
+- SA: single negative + two positive loans → pro-rata allocation
+- FIRB: netting reduces LGD (cash collateral path), not direct EAD
+- Mixed netting / non-netting in facility → only netting-eligible benefit
+- Currency mismatch → FX haircut applied
+- No negative-drawn netting loans → no synthetic collateral
+- Netting exceeds exposure → EAD floored at 0
+- Missing column (backward compat) → returns None
+- No parent_facility_reference → standalone loans excluded
+- Multiple negative-drawn loans pool together
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import polars as pl
+import pytest
+
+from rwa_calc.contracts.bundles import (
+    ClassifiedExposuresBundle,
+    CounterpartyLookup,
+)
+from rwa_calc.contracts.config import CalculationConfig, IRBPermissions
+from rwa_calc.domain.enums import ApproachType
+from rwa_calc.engine.crm.processor import CRMProcessor
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def processor() -> CRMProcessor:
+    return CRMProcessor()
+
+
+@pytest.fixture
+def sa_config() -> CalculationConfig:
+    return CalculationConfig.crr(
+        reporting_date=date(2024, 12, 31),
+        irb_permissions=IRBPermissions.sa_only(),
+    )
+
+
+@pytest.fixture
+def firb_config() -> CalculationConfig:
+    return CalculationConfig.crr(
+        reporting_date=date(2024, 12, 31),
+        irb_permissions=IRBPermissions.firb_only(),
+    )
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _netting_exposure(
+    ref: str,
+    drawn: float,
+    facility_ref: str = "FAC_01",
+    cp_ref: str = "CP001",
+    currency: str = "GBP",
+    has_netting: bool = True,
+    approach: str = ApproachType.SA.value,
+) -> dict:
+    """Create an exposure row with netting fields."""
+    return {
+        "exposure_reference": ref,
+        "counterparty_reference": cp_ref,
+        "exposure_class": "corporate",
+        "approach": approach,
+        "drawn_amount": drawn,
+        "interest": 0.0,
+        "nominal_amount": 0.0,
+        "risk_type": "FR",
+        "lgd": 0.45,
+        "seniority": "senior",
+        "parent_facility_reference": facility_ref,
+        "currency": currency,
+        "maturity_date": None,
+        "has_netting_agreement": has_netting,
+    }
+
+
+def _make_bundle(
+    exposures: pl.LazyFrame,
+    collateral: pl.LazyFrame | None = None,
+) -> ClassifiedExposuresBundle:
+    """Build a ClassifiedExposuresBundle with optional collateral."""
+    empty_cp = pl.LazyFrame(
+        schema={"counterparty_reference": pl.String, "entity_type": pl.String}
+    )
+    empty_mappings = pl.LazyFrame(
+        schema={
+            "child_counterparty_reference": pl.String,
+            "parent_counterparty_reference": pl.String,
+        }
+    )
+    empty_ultimate = pl.LazyFrame(
+        schema={
+            "counterparty_reference": pl.String,
+            "ultimate_parent_reference": pl.String,
+            "hierarchy_depth": pl.Int32,
+        }
+    )
+    empty_ri = pl.LazyFrame(
+        schema={
+            "counterparty_reference": pl.String,
+            "cqs": pl.Int8,
+            "rating_type": pl.String,
+        }
+    )
+    return ClassifiedExposuresBundle(
+        all_exposures=exposures,
+        sa_exposures=pl.LazyFrame(),
+        irb_exposures=pl.LazyFrame(),
+        slotting_exposures=pl.LazyFrame(),
+        equity_exposures=None,
+        counterparty_lookup=CounterpartyLookup(
+            counterparties=empty_cp,
+            parent_mappings=empty_mappings,
+            ultimate_parent_mappings=empty_ultimate,
+            rating_inheritance=empty_ri,
+        ),
+        collateral=collateral,
+        guarantees=None,
+        provisions=None,
+    )
+
+
+def _run_crm(
+    processor: CRMProcessor,
+    config: CalculationConfig,
+    exposure_rows: list[dict],
+    collateral: pl.LazyFrame | None = None,
+) -> pl.DataFrame:
+    """Run CRM pipeline and return collected result."""
+    exposures = pl.LazyFrame(exposure_rows)
+    bundle = _make_bundle(exposures, collateral)
+    result = processor.get_crm_adjusted_bundle(bundle, config)
+    return result.exposures.collect()
+
+
+# =============================================================================
+# Tests: _generate_netting_collateral
+# =============================================================================
+
+
+class TestNettingCollateralGeneration:
+    """Unit tests for _generate_netting_collateral method."""
+
+    def test_missing_column_returns_none(self, processor: CRMProcessor):
+        """Backward compat: no has_netting_agreement column → None."""
+        exposures = pl.LazyFrame(
+            {
+                "exposure_reference": ["EXP001"],
+                "drawn_amount": [1000.0],
+                "ead_gross": [1000.0],
+                "parent_facility_reference": ["FAC_01"],
+                "currency": ["GBP"],
+                "maturity_date": [None],
+            }
+        )
+        result = processor._generate_netting_collateral(exposures)
+        assert result is None
+
+    def test_no_negative_drawn_returns_none(self, processor: CRMProcessor):
+        """All positive drawn amounts → no synthetic collateral."""
+        exposures = pl.LazyFrame(
+            {
+                "exposure_reference": ["EXP001"],
+                "drawn_amount": [1000.0],
+                "ead_gross": [1000.0],
+                "parent_facility_reference": ["FAC_01"],
+                "currency": ["GBP"],
+                "maturity_date": [None],
+                "has_netting_agreement": [True],
+            }
+        )
+        result = processor._generate_netting_collateral(exposures)
+        assert result is not None  # returns a LazyFrame (may be empty)
+        df = result.collect()
+        assert len(df) == 0
+
+    def test_no_parent_facility_excluded(self, processor: CRMProcessor):
+        """Standalone loans (no parent_facility_reference) are excluded."""
+        exposures = pl.LazyFrame(
+            {
+                "exposure_reference": ["EXP001", "EXP002"],
+                "drawn_amount": [-500.0, 1000.0],
+                "ead_gross": [0.0, 1000.0],
+                "parent_facility_reference": [None, None],
+                "currency": ["GBP", "GBP"],
+                "maturity_date": [None, None],
+                "has_netting_agreement": [True, True],
+            }
+        )
+        result = processor._generate_netting_collateral(exposures)
+        assert result is not None
+        df = result.collect()
+        assert len(df) == 0
+
+    def test_single_negative_single_positive(self, processor: CRMProcessor):
+        """One negative + one positive → one synthetic collateral row."""
+        exposures = pl.LazyFrame(
+            {
+                "exposure_reference": ["NEG01", "POS01"],
+                "drawn_amount": [-200.0, 1000.0],
+                "ead_gross": [0.0, 1000.0],
+                "parent_facility_reference": ["FAC_01", "FAC_01"],
+                "currency": ["GBP", "GBP"],
+                "maturity_date": [None, None],
+                "has_netting_agreement": [True, True],
+            }
+        )
+        result = processor._generate_netting_collateral(exposures)
+        df = result.collect()
+
+        assert len(df) == 1
+        row = df.row(0, named=True)
+        assert row["collateral_reference"] == "NETTING_POS01"
+        assert row["beneficiary_reference"] == "POS01"
+        assert row["beneficiary_type"] == "loan"
+        assert row["collateral_type"] == "cash"
+        assert row["market_value"] == pytest.approx(200.0)
+        assert row["is_eligible_financial_collateral"] is True
+        assert row["is_eligible_irb_collateral"] is True
+        assert row["currency"] == "GBP"
+
+    def test_pro_rata_allocation(self, processor: CRMProcessor):
+        """Netting pool split pro-rata by ead_gross among positive siblings."""
+        exposures = pl.LazyFrame(
+            {
+                "exposure_reference": ["NEG01", "POS01", "POS02"],
+                "drawn_amount": [-300.0, 600.0, 400.0],
+                "ead_gross": [0.0, 600.0, 400.0],
+                "parent_facility_reference": ["FAC_01", "FAC_01", "FAC_01"],
+                "currency": ["GBP", "GBP", "GBP"],
+                "maturity_date": [None, None, None],
+                "has_netting_agreement": [True, True, True],
+            }
+        )
+        result = processor._generate_netting_collateral(exposures)
+        df = result.collect().sort("beneficiary_reference")
+
+        assert len(df) == 2
+        # POS01 gets 300 * (600/1000) = 180
+        pos01 = df.filter(pl.col("beneficiary_reference") == "POS01")
+        assert pos01["market_value"][0] == pytest.approx(180.0)
+        # POS02 gets 300 * (400/1000) = 120
+        pos02 = df.filter(pl.col("beneficiary_reference") == "POS02")
+        assert pos02["market_value"][0] == pytest.approx(120.0)
+
+    def test_multiple_negatives_pool_together(self, processor: CRMProcessor):
+        """Multiple negative-drawn loans sum into one netting pool per facility."""
+        exposures = pl.LazyFrame(
+            {
+                "exposure_reference": ["NEG01", "NEG02", "POS01"],
+                "drawn_amount": [-100.0, -200.0, 1000.0],
+                "ead_gross": [0.0, 0.0, 1000.0],
+                "parent_facility_reference": ["FAC_01", "FAC_01", "FAC_01"],
+                "currency": ["GBP", "GBP", "GBP"],
+                "maturity_date": [None, None, None],
+                "has_netting_agreement": [True, True, True],
+            }
+        )
+        result = processor._generate_netting_collateral(exposures)
+        df = result.collect()
+
+        assert len(df) == 1
+        # Pool = 100 + 200 = 300, all goes to POS01
+        assert df["market_value"][0] == pytest.approx(300.0)
+
+    def test_non_netting_excluded(self, processor: CRMProcessor):
+        """Exposures without netting agreement don't contribute or benefit."""
+        exposures = pl.LazyFrame(
+            {
+                "exposure_reference": ["NEG01", "POS01", "POS02"],
+                "drawn_amount": [-200.0, 1000.0, 500.0],
+                "ead_gross": [0.0, 1000.0, 500.0],
+                "parent_facility_reference": ["FAC_01", "FAC_01", "FAC_01"],
+                "currency": ["GBP", "GBP", "GBP"],
+                "maturity_date": [None, None, None],
+                "has_netting_agreement": [True, True, False],
+            }
+        )
+        result = processor._generate_netting_collateral(exposures)
+        df = result.collect()
+
+        # Only POS01 benefits (POS02 has no netting agreement)
+        assert len(df) == 1
+        assert df["beneficiary_reference"][0] == "POS01"
+        assert df["market_value"][0] == pytest.approx(200.0)
+
+
+# =============================================================================
+# Tests: End-to-end netting via CRM pipeline
+# =============================================================================
+
+
+class TestNettingSAEndToEnd:
+    """SA pipeline: netting reduces EAD via synthetic cash collateral."""
+
+    def test_sa_ead_reduced_by_netting(
+        self, processor: CRMProcessor, sa_config: CalculationConfig
+    ):
+        """SA: negative-drawn loan reduces sibling's EAD."""
+        rows = [
+            _netting_exposure("NEG01", drawn=-200.0),
+            _netting_exposure("POS01", drawn=1000.0),
+        ]
+        df = _run_crm(processor, sa_config, rows)
+
+        neg = df.filter(pl.col("exposure_reference") == "NEG01")
+        pos = df.filter(pl.col("exposure_reference") == "POS01")
+
+        # Negative-drawn: EAD = 0 (floored by drawn_for_ead)
+        assert neg["ead_final"][0] == pytest.approx(0.0)
+        # Positive-drawn: EAD reduced by 200 (cash collateral, 0% haircut)
+        assert pos["ead_final"][0] == pytest.approx(800.0, abs=1.0)
+
+    def test_sa_pro_rata_two_positive(
+        self, processor: CRMProcessor, sa_config: CalculationConfig
+    ):
+        """SA: netting pool split pro-rata across two positive siblings."""
+        rows = [
+            _netting_exposure("NEG01", drawn=-300.0),
+            _netting_exposure("POS01", drawn=600.0),
+            _netting_exposure("POS02", drawn=400.0),
+        ]
+        df = _run_crm(processor, sa_config, rows)
+
+        pos01 = df.filter(pl.col("exposure_reference") == "POS01")
+        pos02 = df.filter(pl.col("exposure_reference") == "POS02")
+
+        # POS01: 600 - 300*(600/1000) = 600 - 180 = 420
+        assert pos01["ead_final"][0] == pytest.approx(420.0, abs=1.0)
+        # POS02: 400 - 300*(400/1000) = 400 - 120 = 280
+        assert pos02["ead_final"][0] == pytest.approx(280.0, abs=1.0)
+
+    def test_netting_exceeds_exposure_floors_at_zero(
+        self, processor: CRMProcessor, sa_config: CalculationConfig
+    ):
+        """SA: netting pool exceeds exposure → EAD floored at 0."""
+        rows = [
+            _netting_exposure("NEG01", drawn=-500.0),
+            _netting_exposure("POS01", drawn=100.0),
+        ]
+        df = _run_crm(processor, sa_config, rows)
+
+        pos = df.filter(pl.col("exposure_reference") == "POS01")
+        assert pos["ead_final"][0] == pytest.approx(0.0)
+
+    def test_only_netting_eligible_benefit(
+        self, processor: CRMProcessor, sa_config: CalculationConfig
+    ):
+        """Only netting-eligible loans benefit; non-netting loans unaffected."""
+        rows = [
+            _netting_exposure("NEG01", drawn=-200.0, has_netting=True),
+            _netting_exposure("POS01", drawn=1000.0, has_netting=True),
+            _netting_exposure("POS02", drawn=500.0, has_netting=False),
+        ]
+        df = _run_crm(processor, sa_config, rows)
+
+        pos01 = df.filter(pl.col("exposure_reference") == "POS01")
+        pos02 = df.filter(pl.col("exposure_reference") == "POS02")
+
+        # POS01: 1000 - 200 = 800
+        assert pos01["ead_final"][0] == pytest.approx(800.0, abs=1.0)
+        # POS02: unaffected (no netting agreement)
+        assert pos02["ead_final"][0] == pytest.approx(500.0)
+
+    def test_currency_mismatch_fx_haircut(
+        self, processor: CRMProcessor, sa_config: CalculationConfig
+    ):
+        """FX mismatch between negative and positive loans → 8% FX haircut."""
+        rows = [
+            _netting_exposure("NEG01", drawn=-1000.0, currency="EUR"),
+            _netting_exposure("POS01", drawn=1000.0, currency="GBP"),
+        ]
+        df = _run_crm(processor, sa_config, rows)
+
+        pos = df.filter(pl.col("exposure_reference") == "POS01")
+        # Cash collateral in EUR, exposure in GBP → 8% FX haircut
+        # Effective collateral = 1000 * (1 - 0.08) = 920
+        # EAD = 1000 - 920 = 80
+        assert pos["ead_final"][0] == pytest.approx(80.0, abs=1.0)
+
+    def test_no_netting_flag_no_change(
+        self, processor: CRMProcessor, sa_config: CalculationConfig
+    ):
+        """No netting agreement → pipeline unchanged."""
+        rows = [
+            _netting_exposure("NEG01", drawn=-200.0, has_netting=False),
+            _netting_exposure("POS01", drawn=1000.0, has_netting=False),
+        ]
+        df = _run_crm(processor, sa_config, rows)
+
+        pos = df.filter(pl.col("exposure_reference") == "POS01")
+        # No netting → EAD = drawn_amount (no collateral benefit)
+        assert pos["ead_final"][0] == pytest.approx(1000.0)
+
+
+class TestNettingFIRBEndToEnd:
+    """FIRB pipeline: netting reduces LGD via cash collateral path."""
+
+    def test_firb_netting_reduces_lgd(
+        self, processor: CRMProcessor, firb_config: CalculationConfig
+    ):
+        """FIRB: netting generates cash collateral → LGD reduction."""
+        rows = [
+            _netting_exposure(
+                "NEG01", drawn=-200.0, approach=ApproachType.FIRB.value
+            ),
+            _netting_exposure(
+                "POS01", drawn=1000.0, approach=ApproachType.FIRB.value
+            ),
+        ]
+        df = _run_crm(processor, firb_config, rows)
+
+        pos = df.filter(pl.col("exposure_reference") == "POS01")
+        # Cash collateral has LGD = 0% in FIRB supervisory LGD table
+        # With 200 cash against 1000 EAD, LGD should be < 45% (senior unsecured)
+        assert pos["lgd_post_crm"][0] < 0.45
+
+
+class TestNettingMissingColumn:
+    """Backward compatibility when has_netting_agreement column is absent."""
+
+    def test_missing_netting_column_pipeline_works(
+        self, processor: CRMProcessor, sa_config: CalculationConfig
+    ):
+        """Pipeline works normally when has_netting_agreement column is missing."""
+        rows = [
+            {
+                "exposure_reference": "EXP001",
+                "counterparty_reference": "CP001",
+                "exposure_class": "corporate",
+                "approach": ApproachType.SA.value,
+                "drawn_amount": 1000.0,
+                "interest": 0.0,
+                "nominal_amount": 0.0,
+                "risk_type": "FR",
+                "lgd": 0.45,
+                "seniority": "senior",
+                "parent_facility_reference": "FAC_01",
+                "currency": "GBP",
+                "maturity_date": None,
+                # no has_netting_agreement column
+            }
+        ]
+        df = _run_crm(processor, sa_config, rows)
+        assert len(df) == 1
+        assert df["ead_final"][0] == pytest.approx(1000.0)


### PR DESCRIPTION
This pull request introduces support for on-balance sheet netting (CRR Article 195), allowing mutual claims between a firm and a counterparty to be netted when a legally enforceable netting agreement exists. The implementation adds a new field to the loan schema, generates synthetic cash collateral from negative-drawn netting-eligible loans, and integrates this mechanism seamlessly into the existing collateral pipeline. Documentation and fixtures are updated to explain and demonstrate the new feature. The changes are backward compatible and do not affect existing data unless the new field is used.

**On-Balance Sheet Netting (CRR Article 195):**

* Added `has_netting_agreement` field to `LOAN_SCHEMA`, loan fixtures, and unified exposure processing, enabling netting eligibility for loans. [[1]](diffhunk://#diff-04eeea3da0125ae22d7104c692e0f1d41a86209f6fdfcadd5f061376c8092084R91) [[2]](diffhunk://#diff-054f578a992202e82fb2283dbe871200953301a7eb67f21ff1ca5f24e42a7f7bR625) [[3]](diffhunk://#diff-054f578a992202e82fb2283dbe871200953301a7eb67f21ff1ca5f24e42a7f7bR902) [[4]](diffhunk://#diff-054f578a992202e82fb2283dbe871200953301a7eb67f21ff1ca5f24e42a7f7bR988-R992) [[5]](diffhunk://#diff-054f578a992202e82fb2283dbe871200953301a7eb67f21ff1ca5f24e42a7f7bR1053) [[6]](diffhunk://#diff-0d3f98d8548979bda068fd30aab812d6d380fc93e0265a44386bae946090ba36R62) [[7]](diffhunk://#diff-0d3f98d8548979bda068fd30aab812d6d380fc93e0265a44386bae946090ba36R78)
* Implemented `_generate_netting_collateral` method in `crm.processor.py` to create synthetic cash collateral from negative-drawn netting-eligible loans, allocated pro-rata to positive-drawn siblings within the same facility and currency.
* Integrated synthetic collateral generation into both the standard and unified CRM processing pipelines, ensuring netting collateral is included in collateral application and haircut logic. [[1]](diffhunk://#diff-5dec8ac5620ec081b2d95fdf70da54c896e5febcfba6e9c6d626e524753f9950R369-R384) [[2]](diffhunk://#diff-5dec8ac5620ec081b2d95fdf70da54c896e5febcfba6e9c6d626e524753f9950L459-R486)

**Documentation Updates:**

* Expanded user guide and changelog to describe netting mechanics, input requirements, and regulatory context, including practical examples and references to CRR Article 195 and BCBS CRE22.11-14. [[1]](diffhunk://#diff-ead87002ff94650b269ee235bf6ee5e087648a449243ad0825b2f286e9a6db9bR314-R352) [[2]](diffhunk://#diff-ead87002ff94650b269ee235bf6ee5e087648a449243ad0825b2f286e9a6db9bR629) [[3]](diffhunk://#diff-12691c986cf37d1c0ee35539bee390e23a1efe2d12bfd41ef9b5da7ccddaba72R12-R21)

**Backward Compatibility:**

* Ensured the new netting field is optional and defaults to `False`, so existing data and workflows remain unaffected unless explicitly enabled. [[1]](diffhunk://#diff-12691c986cf37d1c0ee35539bee390e23a1efe2d12bfd41ef9b5da7ccddaba72R12-R21) [[2]](diffhunk://#diff-054f578a992202e82fb2283dbe871200953301a7eb67f21ff1ca5f24e42a7f7bR902) [[3]](diffhunk://#diff-054f578a992202e82fb2283dbe871200953301a7eb67f21ff1ca5f24e42a7f7bR988-R992) [[4]](diffhunk://#diff-054f578a992202e82fb2283dbe871200953301a7eb67f21ff1ca5f24e42a7f7bR1053) [[5]](diffhunk://#diff-0d3f98d8548979bda068fd30aab812d6d380fc93e0265a44386bae946090ba36R62)

**References:**  
[[1]](diffhunk://#diff-04eeea3da0125ae22d7104c692e0f1d41a86209f6fdfcadd5f061376c8092084R91) [[2]](diffhunk://#diff-054f578a992202e82fb2283dbe871200953301a7eb67f21ff1ca5f24e42a7f7bR625) [[3]](diffhunk://#diff-054f578a992202e82fb2283dbe871200953301a7eb67f21ff1ca5f24e42a7f7bR902) [[4]](diffhunk://#diff-054f578a992202e82fb2283dbe871200953301a7eb67f21ff1ca5f24e42a7f7bR988-R992) [[5]](diffhunk://#diff-054f578a992202e82fb2283dbe871200953301a7eb67f21ff1ca5f24e42a7f7bR1053) [[6]](diffhunk://#diff-0d3f98d8548979bda068fd30aab812d6d380fc93e0265a44386bae946090ba36R62) [[7]](diffhunk://#diff-0d3f98d8548979bda068fd30aab812d6d380fc93e0265a44386bae946090ba36R78) [[8]](diffhunk://#diff-5dec8ac5620ec081b2d95fdf70da54c896e5febcfba6e9c6d626e524753f9950R627-R741) [[9]](diffhunk://#diff-5dec8ac5620ec081b2d95fdf70da54c896e5febcfba6e9c6d626e524753f9950R369-R384) [[10]](diffhunk://#diff-5dec8ac5620ec081b2d95fdf70da54c896e5febcfba6e9c6d626e524753f9950L459-R486) [[11]](diffhunk://#diff-ead87002ff94650b269ee235bf6ee5e087648a449243ad0825b2f286e9a6db9bR314-R352) [[12]](diffhunk://#diff-ead87002ff94650b269ee235bf6ee5e087648a449243ad0825b2f286e9a6db9bR629) [[13]](diffhunk://#diff-12691c986cf37d1c0ee35539bee390e23a1efe2d12bfd41ef9b5da7ccddaba72R12-R21)