### PR TITLE
Consolidate slotting risk weights into data/tables

### DIFF
--- a/docs/appendix/changelog.md
+++ b/docs/appendix/changelog.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Data Tables**: Consolidate slotting risk weights — `engine/slotting/namespace.py` now sources all risk weights from `data/tables/` instead of defining them inline, consistent with SA/IRB/Equity engines
+- **Data Tables**: Export all 4 CRR slotting weight dicts and convenience functions from `data/tables/__init__.py` (previously only 2 of 4 were exported)
+
+### Added
+- **Data Tables**: Add `b31_slotting.py` with Basel 3.1 slotting risk weights (base, pre-operational, HVCRE) per BCBS CRE33
+- **Tests**: Add unit tests for Basel 3.1 slotting tables and extend CRR slotting short-maturity test coverage
+
 ### Removed
 - **Engine**: Remove unused `calculate_unified()` from `SlottingCalculator`, `IRBCalculator`, and their protocols — only SA uses this method (for the output floor). Simplifies the slotting and IRB calculator interfaces.
 - **Engine**: Remove unused `calculate()` from `SlottingCalculator` and its protocol — the pipeline uses `calculate_branch()` directly. Also remove dead `_run_slotting_calculator()` from pipeline.

--- a/src/rwa_calc/data/tables/__init__.py
+++ b/src/rwa_calc/data/tables/__init__.py
@@ -9,7 +9,8 @@ Modules:
     crr_risk_weights: SA risk weights by exposure class and CQS
     b31_risk_weights: Basel 3.1 LTV-band SA risk weights for real estate
     crr_haircuts: CRM supervisory haircuts
