### PR TITLE
refactor: remove calculate_single_exposure from calculators, use test helpers

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -844,7 +844,6 @@ Each Phase 3 task extends the pipeline itself to produce data not currently avai
 - Risk weight multiplied by 1.5; `currency_mismatch_multiplier_applied` boolean column set for COREP tracking.
 - `currency_mismatch_multiplier_applied` output column added to `CALCULATION_OUTPUT_SCHEMA`.
 - Wired into all 3 SA calculator entry points: `get_sa_result_bundle()`, `calculate_unified()`, `calculate_branch()`.
-- `calculate_single_exposure()` updated with `borrower_income_currency` parameter.
 - CRR unaffected: method returns immediately when `is_basel_3_1 == False`.
 - Null `borrower_income_currency` → no multiplier (graceful handling).
 - COREP generator: `_filter_currency_mismatch()` helper filters on `currency_mismatch_multiplier_applied == True`. Row 0380 populated for B3.1 OF 07.00 memorandum Section 5. Absent under CRR.

--- a/docs/api/engine.md
+++ b/docs/api/engine.md
@@ -504,39 +504,6 @@ class SACalculator:
         Expects only SA rows — no approach guards needed.
         """
 
-    def calculate_single_exposure(
-        self,
-        ead: Decimal,
-        exposure_class: str,
-        cqs: int | None = None,
-        ltv: Decimal | None = None,
-        is_sme: bool = False,
-        is_infrastructure: bool = False,
-        is_managed_as_retail: bool = False,
-        has_income_cover: bool = False,
-        property_type: str | None = None,
-        is_adc: bool = False,
-        is_presold: bool = False,
-        seniority: str = "senior",
-        scra_grade: str | None = None,
-        is_investment_grade: bool = False,
-        config: CalculationConfig | None = None,
-    ) -> dict:
-        """
-        Calculate RWA for a single exposure (convenience method).
-
-        Returns dict with: ead, exposure_class, cqs, risk_weight,
-        rwa_pre_factor, supporting_factor, rwa, supporting_factor_applied.
-
-        Example:
-            >>> calculator = SACalculator()
-            >>> result = calculator.calculate_single_exposure(
-            ...     ead=Decimal("1000000"),
-            ...     exposure_class="CORPORATE",
-            ...     cqs=3,
-            ... )
-            >>> print(f"RWA: {result['rwa']:,.0f}")
-        """
 ```
 
 **Factory:**
@@ -646,32 +613,6 @@ class IRBCalculator:
     ) -> LazyFrameResult:
         """Calculate expected loss for IRB exposures. EL = PD x LGD x EAD."""
 
-    def calculate_single_exposure(
-        self,
-        ead: Decimal,
-        pd: Decimal,
-        lgd: Decimal | None = None,
-        maturity: Decimal = Decimal("2.5"),
-        exposure_class: str = "CORPORATE",
-        turnover_m: Decimal | None = None,
-        collateral_type: str | None = None,
-        is_subordinated: bool = False,
-        config: CalculationConfig | None = None,
-    ) -> dict:
-        """
-        Calculate RWA for a single exposure (convenience method).
-
-        Returns dict with full calculation results including expected_loss.
-
-        Example:
-            >>> calculator = IRBCalculator()
-            >>> result = calculator.calculate_single_exposure(
-            ...     ead=Decimal("5000000"),
-            ...     pd=Decimal("0.01"),
-            ...     lgd=Decimal("0.45"),
-            ... )
-            >>> print(f"RWA: {result['rwa']:,.0f}")
-        """
 ```
 
 **Factory:**
@@ -859,22 +800,6 @@ class SlottingCalculator:
         Uses: prepare_columns → apply_slotting_weights → calculate_rwa.
         """
 
-    def calculate_single_exposure(
-        self,
-        ead: Decimal,
-        category: str,
-        is_hvcre: bool = False,
-        sl_type: str = "project_finance",
-        is_short_maturity: bool = False,
-        is_pre_operational: bool = False,
-        config: CalculationConfig | None = None,
-    ) -> dict:
-        """
-        Calculate RWA for a single slotting exposure (convenience method).
-
-        Returns dict with: ead, category, is_hvcre, sl_type,
-        risk_weight, rwa, framework.
-        """
 ```
 
 **Factory:**
@@ -990,32 +915,6 @@ class EquityCalculator:
             EquityResultBundle with results and audit trail.
         """
 
-    def calculate_single_exposure(
-        self,
-        ead: Decimal,
-        equity_type: str,
-        is_diversified: bool = False,
-        is_speculative: bool = False,
-        is_exchange_traded: bool = False,
-        is_government_supported: bool = False,
-        config: CalculationConfig | None = None,
-    ) -> dict:
-        """
-        Calculate RWA for a single equity exposure (convenience method).
-
-        Returns dict with: ead, equity_type, effective_type, is_diversified,
-        is_speculative, is_exchange_traded, is_government_supported,
-        approach, article, risk_weight, rwa.
-
-        Example:
-            >>> calculator = EquityCalculator()
-            >>> result = calculator.calculate_single_exposure(
-            ...     ead=Decimal("1000000"),
-            ...     equity_type="private_equity",
-            ...     is_diversified=True,
-            ... )
-            >>> print(f"RWA: {result['rwa']:,.0f}")
-        """
 ```
 
 **Factory:**

