### PR TITLE
refactor: remove unused `calculate` from SlottingCalculator

### DIFF
--- a/docs/api/contracts.md
+++ b/docs/api/contracts.md
@@ -582,14 +582,6 @@ class SlottingCalculatorProtocol(Protocol):
     ) -> pl.LazyFrame:
         """Calculate slotting RWA on pre-filtered slotting-only rows."""
         ...
-
-    def calculate(
-        self,
-        data: CRMAdjustedBundle,
-        config: CalculationConfig,
-    ) -> LazyFrameResult:
-        """Calculate RWA using supervisory slotting approach."""
-        ...
 ```
 
 #### `EquityCalculatorProtocol`

--- a/docs/api/engine.md
+++ b/docs/api/engine.md
@@ -736,22 +736,6 @@ class SlottingCalculator:
     Basel 3.1 (BCBS CRE33): Revised operational, PF pre-op, and HVCRE weights.
     """
 
-    def calculate(
-        self,
-        data: CRMAdjustedBundle,
-        config: CalculationConfig,
-    ) -> LazyFrameResult:
-        """
-        Calculate slotting RWA for all specialised lending exposures.
-
-        Args:
-            data: CRM-adjusted bundle (uses slotting_exposures field).
-            config: Calculation configuration.
-
-        Returns:
-            LazyFrameResult with slotting RWA calculations.
-        """
-
     def get_slotting_result_bundle(
         self,
         data: CRMAdjustedBundle,

--- a/docs/appendix/changelog.md
+++ b/docs/appendix/changelog.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - **Engine**: Remove unused `calculate_unified()` from `SlottingCalculator`, `IRBCalculator`, and their protocols — only SA uses this method (for the output floor). Simplifies the slotting and IRB calculator interfaces.
+- **Engine**: Remove unused `calculate()` from `SlottingCalculator` and its protocol — the pipeline uses `calculate_branch()` directly. Also remove dead `_run_slotting_calculator()` from pipeline.
 
 ### Added
 - **Docs**: Add OF 02.00 and OF 02.01 output floor reporting documentation — master own funds requirements template with new SA-only and output floor columns, dedicated output floor comparison template (U-TREA vs S-TREA), flow diagram showing how IRB output floor columns feed into total capital, Pillar III cross-reference (UKB OV1/KM1)

--- a/src/rwa_calc/contracts/protocols.py
+++ b/src/rwa_calc/contracts/protocols.py
@@ -354,23 +354,6 @@ class SlottingCalculatorProtocol(Protocol):
         """
         ...
 
-    def calculate(
-        self,
-        data: CRMAdjustedBundle,
-        config: CalculationConfig,
-    ) -> LazyFrameResult:
-        """
-        Calculate RWA using supervisory slotting approach.
-
-        Args:
-            data: CRM-adjusted exposures (specialised lending)
-            config: Calculation configuration
-
-        Returns:
-            LazyFrameResult with slotting RWA calculations
-        """
-        ...
-
 
 @runtime_checkable
 class EquityCalculatorProtocol(Protocol):

--- a/src/rwa_calc/engine/pipeline.py
+++ b/src/rwa_calc/engine/pipeline.py
@@ -486,34 +486,7 @@ class PipelineOrchestrator:
             )
             return None
 
-    def _run_slotting_calculator(
-        self,
-        data: CRMAdjustedBundle,
-        config: CalculationConfig,
-    ) -> SlottingResultBundle | None:
-        """Run Slotting calculation stage."""
-        try:
-            result = self._slotting_calculator.get_slotting_result_bundle(data, config)
-            # Accumulate Slotting errors
-            if result.errors:
-                for error in result.errors:
-                    self._errors.append(
-                        PipelineError(
-                            stage="slotting_calculator",
-                            error_type=getattr(error, "error_type", "unknown"),
-                            message=getattr(error, "message", str(error)),
-                        )
-                    )
-            return result
-        except Exception as e:
-            self._errors.append(
-                PipelineError(
-                    stage="slotting_calculator",
-                    error_type="slotting_calculation_error",
-                    message=str(e),
-                )
-            )
-            return None
+
 
     def _run_equity_calculator(
         self,

--- a/src/rwa_calc/engine/slotting/calculator.py
+++ b/src/rwa_calc/engine/slotting/calculator.py
@@ -35,12 +35,6 @@ from typing import TYPE_CHECKING
 import polars as pl
 
 from rwa_calc.contracts.bundles import CRMAdjustedBundle, SlottingResultBundle
-from rwa_calc.contracts.errors import (
-    CalculationError,
-    ErrorCategory,
-    ErrorSeverity,
-    LazyFrameResult,
-)
 
 if TYPE_CHECKING:
     from rwa_calc.contracts.config import CalculationConfig
@@ -65,7 +59,7 @@ class SlottingCalculator:
 
     Usage:
         calculator = SlottingCalculator()
-        result = calculator.calculate(crm_bundle, config)
+        result = calculator.calculate_branch(exposures, config)
     """
 
     def __init__(self) -> None:
@@ -90,39 +84,6 @@ class SlottingCalculator:
             exposures.slotting.prepare_columns(config)
             .slotting.apply_slotting_weights(config)
             .slotting.calculate_rwa()
-        )
-
-    def calculate(
-        self,
-        data: CRMAdjustedBundle,
-        config: CalculationConfig,
-    ) -> LazyFrameResult:
-        """
-        Calculate RWA using supervisory slotting approach.
-
-        Args:
-            data: CRM-adjusted exposures (uses slotting_exposures)
-            config: Calculation configuration
-
-        Returns:
-            LazyFrameResult with slotting RWA calculations
-        """
-        bundle = self.get_slotting_result_bundle(data, config)
-
-        # Convert bundle errors to CalculationErrors
-        calc_errors = [
-            CalculationError(
-                code="SLOTTING001",
-                message=str(err),
-                severity=ErrorSeverity.ERROR,
-                category=ErrorCategory.CALCULATION,
-            )
-            for err in bundle.errors
-        ]
-
-        return LazyFrameResult(
-            frame=bundle.results,
-            errors=calc_errors,
         )
 
     def get_slotting_result_bundle(

--- a/tests/unit/crr/test_crr_slotting.py
+++ b/tests/unit/crr/test_crr_slotting.py
@@ -24,7 +24,6 @@ from tests.fixtures.single_exposure import calculate_single_slotting_exposure
 
 from rwa_calc.contracts.bundles import CRMAdjustedBundle, SlottingResultBundle
 from rwa_calc.contracts.config import CalculationConfig
-from rwa_calc.contracts.errors import LazyFrameResult
 from rwa_calc.engine.slotting import SlottingCalculator, create_slotting_calculator
 
 # =============================================================================
@@ -431,25 +430,24 @@ class TestSlottingRWACalculation:
 class TestSlottingBundleProcessing:
     """Test slotting calculator bundle processing."""
 
-    def test_calculate_returns_lazyframe_result(
+    def test_calculate_branch_returns_lazyframe(
         self,
         slotting_calculator: SlottingCalculator,
         crr_config: CalculationConfig,
     ):
-        """Calculate method returns LazyFrameResult."""
-        bundle = create_slotting_bundle(
-            [
-                {
-                    "exposure_reference": "SL001",
-                    "slotting_category": "strong",
-                    "is_hvcre": False,
-                    "ead": 10_000_000.0,
-                },
-            ]
+        """calculate_branch returns a LazyFrame with results."""
+        exposures = pl.LazyFrame(
+            {
+                "exposure_reference": ["SL001"],
+                "slotting_category": ["strong"],
+                "is_hvcre": [False],
+                "ead": [10_000_000.0],
+            }
         )
-        result = slotting_calculator.calculate(bundle, crr_config)
-        assert isinstance(result, LazyFrameResult)
-        assert result.frame is not None
+        result = slotting_calculator.calculate_branch(exposures, crr_config)
+        assert isinstance(result, pl.LazyFrame)
+        df = result.collect()
+        assert len(df) == 1
 
     def test_multiple_exposures_processed(
         self,
@@ -457,24 +455,15 @@ class TestSlottingBundleProcessing:
         crr_config: CalculationConfig,
     ):
         """Multiple slotting exposures are processed correctly."""
-        bundle = create_slotting_bundle(
-            [
-                {
-                    "exposure_reference": "SL001",
-                    "slotting_category": "strong",
-                    "is_hvcre": False,
-                    "ead": 10_000_000.0,
-                },
-                {
-                    "exposure_reference": "SL002",
-                    "slotting_category": "weak",
-                    "is_hvcre": True,
-                    "ead": 5_000_000.0,
-                },
-            ]
+        exposures = pl.LazyFrame(
+            {
+                "exposure_reference": ["SL001", "SL002"],
+                "slotting_category": ["strong", "weak"],
+                "is_hvcre": [False, True],
+                "ead": [10_000_000.0, 5_000_000.0],
+            }
         )
-        result = slotting_calculator.calculate(bundle, crr_config)
-        df = result.frame.collect()
+        df = slotting_calculator.calculate_branch(exposures, crr_config).collect()
         assert len(df) == 2
 
         # Check first exposure (non-HVCRE Strong = 70%)
@@ -492,15 +481,15 @@ class TestSlottingBundleProcessing:
         slotting_calculator: SlottingCalculator,
         crr_config: CalculationConfig,
     ):
-        """Empty slotting exposures returns empty result."""
+        """None slotting exposures returns empty result via get_slotting_result_bundle."""
         bundle = CRMAdjustedBundle(
             exposures=pl.LazyFrame(),
             sa_exposures=pl.LazyFrame(),
             irb_exposures=pl.LazyFrame(),
             slotting_exposures=None,
         )
-        result = slotting_calculator.calculate(bundle, crr_config)
-        df = result.frame.collect()
+        result = slotting_calculator.get_slotting_result_bundle(bundle, crr_config)
+        df = result.results.collect()
         assert len(df) == 0
 
     def test_get_slotting_result_bundle_returns_bundle(
@@ -757,18 +746,15 @@ class TestSlottingEdgeCases:
         crr_config: CalculationConfig,
     ):
         """Slotting category matching is case-insensitive."""
-        bundle = create_slotting_bundle(
-            [
-                {
-                    "exposure_reference": "SL001",
-                    "slotting_category": "STRONG",
-                    "is_hvcre": False,
-                    "ead": 10_000_000.0,
-                },
-            ]
+        exposures = pl.LazyFrame(
+            {
+                "exposure_reference": ["SL001"],
+                "slotting_category": ["STRONG"],
+                "is_hvcre": [False],
+                "ead": [10_000_000.0],
+            }
         )
-        result = slotting_calculator.calculate(bundle, crr_config)
-        df = result.frame.collect()
+        df = slotting_calculator.calculate_branch(exposures, crr_config).collect()
         assert df["risk_weight"][0] == pytest.approx(0.70)
 
     def test_unknown_category_defaults_to_satisfactory(
@@ -777,18 +763,15 @@ class TestSlottingEdgeCases:
         crr_config: CalculationConfig,
     ):
         """Unknown slotting category defaults to satisfactory (115%)."""
-        bundle = create_slotting_bundle(
-            [
-                {
-                    "exposure_reference": "SL001",
-                    "slotting_category": "unknown_category",
-                    "is_hvcre": False,
-                    "ead": 10_000_000.0,
-                },
-            ]
+        exposures = pl.LazyFrame(
+            {
+                "exposure_reference": ["SL001"],
+                "slotting_category": ["unknown_category"],
+                "is_hvcre": [False],
+                "ead": [10_000_000.0],
+            }
         )
-        result = slotting_calculator.calculate(bundle, crr_config)
-        df = result.frame.collect()
+        df = slotting_calculator.calculate_branch(exposures, crr_config).collect()
         assert df["risk_weight"][0] == pytest.approx(1.15)
 
     def test_zero_ead_produces_zero_rwa(


### PR DESCRIPTION
The pipeline calls `calculate_branch` directly — `calculate()` was a thin wrapper only used by tests. Converts those tests to use `calculate_branch`. Also removes the dead `_run_slotting_calculator` method from the pipeline.

https://claude.ai/code/session_01K6npxeTKfW6XdRB65YyDWs