-    crr_slotting: Specialised lending slotting risk weights
+    crr_slotting: CRR specialised lending slotting risk weights
+    b31_slotting: Basel 3.1 specialised lending slotting risk weights
     crr_firb_lgd: F-IRB supervisory LGD values
     crr_equity_rw: Equity risk weights (Art. 133 SA, Art. 155 IRB Simple)
 """
@@ -28,6 +29,12 @@ from .b31_risk_weights import (
     b31_residential_rw_expr,
     lookup_b31_commercial_rw,
     lookup_b31_residential_rw,
+)
+from .b31_slotting import (
+    B31_SLOTTING_RISK_WEIGHTS,
+    B31_SLOTTING_RISK_WEIGHTS_HVCRE,
+    B31_SLOTTING_RISK_WEIGHTS_PREOP,
+    lookup_b31_slotting_rw,
 )
 from .crr_equity_rw import (
     IRB_SIMPLE_EQUITY_RISK_WEIGHTS,
@@ -62,6 +69,10 @@ from .crr_risk_weights import (
 from .crr_slotting import (
     SLOTTING_RISK_WEIGHTS,
     SLOTTING_RISK_WEIGHTS_HVCRE,
+    SLOTTING_RISK_WEIGHTS_HVCRE_SHORT,
+    SLOTTING_RISK_WEIGHTS_SHORT,
+    calculate_slotting_rwa,
+    lookup_slotting_rw,
 )
 from .eu_sovereign import (
     EU_COUNTRY_DOMESTIC_CURRENCY,
@@ -98,9 +109,18 @@ __all__ = [
     "BASEL31_COLLATERAL_HAIRCUTS",
     "FX_HAIRCUT",
     "get_haircut_table",
-    # Slotting
+    # Slotting — CRR
     "SLOTTING_RISK_WEIGHTS",
+    "SLOTTING_RISK_WEIGHTS_SHORT",
     "SLOTTING_RISK_WEIGHTS_HVCRE",
+    "SLOTTING_RISK_WEIGHTS_HVCRE_SHORT",
+    "lookup_slotting_rw",
+    "calculate_slotting_rwa",
+    # Slotting — Basel 3.1
+    "B31_SLOTTING_RISK_WEIGHTS",
+    "B31_SLOTTING_RISK_WEIGHTS_PREOP",
+    "B31_SLOTTING_RISK_WEIGHTS_HVCRE",
+    "lookup_b31_slotting_rw",
     # F-IRB LGD
     "FIRB_SUPERVISORY_LGD",
     "BASEL31_FIRB_SUPERVISORY_LGD",

--- a/src/rwa_calc/data/tables/b31_slotting.py
+++ b/src/rwa_calc/data/tables/b31_slotting.py
@@ -1,0 +1,89 @@
+"""
+Basel 3.1 Specialised Lending Slotting risk weights (BCBS CRE33).
+
+Provides slotting risk weight constants and scalar lookup functions for the
+Basel 3.1 framework as implemented by PRA PS1/26.
+
+Basel 3.1 defines three weight tables:
+    Table 1 - Non-HVCRE operational specialised lending
+    Table 2 - Project finance pre-operational phase
+    Table 3 - HVCRE
+
+References:
+    BCBS CRE33.5-8: Supervisory slotting criteria for specialised lending
+    PRA PS1/26 Appendix 1: UK implementation
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from rwa_calc.domain.enums import SlottingCategory
+
+# =============================================================================
+# BASEL 3.1 SLOTTING RISK WEIGHTS (BCBS CRE33)
+# =============================================================================
+
+# Non-HVCRE, operational (base table)
+B31_SLOTTING_RISK_WEIGHTS: dict[SlottingCategory, Decimal] = {
+    SlottingCategory.STRONG: Decimal("0.70"),
+    SlottingCategory.GOOD: Decimal("0.90"),
+    SlottingCategory.SATISFACTORY: Decimal("1.15"),
+    SlottingCategory.WEAK: Decimal("2.50"),
+    SlottingCategory.DEFAULT: Decimal("0.00"),
+}
+
+# Project finance pre-operational phase
+B31_SLOTTING_RISK_WEIGHTS_PREOP: dict[SlottingCategory, Decimal] = {
+    SlottingCategory.STRONG: Decimal("0.80"),
+    SlottingCategory.GOOD: Decimal("1.00"),
+    SlottingCategory.SATISFACTORY: Decimal("1.20"),
+    SlottingCategory.WEAK: Decimal("3.50"),
+    SlottingCategory.DEFAULT: Decimal("0.00"),
+}
+
+# HVCRE
+B31_SLOTTING_RISK_WEIGHTS_HVCRE: dict[SlottingCategory, Decimal] = {
+    SlottingCategory.STRONG: Decimal("0.95"),
+    SlottingCategory.GOOD: Decimal("1.20"),
+    SlottingCategory.SATISFACTORY: Decimal("1.40"),
+    SlottingCategory.WEAK: Decimal("2.50"),
+    SlottingCategory.DEFAULT: Decimal("0.00"),
+}
+
+
+def lookup_b31_slotting_rw(
+    category: str | SlottingCategory,
+    is_hvcre: bool = False,
+    is_pre_operational: bool = False,
+) -> Decimal:
+    """
+    Look up Basel 3.1 slotting risk weight.
+
+    Convenience function for single lookups. For bulk processing,
+    use the Polars namespace (``col("slotting_category").slotting.lookup_rw(...)``).
+
+    Args:
+        category: Slotting category (strong, good, satisfactory, weak, default)
+        is_hvcre: Whether this is high-volatility commercial real estate
+        is_pre_operational: Whether this is a pre-operational project finance exposure
+
+    Returns:
+        Risk weight as Decimal
+    """
+    if isinstance(category, str):
+        try:
+            cat_enum = SlottingCategory(category.lower())
+        except ValueError:
+            return Decimal("1.15")
+    else:
+        cat_enum = category
+
+    if is_hvcre:
+        table = B31_SLOTTING_RISK_WEIGHTS_HVCRE
+    elif is_pre_operational:
+        table = B31_SLOTTING_RISK_WEIGHTS_PREOP
+    else:
+        table = B31_SLOTTING_RISK_WEIGHTS
+
+    return table.get(cat_enum, Decimal("1.15"))