--- a/docs/user-guide/methodology/specialised-lending.md
+++ b/docs/user-guide/methodology/specialised-lending.md
@@ -184,15 +184,25 @@ result = calculator.calculate(
 rwa_df = result.frame.collect()
 ```
 
-For single-exposure calculations:
+For single-exposure calculations, build a single-row LazyFrame and call
+`calculate_branch()`:
 
 ```python
-rwa = calculator.calculate_single_exposure(
-    ead=20_000_000,
-    slotting_category="good",
-    config=CalculationConfig.crr(reporting_date=date(2026, 12, 31)),
-)
-# Returns: 18_000_000.0
+import polars as pl
+
+df = pl.DataFrame({
+    "exposure_reference": ["EX1"],
+    "ead": [20_000_000.0],
+    "slotting_category": ["good"],
+    "is_hvcre": [False],
+    "is_short_maturity": [False],
+    "is_pre_operational": [False],
+}).lazy()
+
+result = calculator.calculate_branch(
+    df, CalculationConfig.crr(reporting_date=date(2026, 12, 31))
+).collect().to_dicts()[0]
+# result["rwa"] -> 18_000_000.0
 ```
 
 ### Risk Weight Lookup

--- a/docs/user-guide/methodology/standardised-approach.md
+++ b/docs/user-guide/methodology/standardised-approach.md
@@ -327,6 +327,7 @@ Final_RWA_B31 = £5,000,000
 The SA calculator is implemented in [`sa/calculator.py`](https://github.com/OpenAfterHours/rwa_calculator/blob/master/src/rwa_calc/engine/sa/calculator.py).
 
 ```python
+import polars as pl
 from rwa_calc.engine.sa.calculator import SACalculator
 from rwa_calc.contracts.config import CalculationConfig
 from datetime import date
@@ -334,27 +335,22 @@ from datetime import date
 # Create SA calculator
 calculator = SACalculator()
 
-# Calculate RWA for a single exposure (convenience method)
-result = calculator.calculate_single_exposure(
-    ead=Decimal("10000000"),
-    exposure_class="CORPORATE",
-    cqs=2,
-    is_sme=True,
-    config=CalculationConfig.crr(reporting_date=date(2026, 12, 31))
-)
+# Calculate RWA for a single exposure via calculate_branch()
+df = pl.DataFrame({
+    "exposure_reference": ["EX1"],
+    "ead": [10_000_000.0],
+    "exposure_class": ["CORPORATE"],
+    "cqs": [2],
+    "is_sme": [True],
+}).lazy()
+
+config = CalculationConfig.crr(reporting_date=date(2026, 12, 31))
+result = calculator.calculate_branch(df, config).collect().to_dicts()[0]
 
 # Access results
 print(f"Risk Weight: {result['risk_weight']}")
 print(f"RWA: {result['rwa']}")
-print(f"Supporting Factor: {result['supporting_factor_applied']}")
 ```
-
-::: rwa_calc.engine.sa.calculator.SACalculator
-    options:
-      show_root_heading: true
-      members:
-        - calculate_single_exposure
-      show_source: false
 
 ### Risk Weight Lookup
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ ignore = [
 known-first-party = ["rwa_calc"]
 
 [tool.pytest.ini_options]
+pythonpath = ["."]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_functions = ["test_*"]

--- a/src/rwa_calc/engine/equity/calculator.py
+++ b/src/rwa_calc/engine/equity/calculator.py
@@ -36,7 +36,6 @@ References:
 from __future__ import annotations
 
 from dataclasses import dataclass
-from decimal import Decimal
 from typing import TYPE_CHECKING
 
 import polars as pl
@@ -48,7 +47,6 @@ from rwa_calc.contracts.errors import (
     ErrorSeverity,
     LazyFrameResult,
 )
-from rwa_calc.data.tables.crr_equity_rw import lookup_equity_rw
 from rwa_calc.domain.enums import ApproachType
 
 if TYPE_CHECKING:
@@ -84,6 +82,32 @@ class EquityCalculator:
     def __init__(self) -> None:
         """Initialize equity calculator."""
         pass
+
+    def calculate_branch(
+        self,
+        exposures: pl.LazyFrame,
+        config: CalculationConfig,
+    ) -> pl.LazyFrame:
+        """
+        Calculate equity RWA on pre-filtered equity-only rows.
+
+        Args:
+            exposures: Pre-filtered equity rows only
+            config: Calculation configuration
+
+        Returns:
+            LazyFrame with equity RWA columns populated
+        """
+        approach = self._determine_approach(config)
+
+        exposures = self._prepare_columns(exposures, config)
+
+        if approach == "irb_simple":
+            exposures = self._apply_equity_weights_irb_simple(exposures, config)
+        else:
+            exposures = self._apply_equity_weights_sa(exposures, config)
+
+        return self._calculate_rwa(exposures)
 
     def calculate(
         self,
@@ -424,69 +448,6 @@ class EquityCalculator:
         )
 
         return audit
-
-    def calculate_single_exposure(
-        self,
-        ead: Decimal,
-        equity_type: str,
-        is_diversified: bool = False,
-        is_speculative: bool = False,
-        is_exchange_traded: bool = False,
-        is_government_supported: bool = False,
-        config: CalculationConfig | None = None,
-    ) -> dict:
-        """
-        Calculate RWA for a single equity exposure (convenience method).
-
-        Args:
-            ead: Exposure at default
-            equity_type: Type of equity exposure
-            is_diversified: Whether in diversified portfolio (for PE)
-            is_speculative: Whether speculative unlisted
-            is_exchange_traded: Whether exchange traded
-            is_government_supported: Whether government supported
-            config: Calculation configuration (defaults to CRR SA)
-
-        Returns:
-            Dictionary with calculation results
-        """
-        from datetime import date
-
-        from rwa_calc.contracts.config import CalculationConfig
-
-        if config is None:
-            config = CalculationConfig.crr(reporting_date=date.today())
-
-        approach = self._determine_approach(config)
-
-        if is_speculative:
-            effective_type = "speculative"
-        elif is_exchange_traded:
-            effective_type = "exchange_traded"
-        elif is_government_supported:
-            effective_type = "government_supported"
-        elif equity_type.lower() == "private_equity" and is_diversified:
-            effective_type = "private_equity_diversified"
-        else:
-            effective_type = equity_type
-
-        risk_weight = lookup_equity_rw(effective_type, approach, is_diversified)
-
-        rwa = ead * risk_weight
-
-        return {
-            "ead": float(ead),
-            "equity_type": equity_type,
-            "effective_type": effective_type,
-            "is_diversified": is_diversified,
-            "is_speculative": is_speculative,
-            "is_exchange_traded": is_exchange_traded,
-            "is_government_supported": is_government_supported,
-            "approach": approach,
-            "article": "133" if approach == "sa" else "155",
-            "risk_weight": float(risk_weight),
-            "rwa": float(rwa),
-        }
 
 
 def create_equity_calculator() -> EquityCalculator:

--- a/src/rwa_calc/engine/irb/calculator.py
+++ b/src/rwa_calc/engine/irb/calculator.py
@@ -27,7 +27,6 @@ References:
 
 from __future__ import annotations
 
-from decimal import Decimal
 from typing import TYPE_CHECKING
 
 import polars as pl
@@ -41,13 +40,7 @@ from rwa_calc.contracts.errors import (
     ErrorSeverity,
     LazyFrameResult,
 )
-from rwa_calc.data.tables.crr_firb_lgd import lookup_firb_lgd
 from rwa_calc.domain.enums import ApproachType
-from rwa_calc.engine.irb.formulas import (
-    calculate_correlation,
-    calculate_expected_loss,
-    calculate_irb_rwa,
-)
 from rwa_calc.engine.sa.supporting_factors import SupportingFactorCalculator
 
 if TYPE_CHECKING:
@@ -275,88 +268,6 @@ class IRBCalculator:
             )
 
         return exposures
-
-    def calculate_single_exposure(
-        self,
-        ead: Decimal,
-        pd: Decimal,
-        lgd: Decimal | None = None,
-        maturity: Decimal = Decimal("2.5"),
-        exposure_class: str = "CORPORATE",
-        turnover_m: Decimal | None = None,
-        collateral_type: str | None = None,
-        is_subordinated: bool = False,
-        config: CalculationConfig | None = None,
-    ) -> dict:
-        """
-        Calculate RWA for a single exposure (convenience method).
-
-        Args:
-            ead: Exposure at default
-            pd: Probability of default
-            lgd: Loss given default (None for F-IRB supervisory)
-            maturity: Effective maturity in years
-            exposure_class: Exposure class
-            turnover_m: Annual turnover in millions (for SME adjustment)
-            collateral_type: Collateral type for F-IRB LGD
-            is_subordinated: Whether subordinated (for F-IRB LGD)
-            config: Calculation configuration (defaults to CRR)
-
-        Returns:
-            Dictionary with calculation results
-        """
-        from datetime import date
-
-        from rwa_calc.contracts.config import CalculationConfig
-
-        if config is None:
-            config = CalculationConfig.crr(reporting_date=date.today())
-
-        # Determine LGD
-        if lgd is None:
-            # F-IRB supervisory LGD
-            lgd = lookup_firb_lgd(collateral_type, is_subordinated)
-
-        # Calculate correlation (pass EUR/GBP rate for SME adjustment)
-        turnover_float = float(turnover_m) if turnover_m else None
-        eur_gbp_rate = float(config.eur_gbp_rate)
-        correlation = calculate_correlation(
-            pd=float(pd),
-            exposure_class=exposure_class,
-            turnover_m=turnover_float,
-            eur_gbp_rate=eur_gbp_rate,
-        )
-
-        # Check if retail (no MA, no scaling)
-        is_retail = "RETAIL" in exposure_class.upper()
-
-        # Get configuration parameters
-        pd_floor = float(config.pd_floors.corporate)
-        lgd_floor = float(config.lgd_floors.unsecured) if config.is_basel_3_1 else None
-        apply_scaling = config.is_crr and not is_retail
-        apply_ma = not is_retail
-
-        # Calculate IRB RWA
-        result = calculate_irb_rwa(
-            ead=float(ead),
-            pd=float(pd),
-            lgd=float(lgd),
-            correlation=correlation,
-            maturity=float(maturity),
-            apply_maturity_adjustment=apply_ma,
-            apply_scaling_factor=apply_scaling,
-            pd_floor=pd_floor,
-            lgd_floor=lgd_floor,
-        )
-
-        # Add expected loss
-        result["expected_loss"] = calculate_expected_loss(
-            result["pd_floored"],
-            result["lgd_floored"],
-            float(ead),
-        )
-
-        return result
 
 
 def create_irb_calculator() -> IRBCalculator:

--- a/src/rwa_calc/engine/sa/calculator.py
+++ b/src/rwa_calc/engine/sa/calculator.py
@@ -39,7 +39,6 @@ References:
 from __future__ import annotations
 
 from dataclasses import dataclass
-from decimal import Decimal
 from typing import TYPE_CHECKING
 
 import polars as pl
@@ -1043,115 +1042,6 @@ class SACalculator:
         )
 
         return audit
-
-    def calculate_single_exposure(
-        self,
-        ead: Decimal,
-        exposure_class: str,
-        cqs: int | None = None,
-        ltv: Decimal | None = None,
-        is_sme: bool = False,
-        is_infrastructure: bool = False,
-        is_managed_as_retail: bool = False,
-        qualifies_as_retail: bool = True,
-        has_income_cover: bool = False,
-        property_type: str | None = None,
-        is_adc: bool = False,
-        is_presold: bool = False,
-        seniority: str = "senior",
-        scra_grade: str | None = None,
-        is_investment_grade: bool = False,
-        is_defaulted: bool = False,
-        provision_allocated: Decimal | None = None,
-        provision_deducted: Decimal | None = None,
-        currency: str | None = None,
-        country_code: str | None = None,
-        borrower_income_currency: str | None = None,
-        config: CalculationConfig | None = None,
-    ) -> dict:
-        """
-        Calculate RWA for a single exposure (convenience method).
-
-        Args:
-            ead: Exposure at default
-            exposure_class: Exposure class
-            cqs: Credit quality step (1-6 or None for unrated)
-            ltv: Loan-to-value ratio (for real estate)
-            is_sme: Whether SME supporting factor applies
-            is_infrastructure: Whether infrastructure factor applies
-            is_managed_as_retail: Whether SME is managed on pooled retail basis (CRR Art. 123)
-            has_income_cover: Whether income materially depends on property cash flows
-            property_type: Property type ("residential" or "commercial") from collateral
-            is_adc: Whether this is an ADC (Acquisition/Development/Construction) exposure
-            is_presold: Whether ADC exposure is pre-sold to qualifying buyer
-            seniority: "senior" or "subordinated" — subordinated gets 150% under Basel 3.1
-            scra_grade: SCRA grade for unrated institutions ("A"/"B"/"C", Basel 3.1 only)
-            is_investment_grade: Whether counterparty qualifies as investment grade (Basel 3.1)
-            is_defaulted: Whether counterparty is in default (CRR Art. 127 / CRE20.88-90)
-            provision_allocated: Total specific provisions allocated to exposure
-            provision_deducted: Total provisions deducted from EAD
-            currency: Exposure denomination currency (ISO, e.g. "GBP") for Art. 114(3)
-            country_code: Counterparty country (ISO, e.g. "GB") for Art. 114(3)
-            borrower_income_currency: ISO currency of borrower's income (Basel 3.1 Art. 123B)
-            config: Calculation configuration (defaults to CRR)
-
-        Returns:
-            Dictionary with calculation results
-        """
-        from datetime import date
-
-        from rwa_calc.contracts.config import CalculationConfig
-
-        if config is None:
-            config = CalculationConfig.crr(reporting_date=date.today())
-
-        # Create single-row DataFrame
-        df = pl.DataFrame(
-            {
-                "exposure_reference": ["SINGLE"],
-                "ead_final": [float(ead)],
-                "exposure_class": [exposure_class],
-                "cqs": [cqs],
-                "ltv": [float(ltv) if ltv else None],
-                "is_sme": [is_sme],
-                "is_infrastructure": [is_infrastructure],
-                "has_income_cover": [has_income_cover],
-                "cp_is_managed_as_retail": [is_managed_as_retail],
-                "qualifies_as_retail": [qualifies_as_retail],
-                "property_type": [property_type],
-                "is_adc": [is_adc],
-                "is_presold": [is_presold],
-                "seniority": [seniority],
-                "cp_scra_grade": [scra_grade],
-                "cp_is_investment_grade": [is_investment_grade],
-                "is_defaulted": [is_defaulted],
-                "provision_allocated": [float(provision_allocated) if provision_allocated else 0.0],
-                "provision_deducted": [float(provision_deducted) if provision_deducted else 0.0],
-                "currency": [currency],
-                "cp_country_code": [country_code],
-                "borrower_income_currency": [borrower_income_currency],
-            }
-        ).lazy()
-
-        # Apply risk weights
-        df = self._apply_risk_weights(df, config)
-        df = self._apply_currency_mismatch_multiplier(df, config)
-        df = self._calculate_rwa(df)
-        df = self._apply_supporting_factors(df, config)
-
-        # Collect result
-        result = df.collect().to_dicts()[0]
-
-        return {
-            "ead": ead,
-            "exposure_class": exposure_class,
-            "cqs": cqs,
-            "risk_weight": Decimal(str(result["risk_weight"])),
-            "rwa_pre_factor": Decimal(str(result["rwa_pre_factor"])),
-            "supporting_factor": Decimal(str(result["supporting_factor"])),
-            "rwa": Decimal(str(result["rwa_post_factor"])),
-            "supporting_factor_applied": result["supporting_factor_applied"],
-        }
 
 
 def create_sa_calculator() -> SACalculator:

--- a/src/rwa_calc/engine/slotting/calculator.py
+++ b/src/rwa_calc/engine/slotting/calculator.py
@@ -30,7 +30,6 @@ References:
 
 from __future__ import annotations
 
-from decimal import Decimal
 from typing import TYPE_CHECKING
 
 import polars as pl
@@ -205,71 +204,6 @@ class SlottingCalculator:
             calculation_audit=audit,
             errors=[],
         )
-
-    def calculate_single_exposure(
-        self,
-        ead: Decimal,
-        category: str,
-        is_hvcre: bool = False,
-        sl_type: str = "project_finance",
-        is_short_maturity: bool = False,
-        is_pre_operational: bool = False,
-        config: CalculationConfig | None = None,
-    ) -> dict:
-        """
-        Calculate RWA for a single slotting exposure (convenience method).
-
-        Args:
-            ead: Exposure at default
-            category: Slotting category (strong, good, satisfactory, weak, default)
-            is_hvcre: Whether this is high-volatility commercial real estate
-            sl_type: Specialised lending type
-            is_short_maturity: Whether remaining maturity < 2.5 years (CRR)
-            is_pre_operational: Whether PF is pre-operational (Basel 3.1)
-            config: Calculation configuration (defaults to CRR)
-
-        Returns:
-            Dictionary with calculation results
-        """
-        from datetime import date
-
-        import rwa_calc.engine.slotting.namespace  # noqa: F401
-        from rwa_calc.contracts.config import CalculationConfig
-
-        if config is None:
-            config = CalculationConfig.crr(reporting_date=date.today())
-
-        # Use expression namespace for lookup logic
-        df = pl.DataFrame(
-            {
-                "slotting_category": [category],
-                "is_hvcre": [is_hvcre],
-                "is_short_maturity": [is_short_maturity],
-                "is_pre_operational": [is_pre_operational],
-            }
-        )
-
-        rw_expr = col("slotting_category").slotting.lookup_rw(
-            is_crr=config.is_crr,
-            is_hvcre=col("is_hvcre"),
-            is_short=col("is_short_maturity"),
-            is_preop=col("is_pre_operational"),
-        )
-
-        risk_weight = Decimal(str(df.select(rw_expr).item()))
-
-        # Calculate RWA
-        rwa = ead * risk_weight
-
-        return {
-            "ead": float(ead),
-            "category": category,
-            "is_hvcre": is_hvcre,
-            "sl_type": sl_type,
-            "risk_weight": float(risk_weight),
-            "rwa": float(rwa),
-            "framework": "CRR" if config.is_crr else "Basel 3.1",
-        }
 
 
 def create_slotting_calculator() -> SlottingCalculator:

--- a/tests/fixtures/single_exposure.py
+++ b/tests/fixtures/single_exposure.py
@@ -1,0 +1,185 @@
+"""
+Test helpers for single-exposure calculation via calculate_branch.
+
+These helpers build a single-row LazyFrame and call the calculator's
+calculate_branch method, exercising the real pipeline code path.
+
+Usage:
+    from tests.fixtures.single_exposure import calculate_single_sa_exposure
+
+    result = calculate_single_sa_exposure(
+        sa_calculator, ead=Decimal("1000000"),
+        exposure_class="CORPORATE", cqs=3, config=crr_config,
+    )
+    assert result["risk_weight"] == pytest.approx(1.0)
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import polars as pl
+
+from rwa_calc.contracts.config import CalculationConfig
+from rwa_calc.data.tables.crr_firb_lgd import lookup_firb_lgd
+from rwa_calc.engine.equity.calculator import EquityCalculator
+from rwa_calc.engine.irb.calculator import IRBCalculator
+from rwa_calc.engine.sa.calculator import SACalculator
+from rwa_calc.engine.slotting.calculator import SlottingCalculator
+
+
+def calculate_single_sa_exposure(
+    calculator: SACalculator,
+    *,
+    ead: Decimal,
+    exposure_class: str,
+    config: CalculationConfig,
+    cqs: int | None = None,
+    ltv: Decimal | None = None,
+    is_sme: bool = False,
+    is_infrastructure: bool = False,
+    is_managed_as_retail: bool = False,
+    qualifies_as_retail: bool = True,
+    has_income_cover: bool = False,
+    property_type: str | None = None,
+    is_adc: bool = False,
+    is_presold: bool = False,
+    seniority: str = "senior",
+    scra_grade: str | None = None,
+    is_investment_grade: bool = False,
+    is_defaulted: bool = False,
+    provision_allocated: Decimal | None = None,
+    provision_deducted: Decimal | None = None,
+    currency: str | None = None,
+    country_code: str | None = None,
+    borrower_income_currency: str | None = None,
+) -> dict:
+    """Calculate SA RWA for a single exposure via calculate_branch."""
+    df = pl.DataFrame(
+        {
+            "exposure_reference": ["SINGLE"],
+            "ead_final": [float(ead)],
+            "exposure_class": [exposure_class],
+            "cqs": [cqs],
+            "ltv": [float(ltv) if ltv is not None else None],
+            "is_sme": [is_sme],
+            "is_infrastructure": [is_infrastructure],
+            "has_income_cover": [has_income_cover],
+            "cp_is_managed_as_retail": [is_managed_as_retail],
+            "qualifies_as_retail": [qualifies_as_retail],
+            "property_type": [property_type],
+            "is_adc": [is_adc],
+            "is_presold": [is_presold],
+            "seniority": [seniority],
+            "cp_scra_grade": [scra_grade],
+            "cp_is_investment_grade": [is_investment_grade],
+            "is_defaulted": [is_defaulted],
+            "provision_allocated": [float(provision_allocated) if provision_allocated else 0.0],
+            "provision_deducted": [float(provision_deducted) if provision_deducted else 0.0],
+            "currency": [currency],
+            "cp_country_code": [country_code],
+            "borrower_income_currency": [borrower_income_currency],
+        }
+    ).lazy()
+
+    result = calculator.calculate_branch(df, config).collect().to_dicts()[0]
+    # Alias rwa_post_factor as rwa for consistency with other calculators
+    result["rwa"] = result["rwa_post_factor"]
+    return result
+
+
+def calculate_single_irb_exposure(
+    calculator: IRBCalculator,
+    *,
+    ead: Decimal,
+    pd: Decimal,
+    config: CalculationConfig,
+    lgd: Decimal | None = None,
+    maturity: Decimal = Decimal("2.5"),
+    exposure_class: str = "CORPORATE",
+    turnover_m: Decimal | None = None,
+    collateral_type: str | None = None,
+    is_subordinated: bool = False,
+) -> dict:
+    """Calculate IRB RWA for a single exposure via calculate_branch."""
+    seniority = "subordinated" if is_subordinated else "senior"
+
+    data: dict = {
+        "exposure_reference": ["SINGLE"],
+        "ead": [float(ead)],
+        "pd": [float(pd)],
+        "maturity": [float(maturity)],
+        "exposure_class": [exposure_class],
+        "seniority": [seniority],
+    }
+
+    if lgd is not None:
+        data["lgd"] = [float(lgd)]
+
+    if turnover_m is not None:
+        data["turnover_m"] = [float(turnover_m)]
+
+    if collateral_type is not None:
+        data["lgd_post_crm"] = [float(lookup_firb_lgd(collateral_type, is_subordinated))]
+
+    df = pl.DataFrame(data).lazy()
+    return calculator.calculate_branch(df, config).collect().to_dicts()[0]
+
+
+def calculate_single_equity_exposure(
+    calculator: EquityCalculator,
+    *,
+    ead: Decimal,
+    equity_type: str,
+    config: CalculationConfig,
+    is_diversified: bool = False,
+    is_speculative: bool = False,
+    is_exchange_traded: bool = False,
+    is_government_supported: bool = False,
+) -> dict:
+    """Calculate equity RWA for a single exposure via calculate_branch."""
+    df = pl.DataFrame(
+        {
+            "exposure_reference": ["SINGLE"],
+            "ead_final": [float(ead)],
+            "equity_type": [equity_type],
+            "is_diversified_portfolio": [is_diversified],
+            "is_speculative": [is_speculative],
+            "is_exchange_traded": [is_exchange_traded],
+            "is_government_supported": [is_government_supported],
+        }
+    ).lazy()
+
+    result = calculator.calculate_branch(df, config).collect().to_dicts()[0]
+    # Add approach metadata for tests that check approach determination
+    approach = calculator._determine_approach(config)
+    result["approach"] = approach
+    result["article"] = "133" if approach == "sa" else "155"
+    return result
+
+
+def calculate_single_slotting_exposure(
+    calculator: SlottingCalculator,
+    *,
+    ead: Decimal,
+    category: str,
+    config: CalculationConfig,
+    is_hvcre: bool = False,
+    sl_type: str = "project_finance",
+    is_short_maturity: bool = False,
+    is_pre_operational: bool = False,
+) -> dict:
+    """Calculate slotting RWA for a single exposure via calculate_branch."""
+    df = pl.DataFrame(
+        {
+            "exposure_reference": ["SINGLE"],
+            "ead": [float(ead)],
+            "slotting_category": [category],
+            "is_hvcre": [is_hvcre],
+            "sl_type": [sl_type],
+            "is_short_maturity": [is_short_maturity],
+            "is_pre_operational": [is_pre_operational],
+        }
+    ).lazy()
+
+    return calculator.calculate_branch(df, config).collect().to_dicts()[0]

--- a/tests/unit/crr/test_crr_equity.py
+++ b/tests/unit/crr/test_crr_equity.py
@@ -26,6 +26,7 @@ from decimal import Decimal
 
 import polars as pl
 import pytest
+from tests.fixtures.single_exposure import calculate_single_equity_exposure
 
 from rwa_calc.contracts.bundles import CRMAdjustedBundle, EquityResultBundle
 from rwa_calc.contracts.config import CalculationConfig, IRBPermissions
@@ -92,7 +93,8 @@ class TestSAEquityRiskWeights:
         sa_config: CalculationConfig,
     ):
         """Central bank equity gets 0% RW under SA (Art. 133(6))."""
-        result = equity_calculator.calculate_single_exposure(
+        result = calculate_single_equity_exposure(
+            equity_calculator,
             ead=Decimal("1000000"),
             equity_type="central_bank",
             config=sa_config,
@@ -106,7 +108,8 @@ class TestSAEquityRiskWeights:
         sa_config: CalculationConfig,
     ):
         """Listed equity gets 100% RW under SA (Art. 133(1))."""
-        result = equity_calculator.calculate_single_exposure(
+        result = calculate_single_equity_exposure(
+            equity_calculator,
             ead=Decimal("1000000"),
             equity_type="listed",
             config=sa_config,
@@ -119,7 +122,8 @@ class TestSAEquityRiskWeights:
         sa_config: CalculationConfig,
     ):
         """Exchange-traded equity gets 100% RW under SA (Art. 133(1))."""
-        result = equity_calculator.calculate_single_exposure(
+        result = calculate_single_equity_exposure(
+            equity_calculator,
             ead=Decimal("1000000"),
             equity_type="exchange_traded",
             config=sa_config,
@@ -132,7 +136,8 @@ class TestSAEquityRiskWeights:
         sa_config: CalculationConfig,
     ):
         """Government-supported equity gets 100% RW under SA (Art. 133(4)(c))."""
-        result = equity_calculator.calculate_single_exposure(
+        result = calculate_single_equity_exposure(
+            equity_calculator,
             ead=Decimal("1000000"),
             equity_type="government_supported",
             config=sa_config,
@@ -145,7 +150,8 @@ class TestSAEquityRiskWeights:
         sa_config: CalculationConfig,
     ):
         """Unlisted equity gets 250% RW under SA (Art. 133(2))."""
-        result = equity_calculator.calculate_single_exposure(
+        result = calculate_single_equity_exposure(
+            equity_calculator,
             ead=Decimal("1000000"),
             equity_type="unlisted",
             config=sa_config,
@@ -158,7 +164,8 @@ class TestSAEquityRiskWeights:
         sa_config: CalculationConfig,
     ):
         """Speculative unlisted equity gets 400% RW under SA (Art. 133(2))."""
-        result = equity_calculator.calculate_single_exposure(
+        result = calculate_single_equity_exposure(
+            equity_calculator,
             ead=Decimal("1000000"),
             equity_type="speculative",
             config=sa_config,
@@ -171,7 +178,8 @@ class TestSAEquityRiskWeights:
         sa_config: CalculationConfig,
     ):
         """is_speculative flag forces 400% RW even for unlisted type."""
-        result = equity_calculator.calculate_single_exposure(
+        result = calculate_single_equity_exposure(
+            equity_calculator,
             ead=Decimal("1000000"),
             equity_type="unlisted",
             is_speculative=True,
@@ -185,7 +193,8 @@ class TestSAEquityRiskWeights:
         sa_config: CalculationConfig,
     ):
         """Private equity gets 250% RW under SA (same as unlisted)."""
-        result = equity_calculator.calculate_single_exposure(
+        result = calculate_single_equity_exposure(
+            equity_calculator,
             ead=Decimal("1000000"),
             equity_type="private_equity",
             config=sa_config,
@@ -198,7 +207,8 @@ class TestSAEquityRiskWeights:
         sa_config: CalculationConfig,
     ):
         """CIU (collective investment undertaking) gets 250% RW under SA."""
-        result = equity_calculator.calculate_single_exposure(
+        result = calculate_single_equity_exposure(
+            equity_calculator,
             ead=Decimal("1000000"),
             equity_type="ciu",
             config=sa_config,
@@ -220,7 +230,8 @@ class TestIRBSimpleEquityRiskWeights:
         irb_config: CalculationConfig,
     ):
         """Central bank equity gets 0% RW under IRB Simple."""
-        result = equity_calculator.calculate_single_exposure(
+        result = calculate_single_equity_exposure(
+            equity_calculator,
             ead=Decimal("1000000"),
             equity_type="central_bank",
             config=irb_config,
@@ -234,7 +245,8 @@ class TestIRBSimpleEquityRiskWeights:
         irb_config: CalculationConfig,
     ):
         """Diversified private equity gets 190% RW under IRB Simple (Art. 155(2))."""
-        result = equity_calculator.calculate_single_exposure(
+        result = calculate_single_equity_exposure(
+            equity_calculator,
             ead=Decimal("1000000"),
             equity_type="private_equity",
             is_diversified=True,
@@ -248,7 +260,8 @@ class TestIRBSimpleEquityRiskWeights:
         irb_config: CalculationConfig,
     ):
         """Exchange-traded equity gets 290% RW under IRB Simple (Art. 155(2))."""
-        result = equity_calculator.calculate_single_exposure(
+        result = calculate_single_equity_exposure(
+            equity_calculator,
             ead=Decimal("1000000"),
             equity_type="exchange_traded",
             config=irb_config,
@@ -261,7 +274,8 @@ class TestIRBSimpleEquityRiskWeights:
         irb_config: CalculationConfig,
     ):
         """Listed equity gets 290% RW under IRB Simple (same as exchange-traded)."""
-        result = equity_calculator.calculate_single_exposure(
+        result = calculate_single_equity_exposure(
+            equity_calculator,
             ead=Decimal("1000000"),
             equity_type="listed",
             config=irb_config,
@@ -274,7 +288,8 @@ class TestIRBSimpleEquityRiskWeights:
         irb_config: CalculationConfig,
     ):
         """Other equity gets 370% RW under IRB Simple (Art. 155(2))."""
-        result = equity_calculator.calculate_single_exposure(
+        result = calculate_single_equity_exposure(
+            equity_calculator,
             ead=Decimal("1000000"),
             equity_type="other",
             config=irb_config,
@@ -287,7 +302,8 @@ class TestIRBSimpleEquityRiskWeights:
         irb_config: CalculationConfig,
     ):
         """Unlisted equity gets 370% RW under IRB Simple."""
-        result = equity_calculator.calculate_single_exposure(
+        result = calculate_single_equity_exposure(
+            equity_calculator,
             ead=Decimal("1000000"),
             equity_type="unlisted",
             config=irb_config,
@@ -300,7 +316,8 @@ class TestIRBSimpleEquityRiskWeights:
         irb_config: CalculationConfig,
     ):
         """Speculative equity gets 370% RW under IRB Simple (same as other)."""
-        result = equity_calculator.calculate_single_exposure(
+        result = calculate_single_equity_exposure(
+            equity_calculator,
             ead=Decimal("1000000"),
             equity_type="speculative",
             config=irb_config,
@@ -313,7 +330,8 @@ class TestIRBSimpleEquityRiskWeights:
         irb_config: CalculationConfig,
     ):
         """Government-supported gets 190% RW under IRB Simple (treated as PE diversified)."""
-        result = equity_calculator.calculate_single_exposure(
+        result = calculate_single_equity_exposure(
+            equity_calculator,
             ead=Decimal("1000000"),
             equity_type="government_supported",
             config=irb_config,
@@ -326,7 +344,8 @@ class TestIRBSimpleEquityRiskWeights:
         irb_config: CalculationConfig,
     ):
         """Non-diversified private equity gets 370% RW under IRB Simple."""
-        result = equity_calculator.calculate_single_exposure(
+        result = calculate_single_equity_exposure(
+            equity_calculator,
             ead=Decimal("1000000"),
             equity_type="private_equity",
             is_diversified=False,
@@ -350,7 +369,8 @@ class TestEquityRWACalculation:
     ):
         """RWA = EAD × RW."""
         ead = Decimal("1000000")
-        result = equity_calculator.calculate_single_exposure(
+        result = calculate_single_equity_exposure(
+            equity_calculator,
             ead=ead,
             equity_type="listed",
             config=sa_config,
@@ -364,7 +384,8 @@ class TestEquityRWACalculation:
         sa_config: CalculationConfig,
     ):
         """SA Listed: £1m at 100% = £1m RWA."""
-        result = equity_calculator.calculate_single_exposure(
+        result = calculate_single_equity_exposure(
+            equity_calculator,
             ead=Decimal("1000000"),
             equity_type="listed",
             config=sa_config,
@@ -378,7 +399,8 @@ class TestEquityRWACalculation:
         sa_config: CalculationConfig,
     ):
         """SA Unlisted: £1m at 250% = £2.5m RWA."""
-        result = equity_calculator.calculate_single_exposure(
+        result = calculate_single_equity_exposure(
+            equity_calculator,
             ead=Decimal("1000000"),
             equity_type="unlisted",
             config=sa_config,
@@ -392,7 +414,8 @@ class TestEquityRWACalculation:
         sa_config: CalculationConfig,
     ):
         """SA Speculative: £1m at 400% = £4m RWA."""
-        result = equity_calculator.calculate_single_exposure(
+        result = calculate_single_equity_exposure(
+            equity_calculator,
             ead=Decimal("1000000"),
             equity_type="speculative",
             config=sa_config,
@@ -406,7 +429,8 @@ class TestEquityRWACalculation:
         irb_config: CalculationConfig,
     ):
         """IRB PE Diversified: £1m at 190% = £1.9m RWA."""
-        result = equity_calculator.calculate_single_exposure(
+        result = calculate_single_equity_exposure(
+            equity_calculator,
             ead=Decimal("1000000"),
             equity_type="private_equity",
             is_diversified=True,
@@ -421,7 +445,8 @@ class TestEquityRWACalculation:
         irb_config: CalculationConfig,
     ):
         """IRB Exchange-traded: £1m at 290% = £2.9m RWA."""
-        result = equity_calculator.calculate_single_exposure(
+        result = calculate_single_equity_exposure(
+            equity_calculator,
             ead=Decimal("1000000"),
             equity_type="exchange_traded",
             config=irb_config,
@@ -435,7 +460,8 @@ class TestEquityRWACalculation:
         irb_config: CalculationConfig,
     ):
         """IRB Other: £1m at 370% = £3.7m RWA."""
-        result = equity_calculator.calculate_single_exposure(
+        result = calculate_single_equity_exposure(
+            equity_calculator,
             ead=Decimal("1000000"),
             equity_type="other",
             config=irb_config,
@@ -560,7 +586,8 @@ class TestApproachDetermination:
             reporting_date=date(2024, 12, 31),
             irb_permissions=IRBPermissions.sa_only(),
         )
-        result = equity_calculator.calculate_single_exposure(
+        result = calculate_single_equity_exposure(
+            equity_calculator,
             ead=Decimal("1000000"),
             equity_type="listed",
             config=config,
@@ -577,7 +604,8 @@ class TestApproachDetermination:
             reporting_date=date(2024, 12, 31),
             irb_permissions=IRBPermissions.firb_only(),
         )
-        result = equity_calculator.calculate_single_exposure(
+        result = calculate_single_equity_exposure(
+            equity_calculator,
             ead=Decimal("1000000"),
             equity_type="listed",
             config=config,
@@ -594,7 +622,8 @@ class TestApproachDetermination:
             reporting_date=date(2024, 12, 31),
             irb_permissions=IRBPermissions.airb_only(),
         )
-        result = equity_calculator.calculate_single_exposure(
+        result = calculate_single_equity_exposure(
+            equity_calculator,
             ead=Decimal("1000000"),
             equity_type="listed",
             config=config,
@@ -610,7 +639,8 @@ class TestApproachDetermination:
             reporting_date=date(2024, 12, 31),
             irb_permissions=IRBPermissions.full_irb(),
         )
-        result = equity_calculator.calculate_single_exposure(
+        result = calculate_single_equity_exposure(
+            equity_calculator,
             ead=Decimal("1000000"),
             equity_type="listed",
             config=config,
@@ -731,7 +761,8 @@ class TestEquityEdgeCases:
         sa_config: CalculationConfig,
     ):
         """Zero EAD produces zero RWA."""
-        result = equity_calculator.calculate_single_exposure(
+        result = calculate_single_equity_exposure(
+            equity_calculator,
             ead=Decimal("0"),
             equity_type="listed",
             config=sa_config,
@@ -849,12 +880,14 @@ class TestSAVsIRBSimple:
         irb_config: CalculationConfig,
     ):
         """Listed equity: SA (100%) is lower than IRB Simple (290%)."""
-        sa_result = equity_calculator.calculate_single_exposure(
+        sa_result = calculate_single_equity_exposure(
+            equity_calculator,
             ead=Decimal("1000000"),
             equity_type="listed",
             config=sa_config,
         )
-        irb_result = equity_calculator.calculate_single_exposure(
+        irb_result = calculate_single_equity_exposure(
+            equity_calculator,
             ead=Decimal("1000000"),
             equity_type="listed",
             config=irb_config,
@@ -870,12 +903,14 @@ class TestSAVsIRBSimple:
         irb_config: CalculationConfig,
     ):
         """Unlisted equity: SA (250%) is lower than IRB Simple (370%)."""
-        sa_result = equity_calculator.calculate_single_exposure(
+        sa_result = calculate_single_equity_exposure(
+            equity_calculator,
             ead=Decimal("1000000"),
             equity_type="unlisted",
             config=sa_config,
         )
-        irb_result = equity_calculator.calculate_single_exposure(
+        irb_result = calculate_single_equity_exposure(
+            equity_calculator,
             ead=Decimal("1000000"),
             equity_type="unlisted",
             config=irb_config,
@@ -891,12 +926,14 @@ class TestSAVsIRBSimple:
         irb_config: CalculationConfig,
     ):
         """Speculative equity: SA (400%) is higher than IRB Simple (370%)."""
-        sa_result = equity_calculator.calculate_single_exposure(
+        sa_result = calculate_single_equity_exposure(
+            equity_calculator,
             ead=Decimal("1000000"),
             equity_type="speculative",
             config=sa_config,
         )
-        irb_result = equity_calculator.calculate_single_exposure(
+        irb_result = calculate_single_equity_exposure(
+            equity_calculator,
             ead=Decimal("1000000"),
             equity_type="speculative",
             config=irb_config,

--- a/tests/unit/crr/test_crr_irb.py
+++ b/tests/unit/crr/test_crr_irb.py
@@ -23,6 +23,7 @@ from decimal import Decimal
 
 import polars as pl
 import pytest
+from tests.fixtures.single_exposure import calculate_single_irb_exposure
 
 from rwa_calc.contracts.bundles import CRMAdjustedBundle
 from rwa_calc.contracts.config import CalculationConfig
@@ -299,7 +300,8 @@ class TestFIRBSupervisoryLGD:
         crr_config: CalculationConfig,
     ) -> None:
         """Senior unsecured should get 45% LGD."""
-        result = irb_calculator.calculate_single_exposure(
+        result = calculate_single_irb_exposure(
+            irb_calculator,
             ead=Decimal("1000000"),
             pd=Decimal("0.01"),
             lgd=None,  # F-IRB supervisory
@@ -315,7 +317,8 @@ class TestFIRBSupervisoryLGD:
         crr_config: CalculationConfig,
     ) -> None:
         """Subordinated should get 75% LGD."""
-        result = irb_calculator.calculate_single_exposure(
+        result = calculate_single_irb_exposure(
+            irb_calculator,
             ead=Decimal("1000000"),
             pd=Decimal("0.01"),
             lgd=None,
@@ -332,7 +335,8 @@ class TestFIRBSupervisoryLGD:
         crr_config: CalculationConfig,
     ) -> None:
         """Real estate secured should get 35% LGD."""
-        result = irb_calculator.calculate_single_exposure(
+        result = calculate_single_irb_exposure(
+            irb_calculator,
             ead=Decimal("1000000"),
             pd=Decimal("0.01"),
             lgd=None,
@@ -358,7 +362,8 @@ class TestPDFloor:
         crr_config: CalculationConfig,
     ) -> None:
         """CRR PD floor (0.03%) should be applied."""
-        result = irb_calculator.calculate_single_exposure(
+        result = calculate_single_irb_exposure(
+            irb_calculator,
             ead=Decimal("1000000"),
             pd=Decimal("0.0001"),  # 0.01% - below floor
             lgd=Decimal("0.45"),
@@ -375,7 +380,8 @@ class TestPDFloor:
         crr_config: CalculationConfig,
     ) -> None:
         """PD above floor should be unchanged."""
-        result = irb_calculator.calculate_single_exposure(
+        result = calculate_single_irb_exposure(
+            irb_calculator,
             ead=Decimal("1000000"),
             pd=Decimal("0.05"),  # 5% - well above floor
             lgd=Decimal("0.45"),
@@ -456,7 +462,8 @@ class TestIRBRWACalculation:
         crr_config: CalculationConfig,
     ) -> None:
         """Retail exposures should not have maturity adjustment."""
-        result = irb_calculator.calculate_single_exposure(
+        result = calculate_single_irb_exposure(
+            irb_calculator,
             ead=Decimal("100000"),
             pd=Decimal("0.02"),
             lgd=Decimal("0.30"),
@@ -489,7 +496,8 @@ class TestExpectedLoss:
         crr_config: CalculationConfig,
     ) -> None:
         """Expected loss should be included in calculation result."""
-        result = irb_calculator.calculate_single_exposure(
+        result = calculate_single_irb_exposure(
+            irb_calculator,
             ead=Decimal("1000000"),
             pd=Decimal("0.01"),
             lgd=Decimal("0.45"),
@@ -633,7 +641,8 @@ class TestCRRVsBasel31:
         crr_config: CalculationConfig,
     ) -> None:
         """CRR should apply 1.06 scaling factor."""
-        result = irb_calculator.calculate_single_exposure(
+        result = calculate_single_irb_exposure(
+            irb_calculator,
             ead=Decimal("1000000"),
             pd=Decimal("0.01"),
             lgd=Decimal("0.45"),
@@ -649,7 +658,8 @@ class TestCRRVsBasel31:
         basel31_config: CalculationConfig,
     ) -> None:
         """Basel 3.1 should not apply 1.06 scaling factor."""
-        result = irb_calculator.calculate_single_exposure(
+        result = calculate_single_irb_exposure(
+            irb_calculator,
             ead=Decimal("1000000"),
             pd=Decimal("0.01"),
             lgd=Decimal("0.45"),
@@ -666,14 +676,16 @@ class TestCRRVsBasel31:
         basel31_config: CalculationConfig,
     ) -> None:
         """CRR has 0.03% PD floor vs Basel 3.1 0.05% for corporates."""
-        result_crr = irb_calculator.calculate_single_exposure(
+        result_crr = calculate_single_irb_exposure(
+            irb_calculator,
             ead=Decimal("1000000"),
             pd=Decimal("0.0001"),
             lgd=Decimal("0.45"),
             exposure_class="CORPORATE",
             config=crr_config,
         )
-        result_basel = irb_calculator.calculate_single_exposure(
+        result_basel = calculate_single_irb_exposure(
+            irb_calculator,
             ead=Decimal("1000000"),
             pd=Decimal("0.0001"),
             lgd=Decimal("0.45"),

--- a/tests/unit/crr/test_crr_sa.py
+++ b/tests/unit/crr/test_crr_sa.py
@@ -23,6 +23,7 @@ from decimal import Decimal
 
 import polars as pl
 import pytest
+from tests.fixtures.single_exposure import calculate_single_sa_exposure
 
 from rwa_calc.contracts.bundles import CRMAdjustedBundle
 from rwa_calc.contracts.config import CalculationConfig
@@ -75,15 +76,16 @@ class TestSovereignRiskWeights:
         crr_config: CalculationConfig,
     ) -> None:
         """CQS 1 sovereign (e.g., UK Govt) should get 0% RW."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="CENTRAL_GOVT_CENTRAL_BANK",
             cqs=1,
             config=crr_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("0.0"))
-        assert result["rwa"] == pytest.approx(Decimal("0.0"))
+        assert result["risk_weight"] == pytest.approx(0.0)
+        assert result["rwa"] == pytest.approx(0.0)
 
     def test_cqs2_twenty_percent(
         self,
@@ -91,15 +93,16 @@ class TestSovereignRiskWeights:
         crr_config: CalculationConfig,
     ) -> None:
         """CQS 2 sovereign should get 20% RW."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="CENTRAL_GOVT_CENTRAL_BANK",
             cqs=2,
             config=crr_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("0.20"))
-        assert result["rwa"] == pytest.approx(Decimal("200000"))
+        assert result["risk_weight"] == pytest.approx(0.20)
+        assert result["rwa"] == pytest.approx(200000)
 
     def test_unrated_hundred_percent(
         self,
@@ -107,15 +110,16 @@ class TestSovereignRiskWeights:
         crr_config: CalculationConfig,
     ) -> None:
         """Unrated sovereign should get 100% RW."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="CENTRAL_GOVT_CENTRAL_BANK",
             cqs=None,
             config=crr_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("1.0"))
-        assert result["rwa"] == pytest.approx(Decimal("1000000"))
+        assert result["risk_weight"] == pytest.approx(1.0)
+        assert result["rwa"] == pytest.approx(1000000)
 
 
 class TestArticle114_3DomesticCurrency:
@@ -131,7 +135,8 @@ class TestArticle114_3DomesticCurrency:
         crr_config: CalculationConfig,
     ) -> None:
         """UK sovereign + GBP + CQS 2 → 0% RW (domestic currency override)."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="CENTRAL_GOVT_CENTRAL_BANK",
             cqs=2,
@@ -140,8 +145,8 @@ class TestArticle114_3DomesticCurrency:
             config=crr_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("0.0"))
-        assert result["rwa"] == pytest.approx(Decimal("0.0"))
+        assert result["risk_weight"] == pytest.approx(0.0)
+        assert result["rwa"] == pytest.approx(0.0)
 
     def test_uk_sovereign_gbp_unrated_gets_zero_rw(
         self,
@@ -149,7 +154,8 @@ class TestArticle114_3DomesticCurrency:
         crr_config: CalculationConfig,
     ) -> None:
         """UK sovereign + GBP + unrated → 0% RW (domestic currency override)."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="CENTRAL_GOVT_CENTRAL_BANK",
             cqs=None,
@@ -158,8 +164,8 @@ class TestArticle114_3DomesticCurrency:
             config=crr_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("0.0"))
-        assert result["rwa"] == pytest.approx(Decimal("0.0"))
+        assert result["risk_weight"] == pytest.approx(0.0)
+        assert result["rwa"] == pytest.approx(0.0)
 
     def test_uk_sovereign_usd_uses_cqs_based_rw(
         self,
@@ -167,7 +173,8 @@ class TestArticle114_3DomesticCurrency:
         crr_config: CalculationConfig,
     ) -> None:
         """UK sovereign + USD + CQS 2 → 20% RW (foreign currency, no override)."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="CENTRAL_GOVT_CENTRAL_BANK",
             cqs=2,
@@ -176,8 +183,8 @@ class TestArticle114_3DomesticCurrency:
             config=crr_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("0.20"))
-        assert result["rwa"] == pytest.approx(Decimal("200000"))
+        assert result["risk_weight"] == pytest.approx(0.20)
+        assert result["rwa"] == pytest.approx(200000)
 
     def test_non_uk_sovereign_gbp_uses_cqs_based_rw(
         self,
@@ -185,7 +192,8 @@ class TestArticle114_3DomesticCurrency:
         crr_config: CalculationConfig,
     ) -> None:
         """Non-UK sovereign (US) + GBP + CQS 2 → 20% RW (not UK, no override)."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="CENTRAL_GOVT_CENTRAL_BANK",
             cqs=2,
@@ -194,8 +202,8 @@ class TestArticle114_3DomesticCurrency:
             config=crr_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("0.20"))
-        assert result["rwa"] == pytest.approx(Decimal("200000"))
+        assert result["risk_weight"] == pytest.approx(0.20)
+        assert result["rwa"] == pytest.approx(200000)
 
     def test_corporate_gb_gbp_no_override(
         self,
@@ -203,7 +211,8 @@ class TestArticle114_3DomesticCurrency:
         crr_config: CalculationConfig,
     ) -> None:
         """Corporate + GB + GBP → CQS-based RW (Art. 114(3) only applies to CGCB)."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="CORPORATE",
             cqs=2,
@@ -212,8 +221,8 @@ class TestArticle114_3DomesticCurrency:
             config=crr_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("0.50"))
-        assert result["rwa"] == pytest.approx(Decimal("500000"))
+        assert result["risk_weight"] == pytest.approx(0.50)
+        assert result["rwa"] == pytest.approx(500000)
 
     def test_missing_currency_falls_through_to_cqs(
         self,
@@ -221,7 +230,8 @@ class TestArticle114_3DomesticCurrency:
         crr_config: CalculationConfig,
     ) -> None:
         """Missing currency → falls through to CQS-based RW."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="CENTRAL_GOVT_CENTRAL_BANK",
             cqs=2,
@@ -229,7 +239,7 @@ class TestArticle114_3DomesticCurrency:
             config=crr_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("0.20"))
+        assert result["risk_weight"] == pytest.approx(0.20)
 
     def test_uk_sovereign_gbp_cqs1_still_zero(
         self,
@@ -237,7 +247,8 @@ class TestArticle114_3DomesticCurrency:
         crr_config: CalculationConfig,
     ) -> None:
         """UK sovereign + GBP + CQS 1 → 0% RW (both paths agree)."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="CENTRAL_GOVT_CENTRAL_BANK",
             cqs=1,
@@ -246,8 +257,8 @@ class TestArticle114_3DomesticCurrency:
             config=crr_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("0.0"))
-        assert result["rwa"] == pytest.approx(Decimal("0.0"))
+        assert result["risk_weight"] == pytest.approx(0.0)
+        assert result["rwa"] == pytest.approx(0.0)
 
     def test_uk_sovereign_gbp_basel31_gets_zero_rw(
         self,
@@ -255,7 +266,8 @@ class TestArticle114_3DomesticCurrency:
         basel31_config: CalculationConfig,
     ) -> None:
         """Art. 114(3) also applies under Basel 3.1 — UK sovereign + GBP → 0%."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="CENTRAL_GOVT_CENTRAL_BANK",
             cqs=3,
@@ -264,8 +276,8 @@ class TestArticle114_3DomesticCurrency:
             config=basel31_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("0.0"))
-        assert result["rwa"] == pytest.approx(Decimal("0.0"))
+        assert result["risk_weight"] == pytest.approx(0.0)
+        assert result["rwa"] == pytest.approx(0.0)
 
 
 class TestInstitutionRiskWeights:
@@ -277,15 +289,16 @@ class TestInstitutionRiskWeights:
         crr_config: CalculationConfig,
     ) -> None:
         """CQS 1 institution should get 20% RW."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="INSTITUTION",
             cqs=1,
             config=crr_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("0.20"))
-        assert result["rwa"] == pytest.approx(Decimal("200000"))
+        assert result["risk_weight"] == pytest.approx(0.20)
+        assert result["rwa"] == pytest.approx(200000)
 
     def test_cqs2_uk_deviation_thirty_percent(
         self,
@@ -293,7 +306,8 @@ class TestInstitutionRiskWeights:
         crr_config: CalculationConfig,
     ) -> None:
         """CQS 2 institution with UK deviation should get 30% RW."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="INSTITUTION",
             cqs=2,
@@ -301,8 +315,8 @@ class TestInstitutionRiskWeights:
         )
 
         # UK deviation: 30% instead of Basel standard 50%
-        assert result["risk_weight"] == pytest.approx(Decimal("0.30"))
-        assert result["rwa"] == pytest.approx(Decimal("300000"))
+        assert result["risk_weight"] == pytest.approx(0.30)
+        assert result["rwa"] == pytest.approx(300000)
 
     def test_unrated_forty_percent(
         self,
@@ -310,15 +324,16 @@ class TestInstitutionRiskWeights:
         crr_config: CalculationConfig,
     ) -> None:
         """Unrated institution should get 40% RW."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="INSTITUTION",
             cqs=None,
             config=crr_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("0.40"))
-        assert result["rwa"] == pytest.approx(Decimal("400000"))
+        assert result["risk_weight"] == pytest.approx(0.40)
+        assert result["rwa"] == pytest.approx(400000)
 
 
 class TestCorporateRiskWeights:
@@ -330,15 +345,16 @@ class TestCorporateRiskWeights:
         crr_config: CalculationConfig,
     ) -> None:
         """CQS 1 corporate should get 20% RW."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="CORPORATE",
             cqs=1,
             config=crr_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("0.20"))
-        assert result["rwa"] == pytest.approx(Decimal("200000"))
+        assert result["risk_weight"] == pytest.approx(0.20)
+        assert result["rwa"] == pytest.approx(200000)
 
     def test_cqs2_fifty_percent(
         self,
@@ -346,15 +362,16 @@ class TestCorporateRiskWeights:
         crr_config: CalculationConfig,
     ) -> None:
         """CQS 2 corporate should get 50% RW."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="CORPORATE",
             cqs=2,
             config=crr_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("0.50"))
-        assert result["rwa"] == pytest.approx(Decimal("500000"))
+        assert result["risk_weight"] == pytest.approx(0.50)
+        assert result["rwa"] == pytest.approx(500000)
 
     def test_unrated_hundred_percent(
         self,
@@ -362,15 +379,16 @@ class TestCorporateRiskWeights:
         crr_config: CalculationConfig,
     ) -> None:
         """Unrated corporate should get 100% RW."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="CORPORATE",
             cqs=None,
             config=crr_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("1.0"))
-        assert result["rwa"] == pytest.approx(Decimal("1000000"))
+        assert result["risk_weight"] == pytest.approx(1.0)
+        assert result["rwa"] == pytest.approx(1000000)
 
 
 # =============================================================================
@@ -387,14 +405,15 @@ class TestRetailRiskWeights:
         crr_config: CalculationConfig,
     ) -> None:
         """Retail exposures should get 75% RW."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("100000"),
             exposure_class="RETAIL",
             config=crr_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("0.75"))
-        assert result["rwa"] == pytest.approx(Decimal("75000"))
+        assert result["risk_weight"] == pytest.approx(0.75)
+        assert result["rwa"] == pytest.approx(75000)
 
     def test_retail_ignores_cqs(
         self,
@@ -402,14 +421,15 @@ class TestRetailRiskWeights:
         crr_config: CalculationConfig,
     ) -> None:
         """Retail RW should not depend on CQS."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("100000"),
             exposure_class="RETAIL",
             cqs=1,  # Should be ignored
             config=crr_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("0.75"))
+        assert result["risk_weight"] == pytest.approx(0.75)
 
 
 # =============================================================================
@@ -426,15 +446,16 @@ class TestResidentialMortgageRiskWeights:
         crr_config: CalculationConfig,
     ) -> None:
         """LTV <= 80% should get 35% RW."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("500000"),
             exposure_class="RESIDENTIAL_MORTGAGE",
             ltv=Decimal("0.60"),
             config=crr_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("0.35"))
-        assert result["rwa"] == pytest.approx(Decimal("175000"))
+        assert result["risk_weight"] == pytest.approx(0.35)
+        assert result["rwa"] == pytest.approx(175000)
 
     def test_at_threshold_thirty_five_percent(
         self,
@@ -442,14 +463,15 @@ class TestResidentialMortgageRiskWeights:
         crr_config: CalculationConfig,
     ) -> None:
         """LTV exactly at 80% should get 35% RW."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("500000"),
             exposure_class="RESIDENTIAL_MORTGAGE",
             ltv=Decimal("0.80"),
             config=crr_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("0.35"))
+        assert result["risk_weight"] == pytest.approx(0.35)
 
     def test_high_ltv_split_treatment(
         self,
@@ -459,7 +481,8 @@ class TestResidentialMortgageRiskWeights:
         """LTV > 80% should get split treatment."""
         # At 100% LTV: 80% at 35%, 20% at 75%
         # Weighted: (0.80 × 0.35) + (0.20 × 0.75) = 0.28 + 0.15 = 0.43
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("500000"),
             exposure_class="RESIDENTIAL_MORTGAGE",
             ltv=Decimal("1.00"),
@@ -803,7 +826,8 @@ class TestSMESupportingFactor:
         crr_config: CalculationConfig,
     ) -> None:
         """SME factor should reduce RWA."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="CORPORATE",
             cqs=None,  # 100% RW
@@ -813,8 +837,8 @@ class TestSMESupportingFactor:
 
         # Without factor: RWA = 1m × 100% = 1m
         # With factor: RWA = 1m × 100% × 0.7619 = £761,900
-        assert result["supporting_factor"] == pytest.approx(Decimal("0.7619"))
-        assert result["rwa"] == pytest.approx(Decimal("761900"))
+        assert result["supporting_factor"] == pytest.approx(0.7619)
+        assert result["rwa"] == pytest.approx(761900)
         assert result["supporting_factor_applied"] is True
 
     def test_sme_factor_disabled_in_basel31(
@@ -823,7 +847,8 @@ class TestSMESupportingFactor:
         basel31_config: CalculationConfig,
     ) -> None:
         """SME factor should be 1.0 under Basel 3.1."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="CORPORATE",
             cqs=None,
@@ -831,7 +856,7 @@ class TestSMESupportingFactor:
             config=basel31_config,
         )
 
-        assert result["supporting_factor"] == pytest.approx(Decimal("1.0"))
+        assert result["supporting_factor"] == pytest.approx(1.0)
         assert result["supporting_factor_applied"] is False
 
 
@@ -844,7 +869,8 @@ class TestInfrastructureSupportingFactor:
         crr_config: CalculationConfig,
     ) -> None:
         """Infrastructure factor should be 0.75."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("10000000"),
             exposure_class="CORPORATE",
             cqs=None,
@@ -852,9 +878,9 @@ class TestInfrastructureSupportingFactor:
             config=crr_config,
         )
 
-        assert result["supporting_factor"] == pytest.approx(Decimal("0.75"))
+        assert result["supporting_factor"] == pytest.approx(0.75)
         # RWA = 10m × 100% × 0.75 = £7.5m
-        assert result["rwa"] == pytest.approx(Decimal("7500000"))
+        assert result["rwa"] == pytest.approx(7500000)
 
     def test_infrastructure_factor_disabled_in_basel31(
         self,
@@ -862,7 +888,8 @@ class TestInfrastructureSupportingFactor:
         basel31_config: CalculationConfig,
     ) -> None:
         """Infrastructure factor should be 1.0 under Basel 3.1."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("10000000"),
             exposure_class="CORPORATE",
             cqs=None,
@@ -870,7 +897,7 @@ class TestInfrastructureSupportingFactor:
             config=basel31_config,
         )
 
-        assert result["supporting_factor"] == pytest.approx(Decimal("1.0"))
+        assert result["supporting_factor"] == pytest.approx(1.0)
 
 
 class TestSupportingFactorPriority:
@@ -887,7 +914,8 @@ class TestSupportingFactorPriority:
         # Should use 0.75 (infrastructure is lower for large exposures)
 
         # Large exposure where SME factor > infra factor
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("100000000"),  # £100m - SME factor close to 0.85
             exposure_class="CORPORATE",
             cqs=None,
@@ -898,7 +926,7 @@ class TestSupportingFactorPriority:
 
         # At £100m, SME factor is close to 0.85, infra is 0.75
         # Should use 0.75
-        assert result["supporting_factor"] == pytest.approx(Decimal("0.75"))
+        assert result["supporting_factor"] == pytest.approx(0.75)
 
 
 class TestSMESupportingFactorCounterpartyAggregation:
@@ -1219,7 +1247,8 @@ class TestDefaultedExposureRiskWeights:
         crr_config: CalculationConfig,
     ) -> None:
         """CRR Art. 127: provision >= 20% of unsecured EAD -> 100% RW."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="CORPORATE",
             cqs=None,
@@ -1231,7 +1260,7 @@ class TestDefaultedExposureRiskWeights:
             config=crr_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("1.0"))
+        assert result["risk_weight"] == pytest.approx(1.0)
 
     def test_crr_defaulted_low_provision_150pct_rw(
         self,
@@ -1239,7 +1268,8 @@ class TestDefaultedExposureRiskWeights:
         crr_config: CalculationConfig,
     ) -> None:
         """CRR Art. 127: provision < 20% of unsecured EAD -> 150% RW."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="CORPORATE",
             cqs=None,
@@ -1251,7 +1281,7 @@ class TestDefaultedExposureRiskWeights:
             config=crr_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("1.50"))
+        assert result["risk_weight"] == pytest.approx(1.50)
 
     def test_crr_defaulted_zero_provision_150pct_rw(
         self,
@@ -1259,7 +1289,8 @@ class TestDefaultedExposureRiskWeights:
         crr_config: CalculationConfig,
     ) -> None:
         """CRR Art. 127: no provisions at all -> 150% RW."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="CORPORATE",
             cqs=None,
@@ -1267,7 +1298,7 @@ class TestDefaultedExposureRiskWeights:
             config=crr_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("1.50"))
+        assert result["risk_weight"] == pytest.approx(1.50)
 
     def test_crr_defaulted_mortgage_gets_defaulted_rw(
         self,
@@ -1275,7 +1306,8 @@ class TestDefaultedExposureRiskWeights:
         crr_config: CalculationConfig,
     ) -> None:
         """Defaulted mortgage should get defaulted treatment, not LTV-based RW."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("500000"),
             exposure_class="RETAIL_MORTGAGE",
             cqs=None,
@@ -1284,7 +1316,7 @@ class TestDefaultedExposureRiskWeights:
         )
 
         # Should be 150% (no provisions), NOT the 35% LTV-based weight
-        assert result["risk_weight"] == pytest.approx(Decimal("1.50"))
+        assert result["risk_weight"] == pytest.approx(1.50)
 
     def test_crr_non_defaulted_corporate_unchanged(
         self,
@@ -1292,7 +1324,8 @@ class TestDefaultedExposureRiskWeights:
         crr_config: CalculationConfig,
     ) -> None:
         """Non-defaulted corporate should still get normal CQS-based RW."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="CORPORATE",
             cqs=2,
@@ -1300,7 +1333,7 @@ class TestDefaultedExposureRiskWeights:
         )
 
         # CQS 2 corporate = 50%
-        assert result["risk_weight"] == pytest.approx(Decimal("0.50"))
+        assert result["risk_weight"] == pytest.approx(0.50)
 
     def test_b31_defaulted_high_provision_100pct_rw(
         self,
@@ -1308,7 +1341,8 @@ class TestDefaultedExposureRiskWeights:
         basel31_config: CalculationConfig,
     ) -> None:
         """CRE20.89: provision >= 50% -> 100% RW."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="CORPORATE",
             cqs=None,
@@ -1320,7 +1354,7 @@ class TestDefaultedExposureRiskWeights:
             config=basel31_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("1.0"))
+        assert result["risk_weight"] == pytest.approx(1.0)
 
     def test_b31_defaulted_low_provision_150pct_rw(
         self,
@@ -1328,7 +1362,8 @@ class TestDefaultedExposureRiskWeights:
         basel31_config: CalculationConfig,
     ) -> None:
         """CRE20.88: provision < 50% -> 150% RW."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="CORPORATE",
             cqs=None,
@@ -1340,7 +1375,7 @@ class TestDefaultedExposureRiskWeights:
             config=basel31_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("1.50"))
+        assert result["risk_weight"] == pytest.approx(1.50)
 
 
 class TestDefaultedSMEExclusion:
@@ -1355,7 +1390,8 @@ class TestDefaultedSMEExclusion:
         crr_config: CalculationConfig,
     ) -> None:
         """Defaulted SME should NOT receive supporting factor."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="CORPORATE",
             cqs=None,
@@ -1366,7 +1402,7 @@ class TestDefaultedSMEExclusion:
             config=crr_config,
         )
 
-        assert result["supporting_factor"] == pytest.approx(Decimal("1.0"))
+        assert result["supporting_factor"] == pytest.approx(1.0)
         assert result["supporting_factor_applied"] is False
 
     def test_sme_factor_applies_to_performing_sme(
@@ -1375,7 +1411,8 @@ class TestDefaultedSMEExclusion:
         crr_config: CalculationConfig,
     ) -> None:
         """Non-defaulted SME should still receive supporting factor."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="CORPORATE",
             cqs=None,
@@ -1407,7 +1444,8 @@ class TestArticle114_4EUDomesticCurrency:
         crr_config: CalculationConfig,
     ) -> None:
         """German sovereign + EUR + CQS 2 → 0% RW (EU domestic currency override)."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="CENTRAL_GOVT_CENTRAL_BANK",
             cqs=2,
@@ -1416,8 +1454,8 @@ class TestArticle114_4EUDomesticCurrency:
             config=crr_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("0.0"))
-        assert result["rwa"] == pytest.approx(Decimal("0.0"))
+        assert result["risk_weight"] == pytest.approx(0.0)
+        assert result["rwa"] == pytest.approx(0.0)
 
     def test_eu_eurozone_sovereign_eur_unrated_gets_zero_rw(
         self,
@@ -1425,7 +1463,8 @@ class TestArticle114_4EUDomesticCurrency:
         crr_config: CalculationConfig,
     ) -> None:
         """French sovereign + EUR + unrated → 0% RW (EU domestic currency override)."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="CENTRAL_GOVT_CENTRAL_BANK",
             cqs=None,
@@ -1434,8 +1473,8 @@ class TestArticle114_4EUDomesticCurrency:
             config=crr_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("0.0"))
-        assert result["rwa"] == pytest.approx(Decimal("0.0"))
+        assert result["risk_weight"] == pytest.approx(0.0)
+        assert result["rwa"] == pytest.approx(0.0)
 
     def test_eu_non_euro_sovereign_domestic_currency_gets_zero_rw(
         self,
@@ -1443,7 +1482,8 @@ class TestArticle114_4EUDomesticCurrency:
         crr_config: CalculationConfig,
     ) -> None:
         """Polish sovereign + PLN + CQS 3 → 0% RW (non-euro EU domestic currency)."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="CENTRAL_GOVT_CENTRAL_BANK",
             cqs=3,
@@ -1452,8 +1492,8 @@ class TestArticle114_4EUDomesticCurrency:
             config=crr_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("0.0"))
-        assert result["rwa"] == pytest.approx(Decimal("0.0"))
+        assert result["risk_weight"] == pytest.approx(0.0)
+        assert result["rwa"] == pytest.approx(0.0)
 
     def test_eu_non_euro_sovereign_eur_uses_cqs_based_rw(
         self,
@@ -1461,7 +1501,8 @@ class TestArticle114_4EUDomesticCurrency:
         crr_config: CalculationConfig,
     ) -> None:
         """Polish sovereign + EUR → CQS-based RW (EUR is not Poland's domestic currency)."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="CENTRAL_GOVT_CENTRAL_BANK",
             cqs=3,
@@ -1470,7 +1511,7 @@ class TestArticle114_4EUDomesticCurrency:
             config=crr_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("0.50"))
+        assert result["risk_weight"] == pytest.approx(0.50)
 
     def test_eu_sovereign_usd_uses_cqs_based_rw(
         self,
@@ -1478,7 +1519,8 @@ class TestArticle114_4EUDomesticCurrency:
         crr_config: CalculationConfig,
     ) -> None:
         """German sovereign + USD + CQS 2 → 20% RW (foreign currency, no override)."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="CENTRAL_GOVT_CENTRAL_BANK",
             cqs=2,
@@ -1487,8 +1529,8 @@ class TestArticle114_4EUDomesticCurrency:
             config=crr_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("0.20"))
-        assert result["rwa"] == pytest.approx(Decimal("200000"))
+        assert result["risk_weight"] == pytest.approx(0.20)
+        assert result["rwa"] == pytest.approx(200000)
 
     def test_non_eu_sovereign_eur_uses_cqs_based_rw(
         self,
@@ -1496,7 +1538,8 @@ class TestArticle114_4EUDomesticCurrency:
         crr_config: CalculationConfig,
     ) -> None:
         """Non-EU sovereign (US) + EUR → CQS-based RW (not EU, no override)."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="CENTRAL_GOVT_CENTRAL_BANK",
             cqs=2,
@@ -1505,7 +1548,7 @@ class TestArticle114_4EUDomesticCurrency:
             config=crr_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("0.20"))
+        assert result["risk_weight"] == pytest.approx(0.20)
 
     def test_eu_sovereign_eur_basel31_gets_zero_rw(
         self,
@@ -1513,7 +1556,8 @@ class TestArticle114_4EUDomesticCurrency:
         basel31_config: CalculationConfig,
     ) -> None:
         """Art. 114(4) also applies under Basel 3.1 — EU sovereign + EUR → 0%."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="CENTRAL_GOVT_CENTRAL_BANK",
             cqs=3,
@@ -1522,8 +1566,8 @@ class TestArticle114_4EUDomesticCurrency:
             config=basel31_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("0.0"))
-        assert result["rwa"] == pytest.approx(Decimal("0.0"))
+        assert result["risk_weight"] == pytest.approx(0.0)
+        assert result["rwa"] == pytest.approx(0.0)
 
     def test_eu_corporate_eur_no_override(
         self,
@@ -1531,7 +1575,8 @@ class TestArticle114_4EUDomesticCurrency:
         crr_config: CalculationConfig,
     ) -> None:
         """Corporate + DE + EUR → CQS-based RW (Art. 114(4) only applies to CGCB)."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="CORPORATE",
             cqs=2,
@@ -1540,7 +1585,7 @@ class TestArticle114_4EUDomesticCurrency:
             config=crr_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("0.50"))
+        assert result["risk_weight"] == pytest.approx(0.50)
 
     def test_eu_sovereign_cqs6_domestic_gets_zero_rw(
         self,
@@ -1548,7 +1593,8 @@ class TestArticle114_4EUDomesticCurrency:
         crr_config: CalculationConfig,
     ) -> None:
         """Even CQS 6 (150%) gets overridden to 0% for EU domestic sovereign."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="CENTRAL_GOVT_CENTRAL_BANK",
             cqs=6,
@@ -1557,8 +1603,8 @@ class TestArticle114_4EUDomesticCurrency:
             config=crr_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("0.0"))
-        assert result["rwa"] == pytest.approx(Decimal("0.0"))
+        assert result["risk_weight"] == pytest.approx(0.0)
+        assert result["rwa"] == pytest.approx(0.0)
 
     def test_sweden_sek_gets_zero_rw(
         self,
@@ -1566,7 +1612,8 @@ class TestArticle114_4EUDomesticCurrency:
         crr_config: CalculationConfig,
     ) -> None:
         """Swedish sovereign + SEK → 0% RW (non-euro EU domestic currency)."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="CENTRAL_GOVT_CENTRAL_BANK",
             cqs=2,
@@ -1575,5 +1622,5 @@ class TestArticle114_4EUDomesticCurrency:
             config=crr_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("0.0"))
-        assert result["rwa"] == pytest.approx(Decimal("0.0"))
+        assert result["risk_weight"] == pytest.approx(0.0)
+        assert result["rwa"] == pytest.approx(0.0)

--- a/tests/unit/crr/test_crr_slotting.py
+++ b/tests/unit/crr/test_crr_slotting.py
@@ -20,6 +20,7 @@ from decimal import Decimal
 
 import polars as pl
 import pytest
+from tests.fixtures.single_exposure import calculate_single_slotting_exposure
 
 from rwa_calc.contracts.bundles import CRMAdjustedBundle, SlottingResultBundle
 from rwa_calc.contracts.config import CalculationConfig
@@ -76,7 +77,8 @@ class TestCRRSlottingRiskWeights:
         crr_config: CalculationConfig,
     ):
         """Strong category gets 70% RW under CRR (>=2.5yr, non-HVCRE)."""
-        result = slotting_calculator.calculate_single_exposure(
+        result = calculate_single_slotting_exposure(
+            slotting_calculator,
             ead=Decimal("10000000"),
             category="strong",
             is_hvcre=False,
@@ -90,7 +92,8 @@ class TestCRRSlottingRiskWeights:
         crr_config: CalculationConfig,
     ):
         """Good category gets 90% RW under CRR (>=2.5yr, non-HVCRE)."""
-        result = slotting_calculator.calculate_single_exposure(
+        result = calculate_single_slotting_exposure(
+            slotting_calculator,
             ead=Decimal("10000000"),
             category="good",
             is_hvcre=False,
@@ -104,7 +107,8 @@ class TestCRRSlottingRiskWeights:
         crr_config: CalculationConfig,
     ):
         """Satisfactory category gets 115% RW."""
-        result = slotting_calculator.calculate_single_exposure(
+        result = calculate_single_slotting_exposure(
+            slotting_calculator,
             ead=Decimal("5000000"),
             category="satisfactory",
             is_hvcre=False,
@@ -118,7 +122,8 @@ class TestCRRSlottingRiskWeights:
         crr_config: CalculationConfig,
     ):
         """Weak category gets 250% RW (punitive weight)."""
-        result = slotting_calculator.calculate_single_exposure(
+        result = calculate_single_slotting_exposure(
+            slotting_calculator,
             ead=Decimal("5000000"),
             category="weak",
             is_hvcre=False,
@@ -132,7 +137,8 @@ class TestCRRSlottingRiskWeights:
         crr_config: CalculationConfig,
     ):
         """Default category gets 0% RW (100% provisioned)."""
-        result = slotting_calculator.calculate_single_exposure(
+        result = calculate_single_slotting_exposure(
+            slotting_calculator,
             ead=Decimal("1000000"),
             category="default",
             is_hvcre=False,
@@ -155,7 +161,8 @@ class TestCRRShortMaturityWeights:
         crr_config: CalculationConfig,
     ):
         """Strong gets 50% RW for <2.5yr maturity (vs 70% for >=2.5yr)."""
-        result = slotting_calculator.calculate_single_exposure(
+        result = calculate_single_slotting_exposure(
+            slotting_calculator,
             ead=Decimal("10000000"),
             category="strong",
             is_hvcre=False,
@@ -170,7 +177,8 @@ class TestCRRShortMaturityWeights:
         crr_config: CalculationConfig,
     ):
         """Good gets 70% RW for <2.5yr maturity (vs 90% for >=2.5yr)."""
-        result = slotting_calculator.calculate_single_exposure(
+        result = calculate_single_slotting_exposure(
+            slotting_calculator,
             ead=Decimal("10000000"),
             category="good",
             is_hvcre=False,
@@ -185,7 +193,8 @@ class TestCRRShortMaturityWeights:
         crr_config: CalculationConfig,
     ):
         """Satisfactory is 115% regardless of maturity."""
-        result = slotting_calculator.calculate_single_exposure(
+        result = calculate_single_slotting_exposure(
+            slotting_calculator,
             ead=Decimal("5000000"),
             category="satisfactory",
             is_hvcre=False,
@@ -200,7 +209,8 @@ class TestCRRShortMaturityWeights:
         crr_config: CalculationConfig,
     ):
         """Weak is 250% regardless of maturity."""
-        result = slotting_calculator.calculate_single_exposure(
+        result = calculate_single_slotting_exposure(
+            slotting_calculator,
             ead=Decimal("5000000"),
             category="weak",
             is_hvcre=False,
@@ -224,7 +234,8 @@ class TestCRRHVCREWeights:
         crr_config: CalculationConfig,
     ):
         """HVCRE Strong = 95% (>=2.5yr), higher than non-HVCRE 70%."""
-        result = slotting_calculator.calculate_single_exposure(
+        result = calculate_single_slotting_exposure(
+            slotting_calculator,
             ead=Decimal("5000000"),
             category="strong",
             is_hvcre=True,
@@ -238,7 +249,8 @@ class TestCRRHVCREWeights:
         crr_config: CalculationConfig,
     ):
         """HVCRE Good = 120% (>=2.5yr), higher than non-HVCRE 90%."""
-        result = slotting_calculator.calculate_single_exposure(
+        result = calculate_single_slotting_exposure(
+            slotting_calculator,
             ead=Decimal("5000000"),
             category="good",
             is_hvcre=True,
@@ -252,7 +264,8 @@ class TestCRRHVCREWeights:
         crr_config: CalculationConfig,
     ):
         """HVCRE Satisfactory = 140% (>=2.5yr), higher than non-HVCRE 115%."""
-        result = slotting_calculator.calculate_single_exposure(
+        result = calculate_single_slotting_exposure(
+            slotting_calculator,
             ead=Decimal("5000000"),
             category="satisfactory",
             is_hvcre=True,
@@ -266,13 +279,15 @@ class TestCRRHVCREWeights:
         crr_config: CalculationConfig,
     ):
         """HVCRE Weak = 250%, same as non-HVCRE Weak."""
-        hvcre_result = slotting_calculator.calculate_single_exposure(
+        hvcre_result = calculate_single_slotting_exposure(
+            slotting_calculator,
             ead=Decimal("5000000"),
             category="weak",
             is_hvcre=True,
             config=crr_config,
         )
-        non_hvcre_result = slotting_calculator.calculate_single_exposure(
+        non_hvcre_result = calculate_single_slotting_exposure(
+            slotting_calculator,
             ead=Decimal("5000000"),
             category="weak",
             is_hvcre=False,
@@ -287,7 +302,8 @@ class TestCRRHVCREWeights:
         crr_config: CalculationConfig,
     ):
         """HVCRE Strong <2.5yr = 70%."""
-        result = slotting_calculator.calculate_single_exposure(
+        result = calculate_single_slotting_exposure(
+            slotting_calculator,
             ead=Decimal("5000000"),
             category="strong",
             is_hvcre=True,
@@ -302,7 +318,8 @@ class TestCRRHVCREWeights:
         crr_config: CalculationConfig,
     ):
         """HVCRE Good <2.5yr = 95%."""
-        result = slotting_calculator.calculate_single_exposure(
+        result = calculate_single_slotting_exposure(
+            slotting_calculator,
             ead=Decimal("5000000"),
             category="good",
             is_hvcre=True,
@@ -327,7 +344,8 @@ class TestSlottingRWACalculation:
     ):
         """RWA = EAD x RW."""
         ead = Decimal("10000000")
-        result = slotting_calculator.calculate_single_exposure(
+        result = calculate_single_slotting_exposure(
+            slotting_calculator,
             ead=ead,
             category="strong",
             is_hvcre=False,
@@ -342,7 +360,8 @@ class TestSlottingRWACalculation:
         crr_config: CalculationConfig,
     ):
         """CRR-E1: Project Finance Strong - 10m at 70% = 7m RWA."""
-        result = slotting_calculator.calculate_single_exposure(
+        result = calculate_single_slotting_exposure(
+            slotting_calculator,
             ead=Decimal("10000000"),
             category="strong",
             is_hvcre=False,
@@ -358,7 +377,8 @@ class TestSlottingRWACalculation:
         crr_config: CalculationConfig,
     ):
         """CRR-E2: Project Finance Good - 10m at 90% = 9m RWA."""
-        result = slotting_calculator.calculate_single_exposure(
+        result = calculate_single_slotting_exposure(
+            slotting_calculator,
             ead=Decimal("10000000"),
             category="good",
             is_hvcre=False,
@@ -374,7 +394,8 @@ class TestSlottingRWACalculation:
         crr_config: CalculationConfig,
     ):
         """CRR-E3: IPRE Weak - 5m at 250% = 12.5m RWA."""
-        result = slotting_calculator.calculate_single_exposure(
+        result = calculate_single_slotting_exposure(
+            slotting_calculator,
             ead=Decimal("5000000"),
             category="weak",
             is_hvcre=False,
@@ -390,7 +411,8 @@ class TestSlottingRWACalculation:
         crr_config: CalculationConfig,
     ):
         """CRR-E4: HVCRE Strong - 5m at 95% = 4.75m RWA."""
-        result = slotting_calculator.calculate_single_exposure(
+        result = calculate_single_slotting_exposure(
+            slotting_calculator,
             ead=Decimal("5000000"),
             category="strong",
             is_hvcre=True,
@@ -532,13 +554,15 @@ class TestCRRVsBasel31:
         basel31_config: CalculationConfig,
     ):
         """CRR Strong = 70%, Basel 3.1 Strong = 70% (non-HVCRE operational)."""
-        crr_result = slotting_calculator.calculate_single_exposure(
+        crr_result = calculate_single_slotting_exposure(
+            slotting_calculator,
             ead=Decimal("10000000"),
             category="strong",
             is_hvcre=False,
             config=crr_config,
         )
-        basel31_result = slotting_calculator.calculate_single_exposure(
+        basel31_result = calculate_single_slotting_exposure(
+            slotting_calculator,
             ead=Decimal("10000000"),
             category="strong",
             is_hvcre=False,
@@ -554,13 +578,15 @@ class TestCRRVsBasel31:
         basel31_config: CalculationConfig,
     ):
         """CRR Weak = 250%, Basel 3.1 Weak = 250% (non-HVCRE operational)."""
-        crr_result = slotting_calculator.calculate_single_exposure(
+        crr_result = calculate_single_slotting_exposure(
+            slotting_calculator,
             ead=Decimal("5000000"),
             category="weak",
             is_hvcre=False,
             config=crr_config,
         )
-        basel31_result = slotting_calculator.calculate_single_exposure(
+        basel31_result = calculate_single_slotting_exposure(
+            slotting_calculator,
             ead=Decimal("5000000"),
             category="weak",
             is_hvcre=False,
@@ -575,13 +601,15 @@ class TestCRRVsBasel31:
         basel31_config: CalculationConfig,
     ):
         """Basel 3.1 has higher HVCRE weights than non-HVCRE."""
-        hvcre_result = slotting_calculator.calculate_single_exposure(
+        hvcre_result = calculate_single_slotting_exposure(
+            slotting_calculator,
             ead=Decimal("10000000"),
             category="good",
             is_hvcre=True,
             config=basel31_config,
         )
-        non_hvcre_result = slotting_calculator.calculate_single_exposure(
+        non_hvcre_result = calculate_single_slotting_exposure(
+            slotting_calculator,
             ead=Decimal("10000000"),
             category="good",
             is_hvcre=False,
@@ -598,7 +626,8 @@ class TestCRRVsBasel31:
         basel31_config: CalculationConfig,
     ):
         """Basel 3.1 PF pre-operational Strong = 80% vs operational 70%."""
-        pre_op_result = slotting_calculator.calculate_single_exposure(
+        pre_op_result = calculate_single_slotting_exposure(
+            slotting_calculator,
             ead=Decimal("10000000"),
             category="strong",
             is_hvcre=False,
@@ -606,7 +635,8 @@ class TestCRRVsBasel31:
             sl_type="project_finance",
             config=basel31_config,
         )
-        operational_result = slotting_calculator.calculate_single_exposure(
+        operational_result = calculate_single_slotting_exposure(
+            slotting_calculator,
             ead=Decimal("10000000"),
             category="strong",
             is_hvcre=False,
@@ -700,7 +730,8 @@ class TestSpecialisedLendingTypes:
         expected_rw: float,
     ):
         """All specialised lending types can be processed with correct weights."""
-        result = slotting_calculator.calculate_single_exposure(
+        result = calculate_single_slotting_exposure(
+            slotting_calculator,
             ead=Decimal("5000000"),
             category="good",
             is_hvcre=is_hvcre,
@@ -766,7 +797,8 @@ class TestSlottingEdgeCases:
         crr_config: CalculationConfig,
     ):
         """Zero EAD produces zero RWA."""
-        result = slotting_calculator.calculate_single_exposure(
+        result = calculate_single_slotting_exposure(
+            slotting_calculator,
             ead=Decimal("0"),
             category="strong",
             is_hvcre=False,

--- a/tests/unit/test_b31_sa_risk_weights.py
+++ b/tests/unit/test_b31_sa_risk_weights.py
@@ -38,6 +38,7 @@ from decimal import Decimal
 
 import polars as pl
 import pytest
+from tests.fixtures.single_exposure import calculate_single_sa_exposure
 
 from rwa_calc.contracts.bundles import CRMAdjustedBundle
 from rwa_calc.contracts.config import CalculationConfig
@@ -145,7 +146,8 @@ class TestB31ResidentialGeneral:
         expected_rw: float,
     ) -> None:
         """Loan-splitting produces correct weighted-average RW per Art. 124F."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("500000"),
             exposure_class="RESIDENTIAL_MORTGAGE",
             ltv=ltv,
@@ -160,7 +162,8 @@ class TestB31ResidentialGeneral:
         b31_config: CalculationConfig,
     ) -> None:
         """Null LTV defaults to 1.0: secured_share = 55%, residual = 45%."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("500000"),
             exposure_class="RESIDENTIAL_MORTGAGE",
             ltv=None,
@@ -180,7 +183,8 @@ class TestB31ResidentialGeneral:
         """RWA = EAD × RW for a Basel 3.1 residential mortgage."""
         ltv = 0.65
         expected_rw = _expected_loan_split_rw(ltv)
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("400000"),
             exposure_class="RESIDENTIAL_MORTGAGE",
             ltv=Decimal("0.65"),
@@ -234,7 +238,8 @@ class TestB31ResidentialIncomeProducing:
         expected_rw: Decimal,
     ) -> None:
         """Income-producing residential RE uses higher risk weight table."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("500000"),
             exposure_class="RESIDENTIAL_MORTGAGE",
             ltv=ltv,
@@ -242,7 +247,7 @@ class TestB31ResidentialIncomeProducing:
             config=b31_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(expected_rw)
+        assert float(result["risk_weight"]) == pytest.approx(float(expected_rw))
 
 
 # =============================================================================
@@ -465,15 +470,16 @@ class TestB31ADCExposures:
         b31_config: CalculationConfig,
     ) -> None:
         """ADC exposure should get 150% RW."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("2000000"),
             exposure_class="CORPORATE",
             is_adc=True,
             config=b31_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("1.50"))
-        assert result["rwa"] == pytest.approx(Decimal("3000000"))  # 2m × 150%
+        assert result["risk_weight"] == pytest.approx(1.50)
+        assert result["rwa"] == pytest.approx(3000000)  # 2m × 150%
 
     def test_adc_presold_100pct(
         self,
@@ -481,7 +487,8 @@ class TestB31ADCExposures:
         b31_config: CalculationConfig,
     ) -> None:
         """Pre-sold ADC exposure should get 100% RW."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("2000000"),
             exposure_class="CORPORATE",
             is_adc=True,
@@ -489,8 +496,8 @@ class TestB31ADCExposures:
             config=b31_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("1.00"))
-        assert result["rwa"] == pytest.approx(Decimal("2000000"))  # 2m × 100%
+        assert result["risk_weight"] == pytest.approx(1.00)
+        assert result["rwa"] == pytest.approx(2000000)  # 2m × 100%
 
     def test_adc_takes_priority_over_re(
         self,
@@ -498,7 +505,8 @@ class TestB31ADCExposures:
         b31_config: CalculationConfig,
     ) -> None:
         """ADC flag should override RE LTV-band treatment."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="RESIDENTIAL_MORTGAGE",
             ltv=Decimal("0.50"),  # Would be 20% under B31 LTV bands
@@ -507,7 +515,7 @@ class TestB31ADCExposures:
         )
 
         # ADC overrides: 150%, not 20%
-        assert result["risk_weight"] == pytest.approx(Decimal("1.50"))
+        assert result["risk_weight"] == pytest.approx(1.50)
 
     def test_adc_not_applied_under_crr(
         self,
@@ -515,7 +523,8 @@ class TestB31ADCExposures:
         crr_config: CalculationConfig,
     ) -> None:
         """ADC flag should be ignored under CRR (no ADC treatment in CRR SA)."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="CORPORATE",
             cqs=None,
@@ -524,7 +533,7 @@ class TestB31ADCExposures:
         )
 
         # Under CRR, no ADC treatment → standard corporate unrated 100%
-        assert result["risk_weight"] == pytest.approx(Decimal("1.0"))
+        assert result["risk_weight"] == pytest.approx(1.0)
 
 
 # =============================================================================
@@ -604,14 +613,15 @@ class TestCRRRegression:
         crr_config: CalculationConfig,
     ) -> None:
         """CRR residential mortgage LTV ≤ 80% → 35% (unchanged)."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("500000"),
             exposure_class="RESIDENTIAL_MORTGAGE",
             ltv=Decimal("0.60"),
             config=crr_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("0.35"))
+        assert result["risk_weight"] == pytest.approx(0.35)
 
     def test_crr_residential_high_ltv_split(
         self,
@@ -619,7 +629,8 @@ class TestCRRRegression:
         crr_config: CalculationConfig,
     ) -> None:
         """CRR residential mortgage LTV 100% → split treatment (unchanged)."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("500000"),
             exposure_class="RESIDENTIAL_MORTGAGE",
             ltv=Decimal("1.00"),
@@ -665,14 +676,15 @@ class TestCRRRegression:
         crr_config: CalculationConfig,
     ) -> None:
         """CRR sovereign CQS 1 → 0% (unchanged)."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="CENTRAL_GOVT_CENTRAL_BANK",
             cqs=1,
             config=crr_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("0.0"))
+        assert result["risk_weight"] == pytest.approx(0.0)
 
     def test_crr_retail_still_works(
         self,
@@ -680,13 +692,14 @@ class TestCRRRegression:
         crr_config: CalculationConfig,
     ) -> None:
         """CRR retail → 75% (unchanged)."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("100000"),
             exposure_class="RETAIL",
             config=crr_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("0.75"))
+        assert result["risk_weight"] == pytest.approx(0.75)
 
     def test_crr_institution_uk_deviation_still_works(
         self,
@@ -694,14 +707,15 @@ class TestCRRRegression:
         crr_config: CalculationConfig,
     ) -> None:
         """CRR institution CQS 2 UK deviation → 30% (unchanged)."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="INSTITUTION",
             cqs=2,
             config=crr_config,
         )
 
-        assert result["risk_weight"] == pytest.approx(Decimal("0.30"))
+        assert result["risk_weight"] == pytest.approx(0.30)
 
 
 # =============================================================================
@@ -719,14 +733,16 @@ class TestCRRvsBasel31Comparison:
         b31_config: CalculationConfig,
     ) -> None:
         """At 50% LTV, Basel 3.1 (20%) is lower than CRR (35%)."""
-        crr_result = sa_calculator.calculate_single_exposure(
+        crr_result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("400000"),
             exposure_class="RESIDENTIAL_MORTGAGE",
             ltv=Decimal("0.50"),
             config=crr_config,
         )
 
-        b31_result = sa_calculator.calculate_single_exposure(
+        b31_result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("400000"),
             exposure_class="RESIDENTIAL_MORTGAGE",
             ltv=Decimal("0.50"),
@@ -744,14 +760,16 @@ class TestCRRvsBasel31Comparison:
         b31_config: CalculationConfig,
     ) -> None:
         """At 110% LTV, Basel 3.1 loan-split is higher than CRR split (~46%)."""
-        crr_result = sa_calculator.calculate_single_exposure(
+        crr_result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("400000"),
             exposure_class="RESIDENTIAL_MORTGAGE",
             ltv=Decimal("1.10"),
             config=crr_config,
         )
 
-        b31_result = sa_calculator.calculate_single_exposure(
+        b31_result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("400000"),
             exposure_class="RESIDENTIAL_MORTGAGE",
             ltv=Decimal("1.10"),
@@ -770,7 +788,8 @@ class TestCRRvsBasel31Comparison:
         b31_config: CalculationConfig,
     ) -> None:
         """SME supporting factor should be 1.0 under Basel 3.1."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="CORPORATE",
             cqs=None,
@@ -778,8 +797,8 @@ class TestCRRvsBasel31Comparison:
             config=b31_config,
         )
 
-        assert result["supporting_factor"] == pytest.approx(Decimal("1.0"))
-        assert result["rwa"] == pytest.approx(Decimal("1000000"))
+        assert result["supporting_factor"] == pytest.approx(1.0)
+        assert result["rwa"] == pytest.approx(1000000)
 
 
 # =============================================================================
@@ -904,13 +923,15 @@ class TestB31CorporateCQS:
         expected_crr_rw: float,
     ) -> None:
         """Corporate CQS risk weights differ between CRR and Basel 3.1."""
-        b31_result = sa_calculator.calculate_single_exposure(
+        b31_result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="corporate",
             cqs=cqs,
             config=b31_config,
         )
-        crr_result = sa_calculator.calculate_single_exposure(
+        crr_result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="corporate",
             cqs=cqs,
@@ -928,13 +949,15 @@ class TestB31CorporateCQS:
     ) -> None:
         """CQS 3 corporate: Basel 3.1 RWA should be 25% lower than CRR."""
         ead = Decimal("1000000")
-        b31 = sa_calculator.calculate_single_exposure(
+        b31 = calculate_single_sa_exposure(
+            sa_calculator,
             ead=ead,
             exposure_class="corporate",
             cqs=3,
             config=b31_config,
         )
-        crr = sa_calculator.calculate_single_exposure(
+        crr = calculate_single_sa_exposure(
+            sa_calculator,
             ead=ead,
             exposure_class="corporate",
             cqs=3,
@@ -985,7 +1008,8 @@ class TestB31SCRAInstitutionWeights:
         expected_rw: float,
     ) -> None:
         """Unrated institution risk weight determined by SCRA grade under Basel 3.1."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("5000000"),
             exposure_class="institution",
             cqs=None,
@@ -1001,7 +1025,8 @@ class TestB31SCRAInstitutionWeights:
         b31_config: CalculationConfig,
     ) -> None:
         """Rated institutions use ECRA (CQS-based), not SCRA, even if grade provided."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("5000000"),
             exposure_class="institution",
             cqs=2,  # CQS 2 → 30% (UK deviation)
@@ -1018,7 +1043,8 @@ class TestB31SCRAInstitutionWeights:
         crr_config: CalculationConfig,
     ) -> None:
         """SCRA should be ignored under CRR — unrated institutions get 40%."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("5000000"),
             exposure_class="institution",
             cqs=None,
@@ -1035,7 +1061,8 @@ class TestB31SCRAInstitutionWeights:
         b31_config: CalculationConfig,
     ) -> None:
         """Unrated institution without SCRA grade uses CQS table default under Basel 3.1."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("5000000"),
             exposure_class="institution",
             cqs=None,
@@ -1052,7 +1079,8 @@ class TestB31SCRAInstitutionWeights:
         b31_config: CalculationConfig,
     ) -> None:
         """Grade B institution: verify full RWA calculation."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("10000000"),
             exposure_class="institution",
             cqs=None,
@@ -1087,7 +1115,8 @@ class TestB31InvestmentGradeCorporate:
         b31_config: CalculationConfig,
     ) -> None:
         """Investment-grade corporate gets 65% under Basel 3.1."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("2000000"),
             exposure_class="corporate",
             cqs=None,
@@ -1104,7 +1133,8 @@ class TestB31InvestmentGradeCorporate:
         crr_config: CalculationConfig,
     ) -> None:
         """Investment-grade treatment does not exist under CRR → 100%."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("2000000"),
             exposure_class="corporate",
             cqs=None,
@@ -1121,7 +1151,8 @@ class TestB31InvestmentGradeCorporate:
         b31_config: CalculationConfig,
     ) -> None:
         """Investment-grade flag should not apply to corporate_sme class."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("2000000"),
             exposure_class="corporate_sme",
             cqs=None,
@@ -1138,7 +1169,8 @@ class TestB31InvestmentGradeCorporate:
         b31_config: CalculationConfig,
     ) -> None:
         """Rated corporate uses CQS-based weight, not investment-grade override."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("2000000"),
             exposure_class="corporate",
             cqs=1,
@@ -1172,7 +1204,8 @@ class TestB31SMECorporate:
         b31_config: CalculationConfig,
     ) -> None:
         """SME corporate gets 85% under Basel 3.1."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("500000"),
             exposure_class="corporate_sme",
             cqs=None,
@@ -1188,7 +1221,8 @@ class TestB31SMECorporate:
         crr_config: CalculationConfig,
     ) -> None:
         """SME corporate gets 100% under CRR (no preferential treatment)."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("500000"),
             exposure_class="corporate_sme",
             cqs=None,
@@ -1203,7 +1237,8 @@ class TestB31SMECorporate:
         b31_config: CalculationConfig,
     ) -> None:
         """SME managed as retail keeps 75% when under EUR 1m threshold."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("500000"),
             exposure_class="corporate_sme",
             cqs=None,
@@ -1221,7 +1256,8 @@ class TestB31SMECorporate:
         b31_config: CalculationConfig,
     ) -> None:
         """SME managed as retail but over EUR 1m threshold gets standard SME RW."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1500000"),
             exposure_class="corporate_sme",
             cqs=None,
@@ -1261,7 +1297,8 @@ class TestB31SubordinatedDebt:
         b31_config: CalculationConfig,
     ) -> None:
         """Subordinated corporate debt gets flat 150% under Basel 3.1."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="corporate",
             cqs=1,  # CQS 1 would normally be 20%
@@ -1278,7 +1315,8 @@ class TestB31SubordinatedDebt:
         b31_config: CalculationConfig,
     ) -> None:
         """Subordinated institution debt gets flat 150% under Basel 3.1."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("5000000"),
             exposure_class="institution",
             cqs=2,  # CQS 2 would normally be 30% (UK)
@@ -1296,7 +1334,8 @@ class TestB31SubordinatedDebt:
         crr_config: CalculationConfig,
     ) -> None:
         """Subordinated debt uses normal CQS table under CRR (no override)."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="corporate",
             cqs=1,
@@ -1313,7 +1352,8 @@ class TestB31SubordinatedDebt:
         b31_config: CalculationConfig,
     ) -> None:
         """Senior debt uses normal CQS-based weight under Basel 3.1."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="corporate",
             cqs=1,
@@ -1330,7 +1370,8 @@ class TestB31SubordinatedDebt:
         b31_config: CalculationConfig,
     ) -> None:
         """Subordinated debt 150% takes priority over investment-grade 65%."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="corporate",
             cqs=None,
@@ -1348,7 +1389,8 @@ class TestB31SubordinatedDebt:
         b31_config: CalculationConfig,
     ) -> None:
         """Subordinated debt override only applies to institution + corporate."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="central_govt_central_bank",
             cqs=1,
@@ -1365,7 +1407,8 @@ class TestB31SubordinatedDebt:
         b31_config: CalculationConfig,
     ) -> None:
         """Subordinated SME corporate debt gets flat 150% (not 85%)."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("500000"),
             exposure_class="corporate_sme",
             cqs=None,
@@ -1404,7 +1447,8 @@ class TestCurrencyMismatchMultiplier:
         b31_config: CalculationConfig,
     ) -> None:
         """Retail exposure with currency mismatch gets 75% * 1.5 = 112.5% RW."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("100000"),
             exposure_class="retail_other",
             currency="EUR",
@@ -1419,7 +1463,8 @@ class TestCurrencyMismatchMultiplier:
         b31_config: CalculationConfig,
     ) -> None:
         """Retail exposure in same currency as income — no multiplier."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("100000"),
             exposure_class="retail_other",
             currency="GBP",
@@ -1434,7 +1479,8 @@ class TestCurrencyMismatchMultiplier:
         b31_config: CalculationConfig,
     ) -> None:
         """Residential mortgage with mismatch gets LTV-band RW * 1.5."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("200000"),
             exposure_class="retail_mortgage",
             ltv=Decimal("0.60"),
@@ -1455,7 +1501,8 @@ class TestCurrencyMismatchMultiplier:
         b31_config: CalculationConfig,
     ) -> None:
         """Commercial RE with currency mismatch gets 1.5x multiplier."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("500000"),
             exposure_class="secured_by_re_commercial",
             ltv=Decimal("0.55"),
@@ -1473,7 +1520,8 @@ class TestCurrencyMismatchMultiplier:
         b31_config: CalculationConfig,
     ) -> None:
         """Corporate exposure is NOT subject to currency mismatch multiplier."""
-        result_mismatch = sa_calculator.calculate_single_exposure(
+        result_mismatch = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="corporate",
             cqs=3,
@@ -1481,7 +1529,8 @@ class TestCurrencyMismatchMultiplier:
             borrower_income_currency="GBP",
             config=b31_config,
         )
-        result_no_mismatch = sa_calculator.calculate_single_exposure(
+        result_no_mismatch = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="corporate",
             cqs=3,
@@ -1499,7 +1548,8 @@ class TestCurrencyMismatchMultiplier:
         crr_config: CalculationConfig,
     ) -> None:
         """CRR framework does not apply currency mismatch multiplier."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("100000"),
             exposure_class="retail_other",
             currency="EUR",
@@ -1515,7 +1565,8 @@ class TestCurrencyMismatchMultiplier:
         b31_config: CalculationConfig,
     ) -> None:
         """When borrower income currency is null, no multiplier is applied."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("100000"),
             exposure_class="retail_other",
             currency="EUR",
@@ -1530,7 +1581,8 @@ class TestCurrencyMismatchMultiplier:
         b31_config: CalculationConfig,
     ) -> None:
         """Institution exposure is NOT subject to currency mismatch multiplier."""
-        result = sa_calculator.calculate_single_exposure(
+        result = calculate_single_sa_exposure(
+            sa_calculator,
             ead=Decimal("1000000"),
             exposure_class="institution",
             cqs=1,

--- a/tests/unit/test_basel31_engine.py
+++ b/tests/unit/test_basel31_engine.py
@@ -25,6 +25,7 @@ from decimal import Decimal
 
 import polars as pl
 import pytest
+from tests.fixtures.single_exposure import calculate_single_equity_exposure
 
 import rwa_calc.engine.irb.namespace  # noqa: F401 - register namespace
 from rwa_calc.contracts.config import CalculationConfig, IRBPermissions
@@ -1503,13 +1504,14 @@ class TestEquityBasel31:
         assert approach == "sa"
 
     def test_single_exposure_crr_irb_uses_irb_rw(self) -> None:
-        """CRR: calculate_single_exposure with IRB uses 370% for other."""
+        """CRR: calculate_single_equity_exposure with IRB uses 370% for other."""
         config = CalculationConfig.crr(
             reporting_date=date(2024, 12, 31),
             irb_permissions=IRBPermissions.full_irb(),
         )
         calculator = EquityCalculator()
-        result = calculator.calculate_single_exposure(
+        result = calculate_single_equity_exposure(
+            calculator,
             ead=Decimal("1000000"),
             equity_type="other",
             config=config,
@@ -1518,13 +1520,14 @@ class TestEquityBasel31:
         assert result["risk_weight"] == pytest.approx(3.70)
 
     def test_single_exposure_basel31_uses_sa_rw(self) -> None:
-        """Basel 3.1: calculate_single_exposure with IRB perm uses SA 250%."""
+        """Basel 3.1: calculate_single_equity_exposure with IRB perm uses SA 250%."""
         config = CalculationConfig.basel_3_1(
             reporting_date=date(2028, 1, 1),
             irb_permissions=IRBPermissions.full_irb(),
         )
         calculator = EquityCalculator()
-        result = calculator.calculate_single_exposure(
+        result = calculate_single_equity_exposure(
+            calculator,
             ead=Decimal("1000000"),
             equity_type="unlisted",
             config=config,
@@ -1539,7 +1542,8 @@ class TestEquityBasel31:
             irb_permissions=IRBPermissions.full_irb(),
         )
         calculator = EquityCalculator()
-        result = calculator.calculate_single_exposure(
+        result = calculate_single_equity_exposure(
+            calculator,
             ead=Decimal("500000"),
             equity_type="listed",
             is_exchange_traded=True,


### PR DESCRIPTION
Remove convenience methods from SA, IRB, Equity, and Slotting calculators
that were only used in tests (180 call sites, 0 production callers).
Replace with thin test helpers in tests/fixtures/single_exposure.py that
build a single-row LazyFrame and call calculate_branch(), exercising the
real pipeline code path.

Key improvements:
- IRB tests now exercise the namespace chain instead of scalar functions
- Equity calculator gains calculate_branch() for consistency
- ~220 lines removed from production code
- Tests validate the actual pipeline, not a parallel implementation

https://claude.ai/code/session_01E7tXTAm1qeA4uzRYqbG3vc