--- a/src/rwa_calc/engine/slotting/namespace.py
+++ b/src/rwa_calc/engine/slotting/namespace.py
@@ -33,65 +33,49 @@ from typing import TYPE_CHECKING
 import polars as pl
 from polars import col, lit
 
+from rwa_calc.data.tables.b31_slotting import (
+    B31_SLOTTING_RISK_WEIGHTS,
+    B31_SLOTTING_RISK_WEIGHTS_HVCRE,
+    B31_SLOTTING_RISK_WEIGHTS_PREOP,
+)
+from rwa_calc.data.tables.crr_slotting import (
+    SLOTTING_RISK_WEIGHTS,
+    SLOTTING_RISK_WEIGHTS_HVCRE,
+    SLOTTING_RISK_WEIGHTS_HVCRE_SHORT,
+    SLOTTING_RISK_WEIGHTS_SHORT,
+)
 from rwa_calc.engine.utils import exact_fractional_years_expr
 
 if TYPE_CHECKING:
+    from decimal import Decimal
+
     from rwa_calc.contracts.config import CalculationConfig
+    from rwa_calc.domain.enums import SlottingCategory
 
 # Threshold for short maturity classification under CRR Art. 153(5)
 _SHORT_MATURITY_THRESHOLD_YEARS = 2.5
 
 
+def _to_float_map(weights: dict[SlottingCategory, Decimal]) -> dict[str, float]:
+    """Convert Decimal enum-keyed weights to str/float dict for Polars replace_strict."""
+    return {cat.value: float(w) for cat, w in weights.items()}
+
+
 # =============================================================================
-# RISK WEIGHT CONSTANTS
+# RISK WEIGHT CONSTANTS — sourced from data/tables/
 # =============================================================================
 
-# Categories: strong, good, satisfactory, weak, default
-# Default weight for unknown categories is 'satisfactory'
-
-SLOTTING_WEIGHTS = {
-    # CRR Art. 153(5)
+_SLOTTING_WEIGHTS: dict[str, dict[str, dict[str, float]]] = {
     "crr": {
-        "base": {"strong": 0.70, "good": 0.90, "satisfactory": 1.15, "weak": 2.50, "default": 0.00},
-        "short": {
-            "strong": 0.50,
-            "good": 0.70,
-            "satisfactory": 1.15,
-            "weak": 2.50,
-            "default": 0.00,
-        },
-        "hvcre": {
-            "strong": 0.95,
-            "good": 1.20,
-            "satisfactory": 1.40,
-            "weak": 2.50,
-            "default": 0.00,
-        },
-        "hvcre_short": {
-            "strong": 0.70,
-            "good": 0.95,
-            "satisfactory": 1.40,
-            "weak": 2.50,
-            "default": 0.00,
-        },
+        "base": _to_float_map(SLOTTING_RISK_WEIGHTS),
+        "short": _to_float_map(SLOTTING_RISK_WEIGHTS_SHORT),
+        "hvcre": _to_float_map(SLOTTING_RISK_WEIGHTS_HVCRE),
+        "hvcre_short": _to_float_map(SLOTTING_RISK_WEIGHTS_HVCRE_SHORT),
     },
-    # Basel 3.1 BCBS CRE33
     "basel_3_1": {
-        "base": {"strong": 0.70, "good": 0.90, "satisfactory": 1.15, "weak": 2.50, "default": 0.00},
-        "preop": {
-            "strong": 0.80,
-            "good": 1.00,
-            "satisfactory": 1.20,
-            "weak": 3.50,
-            "default": 0.00,
-        },
-        "hvcre": {
-            "strong": 0.95,
-            "good": 1.20,
-            "satisfactory": 1.40,
-            "weak": 2.50,
-            "default": 0.00,
-        },
+        "base": _to_float_map(B31_SLOTTING_RISK_WEIGHTS),
+        "preop": _to_float_map(B31_SLOTTING_RISK_WEIGHTS_PREOP),
+        "hvcre": _to_float_map(B31_SLOTTING_RISK_WEIGHTS_HVCRE),
     },
 }
 
@@ -296,7 +280,7 @@ class SlottingExpr:
         is_preop_expr = lit(is_preop) if isinstance(is_preop, bool) else is_preop
 
         if is_crr:
-            weights = SLOTTING_WEIGHTS["crr"]
+            weights = _SLOTTING_WEIGHTS["crr"]
             return (
                 pl.when(is_hvcre_expr.not_() & is_short_expr.not_())
                 .then(self._map_category(cat, weights["base"]))
@@ -307,7 +291,7 @@ class SlottingExpr:
                 .otherwise(self._map_category(cat, weights["hvcre_short"]))
             )
         else:
-            weights = SLOTTING_WEIGHTS["basel_3_1"]
+            weights = _SLOTTING_WEIGHTS["basel_3_1"]
             return (
                 pl.when(is_hvcre_expr)
                 .then(self._map_category(cat, weights["hvcre"]))

--- a/tests/unit/crr/test_crr_tables.py
+++ b/tests/unit/crr/test_crr_tables.py
@@ -46,6 +46,8 @@ from rwa_calc.data.tables.crr_risk_weights import (
 from rwa_calc.data.tables.crr_slotting import (
     SLOTTING_RISK_WEIGHTS,
     SLOTTING_RISK_WEIGHTS_HVCRE,
+    SLOTTING_RISK_WEIGHTS_HVCRE_SHORT,
+    SLOTTING_RISK_WEIGHTS_SHORT,
     calculate_slotting_rwa,
     lookup_slotting_rw,
 )
@@ -370,6 +372,44 @@ class TestSlottingRiskWeights:
         assert (
             SLOTTING_RISK_WEIGHTS_HVCRE[SlottingCategory.DEFAULT]
             == SLOTTING_RISK_WEIGHTS[SlottingCategory.DEFAULT]
+        )
+
+
+class TestSlottingShortMaturityWeights:
+    """Tests for short maturity (<2.5yr) slotting weights (CRR Art. 153(5))."""
+
+    def test_short_strong_fifty_percent(self) -> None:
+        """Strong <2.5yr non-HVCRE gets 50% RW."""
+        assert SLOTTING_RISK_WEIGHTS_SHORT[SlottingCategory.STRONG] == Decimal("0.50")
+
+    def test_short_good_seventy_percent(self) -> None:
+        """Good <2.5yr non-HVCRE gets 70% RW."""
+        assert SLOTTING_RISK_WEIGHTS_SHORT[SlottingCategory.GOOD] == Decimal("0.70")
+
+    def test_short_satisfactory_same_as_long(self) -> None:
+        """Satisfactory <2.5yr is same as >=2.5yr (115%)."""
+        assert (
+            SLOTTING_RISK_WEIGHTS_SHORT[SlottingCategory.SATISFACTORY]
+            == SLOTTING_RISK_WEIGHTS[SlottingCategory.SATISFACTORY]
+        )
+
+    def test_hvcre_short_strong_seventy_percent(self) -> None:
+        """Strong <2.5yr HVCRE gets 70% RW."""
+        assert SLOTTING_RISK_WEIGHTS_HVCRE_SHORT[SlottingCategory.STRONG] == Decimal("0.70")
+
+    def test_hvcre_short_good_ninety_five_percent(self) -> None:
+        """Good <2.5yr HVCRE gets 95% RW."""
+        assert SLOTTING_RISK_WEIGHTS_HVCRE_SHORT[SlottingCategory.GOOD] == Decimal("0.95")
+
+    def test_hvcre_short_satisfactory_one_forty(self) -> None:
+        """Satisfactory <2.5yr HVCRE gets 140% RW."""
+        assert SLOTTING_RISK_WEIGHTS_HVCRE_SHORT[SlottingCategory.SATISFACTORY] == Decimal("1.40")
+
+    def test_short_maturity_lookup(self) -> None:
+        """Test lookup function with short maturity flag."""
+        assert lookup_slotting_rw("strong", is_short_maturity=True) == Decimal("0.50")
+        assert (
+            lookup_slotting_rw("strong", is_hvcre=True, is_short_maturity=True) == Decimal("0.70")
         )
 
 

--- a/tests/unit/test_b31_slotting_tables.py
+++ b/tests/unit/test_b31_slotting_tables.py
@@ -1,0 +1,132 @@
+"""
+Unit tests for Basel 3.1 slotting data tables.
+
+Tests verify:
+- Lookup tables contain expected values per BCBS CRE33
+- Lookup function returns correct values
+- Pre-operational phase has distinct (higher) weights
+- HVCRE weights match CRR HVCRE equivalents
+"""
+
+from decimal import Decimal
+
+from rwa_calc.data.tables.b31_slotting import (
+    B31_SLOTTING_RISK_WEIGHTS,
+    B31_SLOTTING_RISK_WEIGHTS_HVCRE,
+    B31_SLOTTING_RISK_WEIGHTS_PREOP,
+    lookup_b31_slotting_rw,
+)
+from rwa_calc.domain.enums import SlottingCategory
+
+
+class TestB31SlottingRiskWeights:
+    """Tests for Basel 3.1 slotting risk weights (BCBS CRE33)."""
+
+    def test_base_strong_seventy_percent(self) -> None:
+        """Strong operational gets 70% RW."""
+        assert B31_SLOTTING_RISK_WEIGHTS[SlottingCategory.STRONG] == Decimal("0.70")
+
+    def test_base_good_ninety_percent(self) -> None:
+        """Good operational gets 90% RW."""
+        assert B31_SLOTTING_RISK_WEIGHTS[SlottingCategory.GOOD] == Decimal("0.90")
+
+    def test_base_satisfactory_one_fifteen(self) -> None:
+        """Satisfactory operational gets 115% RW."""
+        assert B31_SLOTTING_RISK_WEIGHTS[SlottingCategory.SATISFACTORY] == Decimal("1.15")
+
+    def test_base_weak_two_fifty(self) -> None:
+        """Weak operational gets 250% RW."""
+        assert B31_SLOTTING_RISK_WEIGHTS[SlottingCategory.WEAK] == Decimal("2.50")
+
+    def test_base_default_zero(self) -> None:
+        """Default gets 0% RW."""
+        assert B31_SLOTTING_RISK_WEIGHTS[SlottingCategory.DEFAULT] == Decimal("0.00")
+
+    def test_base_has_five_categories(self) -> None:
+        """Base table has exactly 5 categories."""
+        assert len(B31_SLOTTING_RISK_WEIGHTS) == 5
+
+
+class TestB31SlottingPreOperational:
+    """Tests for Basel 3.1 pre-operational phase weights."""
+
+    def test_preop_strong_eighty_percent(self) -> None:
+        """Strong pre-operational gets 80% RW (higher than base 70%)."""
+        assert B31_SLOTTING_RISK_WEIGHTS_PREOP[SlottingCategory.STRONG] == Decimal("0.80")
+
+    def test_preop_good_hundred_percent(self) -> None:
+        """Good pre-operational gets 100% RW."""
+        assert B31_SLOTTING_RISK_WEIGHTS_PREOP[SlottingCategory.GOOD] == Decimal("1.00")
+
+    def test_preop_satisfactory_one_twenty(self) -> None:
+        """Satisfactory pre-operational gets 120% RW."""
+        assert B31_SLOTTING_RISK_WEIGHTS_PREOP[SlottingCategory.SATISFACTORY] == Decimal("1.20")
+
+    def test_preop_weak_three_fifty(self) -> None:
+        """Weak pre-operational gets 350% RW (higher than base 250%)."""
+        assert B31_SLOTTING_RISK_WEIGHTS_PREOP[SlottingCategory.WEAK] == Decimal("3.50")
+
+    def test_preop_weak_differs_from_base(self) -> None:
+        """Pre-operational Weak (350%) differs from base Weak (250%)."""
+        assert (
+            B31_SLOTTING_RISK_WEIGHTS_PREOP[SlottingCategory.WEAK]
+            != B31_SLOTTING_RISK_WEIGHTS[SlottingCategory.WEAK]
+        )
+
+
+class TestB31SlottingHVCRE:
+    """Tests for Basel 3.1 HVCRE slotting weights."""
+
+    def test_hvcre_strong_ninety_five(self) -> None:
+        """HVCRE Strong gets 95% RW."""
+        assert B31_SLOTTING_RISK_WEIGHTS_HVCRE[SlottingCategory.STRONG] == Decimal("0.95")
+
+    def test_hvcre_good_one_twenty(self) -> None:
+        """HVCRE Good gets 120% RW."""
+        assert B31_SLOTTING_RISK_WEIGHTS_HVCRE[SlottingCategory.GOOD] == Decimal("1.20")
+
+    def test_hvcre_satisfactory_one_forty(self) -> None:
+        """HVCRE Satisfactory gets 140% RW."""
+        assert B31_SLOTTING_RISK_WEIGHTS_HVCRE[SlottingCategory.SATISFACTORY] == Decimal("1.40")
+
+    def test_hvcre_weak_same_as_base(self) -> None:
+        """HVCRE Weak (250%) is same as base Weak."""
+        assert (
+            B31_SLOTTING_RISK_WEIGHTS_HVCRE[SlottingCategory.WEAK]
+            == B31_SLOTTING_RISK_WEIGHTS[SlottingCategory.WEAK]
+        )
+
+
+class TestB31SlottingLookup:
+    """Tests for Basel 3.1 slotting lookup function."""
+
+    def test_lookup_base_by_string(self) -> None:
+        """Lookup base weight by string category."""
+        assert lookup_b31_slotting_rw("strong") == Decimal("0.70")
+
+    def test_lookup_base_by_enum(self) -> None:
+        """Lookup base weight by enum."""
+        assert lookup_b31_slotting_rw(SlottingCategory.GOOD) == Decimal("0.90")
+
+    def test_lookup_hvcre(self) -> None:
+        """Lookup HVCRE weight."""
+        assert lookup_b31_slotting_rw("strong", is_hvcre=True) == Decimal("0.95")
+
+    def test_lookup_preop(self) -> None:
+        """Lookup pre-operational weight."""
+        assert lookup_b31_slotting_rw("strong", is_pre_operational=True) == Decimal("0.80")
+
+    def test_lookup_hvcre_takes_precedence_over_preop(self) -> None:
+        """HVCRE flag takes precedence when both flags are set."""
+        assert (
+            lookup_b31_slotting_rw("strong", is_hvcre=True, is_pre_operational=True)
+            == Decimal("0.95")
+        )
+
+    def test_lookup_unknown_category_defaults_to_satisfactory(self) -> None:
+        """Unknown category defaults to satisfactory (115%)."""
+        assert lookup_b31_slotting_rw("unknown") == Decimal("1.15")
+
+    def test_lookup_case_insensitive(self) -> None:
+        """Lookup handles uppercase input."""
+        assert lookup_b31_slotting_rw("STRONG") == Decimal("0.70")


### PR DESCRIPTION
The slotting engine was the only engine defining risk weights inline
(in namespace.py) rather than sourcing them from data/tables/. This
created duplication with crr_slotting.py which had the same CRR values
in Decimal form but was unused by production code.

- Create b31_slotting.py with Basel 3.1 weights (base, preop, HVCRE)
- Update namespace.py to import all weights from data/tables/ and
  convert Decimal→float at the Polars boundary via _to_float_map()
- Export all 4 CRR slotting dicts + convenience functions from __init__
- Add B31 slotting table tests and extend CRR short-maturity coverage

https://claude.ai/code/session_01T7PfmYsdy6KoptThgTEV5U