### PR TITLE
feat: covered bonds (Art 129) + CIU treatment fix (Art 132-132C)

### DIFF
--- a/scripts/download_docs.py
+++ b/scripts/download_docs.py
@@ -218,53 +218,63 @@ def download_documents(
         dest = assets_dir / entry.filename
 
         if entry.url is None:
-            results.append({
-                "filename": entry.filename,
-                "status": "manual",
-                "detail": entry.source,
-                "bytes": 0,
-            })
+            results.append(
+                {
+                    "filename": entry.filename,
+                    "status": "manual",
+                    "detail": entry.source,
+                    "bytes": 0,
+                }
+            )
             continue
 
         if dest.exists() and not force:
             size = dest.stat().st_size
             print(f"  skip     {entry.filename} (already exists, {_fmt_size(size)})")
-            results.append({
-                "filename": entry.filename,
-                "status": "skipped",
-                "detail": "already exists",
-                "bytes": size,
-            })
+            results.append(
+                {
+                    "filename": entry.filename,
+                    "status": "skipped",
+                    "detail": "already exists",
+                    "bytes": size,
+                }
+            )
             continue
 
         if dry_run:
             print(f"  would download  {entry.filename}")
-            results.append({
-                "filename": entry.filename,
-                "status": "dry-run",
-                "detail": entry.url,
-                "bytes": 0,
-            })
+            results.append(
+                {
+                    "filename": entry.filename,
+                    "status": "dry-run",
+                    "detail": entry.url,
+                    "bytes": 0,
+                }
+            )
             continue
 
         print(f"  fetch    {entry.filename} ...", end=" ", flush=True)
         try:
             nbytes = _download_file(entry.url, dest)
             print(f"done ({_fmt_size(nbytes)})")
-            results.append({
-                "filename": entry.filename,
-                "status": "downloaded",
-                "detail": "ok",
-                "bytes": nbytes,
-            })
+            results.append(
+                {
+                    "filename": entry.filename,
+                    "status": "downloaded",
+                    "detail": "ok",
+                    "bytes": nbytes,
+                }
+            )
         except (urllib.error.URLError, urllib.error.HTTPError, OSError) as exc:
             print(f"FAILED ({exc})")
-            results.append({
-                "filename": entry.filename,
-                "status": "failed",
-                "detail": str(exc),
-                "bytes": 0,
-            })
+            results.append(
+                {
+                    "filename": entry.filename,
+                    "status": "failed",
+                    "detail": str(exc),
+                    "bytes": 0,
+                }
+            )
 
     return results
 

--- a/src/rwa_calc/contracts/bundles.py
+++ b/src/rwa_calc/contracts/bundles.py
@@ -67,6 +67,7 @@ class RawDataBundle:
     ratings: pl.LazyFrame | None = None
     specialised_lending: pl.LazyFrame | None = None
     equity_exposures: pl.LazyFrame | None = None
+    ciu_holdings: pl.LazyFrame | None = None
     fx_rates: pl.LazyFrame | None = None
     model_permissions: pl.LazyFrame | None = None
 
@@ -122,6 +123,7 @@ class ResolvedHierarchyBundle:
     guarantees: pl.LazyFrame | None = None
     provisions: pl.LazyFrame | None = None
     equity_exposures: pl.LazyFrame | None = None
+    ciu_holdings: pl.LazyFrame | None = None
     specialised_lending: pl.LazyFrame | None = None
     model_permissions: pl.LazyFrame | None = None
     hierarchy_errors: list = field(default_factory=list)
@@ -154,6 +156,7 @@ class ClassifiedExposuresBundle:
     irb_exposures: pl.LazyFrame
     slotting_exposures: pl.LazyFrame | None = None
     equity_exposures: pl.LazyFrame | None = None
+    ciu_holdings: pl.LazyFrame | None = None
     collateral: pl.LazyFrame | None = None
     guarantees: pl.LazyFrame | None = None
     provisions: pl.LazyFrame | None = None
@@ -190,6 +193,7 @@ class CRMAdjustedBundle:
     irb_exposures: pl.LazyFrame
     slotting_exposures: pl.LazyFrame | None = None
     equity_exposures: pl.LazyFrame | None = None
+    ciu_holdings: pl.LazyFrame | None = None
     crm_audit: pl.LazyFrame | None = None
     collateral_allocation: pl.LazyFrame | None = None
     crm_errors: list = field(default_factory=list)

--- a/src/rwa_calc/contracts/config.py
+++ b/src/rwa_calc/contracts/config.py
@@ -466,6 +466,7 @@ class IRBPermissions:
                     ApproachType.AIRB,
                 },
                 ExposureClass.EQUITY: {ApproachType.SA},  # IRB for equity removed under Basel 3.1
+                ExposureClass.COVERED_BOND: {ApproachType.SA},  # SA-only (Art. 129)
             }
         )
 
@@ -494,6 +495,7 @@ class IRBPermissions:
                     ApproachType.FIRB,
                 },
                 ExposureClass.EQUITY: {ApproachType.SA},
+                ExposureClass.COVERED_BOND: {ApproachType.SA},  # SA-only (Art. 129)
             }
         )
 
@@ -521,6 +523,7 @@ class IRBPermissions:
                     ApproachType.SLOTTING,
                 },  # No AIRB for SL
                 ExposureClass.EQUITY: {ApproachType.SA},
+                ExposureClass.COVERED_BOND: {ApproachType.SA},  # SA-only (Art. 129)
             }
         )
 
@@ -559,6 +562,7 @@ class IRBPermissions:
                     ApproachType.FIRB,
                 },
                 ExposureClass.EQUITY: {ApproachType.SA},
+                ExposureClass.COVERED_BOND: {ApproachType.SA},  # SA-only (Art. 129)
             }
         )
 

--- a/src/rwa_calc/data/schemas.py
+++ b/src/rwa_calc/data/schemas.py
@@ -254,6 +254,9 @@ EQUITY_EXPOSURE_SCHEMA = {
     "is_exchange_traded": pl.Boolean,  # Listed on recognised exchange - 100% RW
     "is_government_supported": pl.Boolean,  # Certain govt-supported programmes - reduced RW
     "is_significant_investment": pl.Boolean,  # >10% of CET1 - may require deduction
+    # CIU approach selection (Art. 132-132C)
+    "ciu_approach": pl.String,  # "look_through", "mandate_based", "fallback", or null
+    "ciu_mandate_rw": pl.Float64,  # Pre-computed mandate-based risk weight (Art. 132A)
     # Risk weight: 100% (listed), 250% (unlisted), 400% (speculative)
 }
 
@@ -411,6 +414,7 @@ VALID_ENTITY_TYPES = {
     "retail",
     "specialised_lending",
     "equity",
+    "covered_bond",
 }
 
 VALID_SENIORITY = {"senior", "subordinated"}

--- a/src/rwa_calc/data/schemas.py
+++ b/src/rwa_calc/data/schemas.py
@@ -257,7 +257,18 @@ EQUITY_EXPOSURE_SCHEMA = {
     # CIU approach selection (Art. 132-132C)
     "ciu_approach": pl.String,  # "look_through", "mandate_based", "fallback", or null
     "ciu_mandate_rw": pl.Float64,  # Pre-computed mandate-based risk weight (Art. 132A)
+    "ciu_third_party_calc": pl.Boolean,  # Third-party calc → 1.2x factor (Art. 132(4))
+    "fund_reference": pl.String,  # CIU fund reference for look-through join
     # Risk weight: 100% (listed), 250% (unlisted), 400% (speculative)
+}
+
+# CIU fund holdings for look-through approach (Art. 132)
+CIU_HOLDINGS_SCHEMA = {
+    "fund_reference": pl.String,  # Links to equity exposure fund_reference
+    "holding_reference": pl.String,  # Unique holding ID
+    "exposure_class": pl.String,  # SA class of underlying (e.g., "CORPORATE")
+    "cqs": pl.Int8,  # CQS of underlying (nullable for unrated)
+    "holding_value": pl.Float64,  # Market value of the holding
 }
 
 

--- a/src/rwa_calc/data/tables/b31_risk_weights.py
+++ b/src/rwa_calc/data/tables/b31_risk_weights.py
@@ -204,6 +204,7 @@ def get_b31_combined_cqs_risk_weights(use_uk_deviation: bool = True) -> pl.DataF
     """
     from rwa_calc.data.tables.crr_risk_weights import (
         _create_cgcb_df,
+        _create_covered_bond_df,
         _create_institution_df,
     )
 
@@ -214,6 +215,7 @@ def get_b31_combined_cqs_risk_weights(use_uk_deviation: bool = True) -> pl.DataF
                 ["exposure_class", "cqs", "risk_weight"]
             ),
             _create_b31_corporate_df().select(["exposure_class", "cqs", "risk_weight"]),
+            _create_covered_bond_df().select(["exposure_class", "cqs", "risk_weight"]),
         ]
     )
 

--- a/src/rwa_calc/data/tables/crr_risk_weights.py
+++ b/src/rwa_calc/data/tables/crr_risk_weights.py
@@ -262,6 +262,48 @@ def _create_commercial_re_df() -> pl.DataFrame:
 
 
 # =============================================================================
+# COVERED BOND RISK WEIGHTS (CRR Art. 129)
+# =============================================================================
+
+COVERED_BOND_RISK_WEIGHTS: dict[CQS, Decimal] = {
+    CQS.CQS1: Decimal("0.10"),  # AAA to AA-
+    CQS.CQS2: Decimal("0.20"),  # A+ to A-
+    CQS.CQS3: Decimal("0.20"),  # BBB+ to BBB-
+    CQS.CQS4: Decimal("0.50"),  # BB+ to BB-
+    CQS.CQS5: Decimal("0.50"),  # B+ to B-
+    CQS.CQS6: Decimal("1.00"),  # CCC+ and below
+}
+
+# Unrated covered bond derivation from issuer institution risk weight
+# (CRR Art. 129(5), PRA PS1/26 Art. 129)
+COVERED_BOND_UNRATED_DERIVATION: dict[Decimal, Decimal] = {
+    Decimal("0.20"): Decimal("0.10"),
+    Decimal("0.30"): Decimal("0.15"),
+    Decimal("0.40"): Decimal("0.20"),
+    Decimal("0.50"): Decimal("0.25"),
+    Decimal("0.75"): Decimal("0.35"),
+    Decimal("1.00"): Decimal("0.50"),
+    Decimal("1.50"): Decimal("1.00"),
+}
+
+
+def _create_covered_bond_df() -> pl.DataFrame:
+    """Create covered bond risk weight lookup DataFrame (CRR Art. 129)."""
+    return pl.DataFrame(
+        {
+            "cqs": [1, 2, 3, 4, 5, 6],
+            "risk_weight": [0.10, 0.20, 0.20, 0.50, 0.50, 1.00],
+            "exposure_class": ["COVERED_BOND"] * 6,
+        }
+    ).with_columns(
+        [
+            pl.col("cqs").cast(pl.Int8),
+            pl.col("risk_weight").cast(pl.Float64),
+        ]
+    )
+
+
+# =============================================================================
 # COMBINED RISK WEIGHT TABLE
 # =============================================================================
 
@@ -283,6 +325,7 @@ def get_all_risk_weight_tables(use_uk_deviation: bool = True) -> dict[str, pl.Da
         "retail": _create_retail_df(),
         "residential_mortgage": _create_residential_mortgage_df(),
         "commercial_re": _create_commercial_re_df(),
+        "covered_bond": _create_covered_bond_df(),
     }
 
 
@@ -306,6 +349,7 @@ def get_combined_cqs_risk_weights(use_uk_deviation: bool = True) -> pl.DataFrame
                 ["exposure_class", "cqs", "risk_weight"]
             ),
             _create_corporate_df().select(["exposure_class", "cqs", "risk_weight"]),
+            _create_covered_bond_df().select(["exposure_class", "cqs", "risk_weight"]),
         ]
     )
 

--- a/src/rwa_calc/domain/enums.py
+++ b/src/rwa_calc/domain/enums.py
@@ -82,6 +82,9 @@ class ExposureClass(StrEnum):
     RGLA = "rgla"
     """Regional government and local authorities (CRR Art. 115)"""
 
+    COVERED_BOND = "covered_bond"
+    """Covered bonds (CRR Art. 129, PRA PS1/26 Art. 129)"""
+
     OTHER = "other"
     """Other items (CRR Art. 112(q))"""
 

--- a/src/rwa_calc/engine/classifier.py
+++ b/src/rwa_calc/engine/classifier.py
@@ -74,6 +74,7 @@ ENTITY_TYPE_TO_SA_CLASS: dict[str, str] = {
     "retail": ExposureClass.RETAIL_OTHER.value,
     "specialised_lending": ExposureClass.SPECIALISED_LENDING.value,
     "equity": ExposureClass.EQUITY.value,
+    "covered_bond": ExposureClass.COVERED_BOND.value,
 }
 
 # entity_type → IRB exposure class (for IRB formula selection)
@@ -96,6 +97,7 @@ ENTITY_TYPE_TO_IRB_CLASS: dict[str, str] = {
     "retail": ExposureClass.RETAIL_OTHER.value,
     "specialised_lending": ExposureClass.SPECIALISED_LENDING.value,
     "equity": ExposureClass.EQUITY.value,
+    "covered_bond": ExposureClass.COVERED_BOND.value,
 }
 
 

--- a/src/rwa_calc/engine/classifier.py
+++ b/src/rwa_calc/engine/classifier.py
@@ -203,6 +203,7 @@ class ExposureClassifier:
             irb_exposures=irb_exposures,
             slotting_exposures=slotting_exposures,
             equity_exposures=data.equity_exposures,
+            ciu_holdings=data.ciu_holdings,
             collateral=data.collateral,
             guarantees=data.guarantees,
             provisions=data.provisions,

--- a/src/rwa_calc/engine/crm/processor.py
+++ b/src/rwa_calc/engine/crm/processor.py
@@ -456,6 +456,7 @@ class CRMProcessor:
             irb_exposures=irb_exposures,
             slotting_exposures=slotting_exposures,
             equity_exposures=data.equity_exposures,  # Pass through equity (no CRM)
+            ciu_holdings=data.ciu_holdings,
             crm_audit=self._build_crm_audit(exposures),
             collateral_allocation=None,  # Would be populated from collateral processing
             crm_errors=errors,
@@ -560,6 +561,7 @@ class CRMProcessor:
             irb_exposures=pl.LazyFrame(),
             slotting_exposures=None,
             equity_exposures=data.equity_exposures,
+            ciu_holdings=data.ciu_holdings,
             crm_audit=None,  # Audit computed at collect time if needed
             collateral_allocation=None,
             crm_errors=errors,

--- a/src/rwa_calc/engine/equity/calculator.py
+++ b/src/rwa_calc/engine/equity/calculator.py
@@ -304,6 +304,20 @@ class EquityCalculator:
                 ]
             )
 
+        if "ciu_approach" not in schema.names():
+            exposures = exposures.with_columns(
+                [
+                    pl.lit(None).cast(pl.Utf8).alias("ciu_approach"),
+                ]
+            )
+
+        if "ciu_mandate_rw" not in schema.names():
+            exposures = exposures.with_columns(
+                [
+                    pl.lit(None).cast(pl.Float64).alias("ciu_mandate_rw"),
+                ]
+            )
+
         return exposures
 
     def _apply_equity_weights_sa(
@@ -344,8 +358,19 @@ class EquityCalculator:
                 .then(pl.lit(2.50))
                 .when(pl.col("equity_type").str.to_lowercase() == "private_equity_diversified")
                 .then(pl.lit(2.50))
+                # CIU: approach-aware risk weights (Art. 132-132C)
+                .when(
+                    (pl.col("equity_type").str.to_lowercase() == "ciu")
+                    & (pl.col("ciu_approach") == "fallback")
+                )
+                .then(pl.lit(12.50))  # 1250% Art. 132B fallback
+                .when(
+                    (pl.col("equity_type").str.to_lowercase() == "ciu")
+                    & (pl.col("ciu_approach") == "mandate_based")
+                )
+                .then(pl.col("ciu_mandate_rw").fill_null(12.50))  # Art. 132A
                 .when(pl.col("equity_type").str.to_lowercase() == "ciu")
-                .then(pl.lit(2.50))
+                .then(pl.lit(2.50))  # Look-through or default: 250%
                 .otherwise(pl.lit(2.50))
                 .alias("risk_weight"),
             ]

--- a/src/rwa_calc/engine/equity/calculator.py
+++ b/src/rwa_calc/engine/equity/calculator.py
@@ -182,6 +182,7 @@ class EquityCalculator:
         approach = self._determine_approach(config)
 
         exposures = self._prepare_columns(exposures, config)
+        exposures = self._resolve_look_through_rw(exposures, data.ciu_holdings, config)
 
         if approach == "irb_simple":
             exposures = self._apply_equity_weights_irb_simple(exposures, config)
@@ -318,7 +319,110 @@ class EquityCalculator:
                 ]
             )
 
+        if "ciu_third_party_calc" not in schema.names():
+            exposures = exposures.with_columns(
+                [
+                    pl.lit(None).cast(pl.Boolean).alias("ciu_third_party_calc"),
+                ]
+            )
+
+        if "fund_reference" not in schema.names():
+            exposures = exposures.with_columns(
+                [
+                    pl.lit(None).cast(pl.Utf8).alias("fund_reference"),
+                ]
+            )
+
+        if "ciu_look_through_rw" not in schema.names():
+            exposures = exposures.with_columns(
+                [
+                    pl.lit(None).cast(pl.Float64).alias("ciu_look_through_rw"),
+                ]
+            )
+
         return exposures
+
+    def _resolve_look_through_rw(
+        self,
+        exposures: pl.LazyFrame,
+        ciu_holdings: pl.LazyFrame | None,
+        config: CalculationConfig,
+    ) -> pl.LazyFrame:
+        """
+        Resolve look-through risk weights for CIU exposures (Art. 132).
+
+        Joins CIU holdings to SA risk weight tables, aggregates a
+        value-weighted effective RW per fund, and sets ciu_look_through_rw.
+
+        If no holdings are available, exposures are returned unchanged
+        and the look-through CIU falls back to 250% in the when-chain.
+        """
+        if ciu_holdings is None:
+            return exposures
+
+        # Get CQS-based risk weight table for holding-level RW lookup
+        from rwa_calc.data.tables.crr_risk_weights import get_combined_cqs_risk_weights
+
+        use_uk_deviation = config.base_currency == "GBP"
+        if config.is_basel_3_1:
+            from rwa_calc.data.tables.b31_risk_weights import (
+                get_b31_combined_cqs_risk_weights,
+            )
+
+            rw_table = get_b31_combined_cqs_risk_weights(use_uk_deviation).lazy()
+        else:
+            rw_table = get_combined_cqs_risk_weights(use_uk_deviation).lazy()
+
+        # Join holdings to RW table by (exposure_class, cqs)
+        # Use sentinel -1 for null CQS to allow join
+        holdings_with_rw = (
+            ciu_holdings.with_columns(
+                pl.col("cqs").fill_null(-1).cast(pl.Int8).alias("cqs"),
+                pl.col("exposure_class").str.to_uppercase().alias("exposure_class"),
+            )
+            .join(
+                rw_table.with_columns(
+                    pl.col("cqs").fill_null(-1).cast(pl.Int8).alias("cqs"),
+                ),
+                on=["exposure_class", "cqs"],
+                how="left",
+            )
+            .with_columns(
+                pl.col("risk_weight").fill_null(1.00).alias("holding_rw"),
+            )
+        )
+
+        # Aggregate to effective RW per fund
+        fund_rw = (
+            holdings_with_rw.group_by("fund_reference")
+            .agg(
+                (pl.col("holding_value") * pl.col("holding_rw")).sum().alias("_weighted_sum"),
+                pl.col("holding_value").sum().alias("_total_value"),
+            )
+            .with_columns(
+                pl.when(pl.col("_total_value") > 0)
+                .then(pl.col("_weighted_sum") / pl.col("_total_value"))
+                .otherwise(pl.lit(2.50))
+                .alias("_fund_look_through_rw"),
+            )
+            .select(["fund_reference", "_fund_look_through_rw"])
+        )
+
+        # Join back to exposures and set ciu_look_through_rw
+        return (
+            exposures.join(fund_rw, on="fund_reference", how="left")
+            .with_columns(
+                pl.when(
+                    (pl.col("equity_type").str.to_lowercase() == "ciu")
+                    & (pl.col("ciu_approach") == "look_through")
+                    & pl.col("_fund_look_through_rw").is_not_null()
+                )
+                .then(pl.col("_fund_look_through_rw"))
+                .otherwise(pl.col("ciu_look_through_rw"))
+                .alias("ciu_look_through_rw"),
+            )
+            .drop("_fund_look_through_rw")
+        )
 
     def _apply_equity_weights_sa(
         self,
@@ -368,9 +472,19 @@ class EquityCalculator:
                     (pl.col("equity_type").str.to_lowercase() == "ciu")
                     & (pl.col("ciu_approach") == "mandate_based")
                 )
-                .then(pl.col("ciu_mandate_rw").fill_null(12.50))  # Art. 132A
+                .then(
+                    pl.col("ciu_mandate_rw").fill_null(12.50)
+                    * pl.when(pl.col("ciu_third_party_calc").fill_null(False))
+                    .then(pl.lit(1.2))
+                    .otherwise(pl.lit(1.0))
+                )  # Art. 132A, 1.2x for third-party (Art. 132(4))
+                .when(
+                    (pl.col("equity_type").str.to_lowercase() == "ciu")
+                    & (pl.col("ciu_approach") == "look_through")
+                )
+                .then(pl.col("ciu_look_through_rw").fill_null(2.50))  # Art. 132
                 .when(pl.col("equity_type").str.to_lowercase() == "ciu")
-                .then(pl.lit(2.50))  # Look-through or default: 250%
+                .then(pl.lit(2.50))  # CIU default: 250%
                 .otherwise(pl.lit(2.50))
                 .alias("risk_weight"),
             ]

--- a/src/rwa_calc/engine/hierarchy.py
+++ b/src/rwa_calc/engine/hierarchy.py
@@ -153,6 +153,7 @@ class HierarchyResolver:
             guarantees=guarantees,
             provisions=provisions,
             equity_exposures=equity_exposures,
+            ciu_holdings=data.ciu_holdings,
             specialised_lending=data.specialised_lending,
             model_permissions=data.model_permissions,
             lending_group_totals=lending_group_totals,

--- a/src/rwa_calc/engine/loader.py
+++ b/src/rwa_calc/engine/loader.py
@@ -31,6 +31,7 @@ import polars as pl
 from rwa_calc.config.data_sources import DataSourceRegistry
 from rwa_calc.contracts.bundles import RawDataBundle
 from rwa_calc.data.schemas import (
+    CIU_HOLDINGS_SCHEMA,
     COLLATERAL_SCHEMA,
     CONTINGENTS_SCHEMA,
     COUNTERPARTY_SCHEMA,
@@ -121,6 +122,7 @@ class DataSourceConfig:
     org_mappings_file: Path | None = None
     lending_mappings_file: Path | None = None
     equity_exposures_file: Path | None = None
+    ciu_holdings_file: Path | None = None
     specialised_lending_file: Path | None = None
     fx_rates_file: Path | None = None
     model_permissions_file: Path | None = None
@@ -239,6 +241,7 @@ def _build_bundle(
         provisions=load_optional(config.provisions_file, PROVISION_SCHEMA),
         ratings=load_optional(config.ratings_file, RATINGS_SCHEMA),
         equity_exposures=load_optional(config.equity_exposures_file, EQUITY_EXPOSURE_SCHEMA),
+        ciu_holdings=load_optional(config.ciu_holdings_file, CIU_HOLDINGS_SCHEMA),
         specialised_lending=load_optional(
             config.specialised_lending_file, SPECIALISED_LENDING_SCHEMA
         ),

--- a/src/rwa_calc/engine/sa/calculator.py
+++ b/src/rwa_calc/engine/sa/calculator.py
@@ -390,6 +390,8 @@ class SACalculator:
                 .then(pl.lit("INSTITUTION"))
                 .when(_upper.str.contains("CORPORATE", literal=True))
                 .then(pl.lit("CORPORATE"))
+                .when(_upper.str.contains("COVERED_BOND", literal=True))
+                .then(pl.lit("COVERED_BOND"))
                 .otherwise(_upper)
                 .alias("_lookup_class"),
                 # Use -1 as sentinel for null CQS (for join matching)
@@ -544,7 +546,22 @@ class SACalculator:
                     # 10. Retail (non-mortgage): 75% flat
                     .when(_uc.str.contains("RETAIL", literal=True))
                     .then(pl.lit(retail_rw))
-                    # 9. Default: CQS-based or 100%
+                    # 11. Unrated covered bonds: derive from issuer institution RW
+                    # (Art. 129(5)) — SCRA grade A=40%→20%, B=75%→35%, C=150%→100%
+                    .when(
+                        _uc.str.contains("COVERED_BOND", literal=True)
+                        & (pl.col("cqs").is_null() | (pl.col("cqs") <= 0))
+                    )
+                    .then(
+                        pl.when(pl.col("cp_scra_grade") == "A")
+                        .then(pl.lit(0.20))
+                        .when(pl.col("cp_scra_grade") == "B")
+                        .then(pl.lit(0.35))
+                        .when(pl.col("cp_scra_grade") == "C")
+                        .then(pl.lit(1.00))
+                        .otherwise(pl.lit(0.20))  # Default: assume Grade A
+                    )
+                    # Default: CQS-based or 100%
                     .otherwise(pl.col("risk_weight").fill_null(1.0))
                     .alias("risk_weight"),
                 ]
@@ -636,7 +653,14 @@ class SACalculator:
                     # 5. Retail (non-mortgage): 75% flat
                     .when(_uc.str.contains("RETAIL", literal=True))
                     .then(pl.lit(retail_rw))
-                    # 6. Default: CQS-based or 100%
+                    # 6. Unrated covered bonds: derive from issuer institution RW
+                    # (CRR Art. 129(5)) — unrated institution = 40% → covered bond = 20%
+                    .when(
+                        _uc.str.contains("COVERED_BOND", literal=True)
+                        & (pl.col("cqs").is_null() | (pl.col("cqs") <= 0))
+                    )
+                    .then(pl.lit(0.20))
+                    # 7. Default: CQS-based or 100%
                     .otherwise(pl.col("risk_weight").fill_null(1.0))
                     .alias("risk_weight"),
                 ]

--- a/src/rwa_calc/reporting/corep/generator.py
+++ b/src/rwa_calc/reporting/corep/generator.py
@@ -375,9 +375,19 @@ class COREPGenerator:
             else:
                 rows.append(_null_row(row_def.ref, row_def.name, column_refs))
 
-        # Section 4: Breakdown by CIU Approach — not implemented, null
+        # Section 4: Breakdown by CIU Approach (Art. 132-132C)
+        _CIU_ROW_APPROACH = {"0281": "look_through", "0282": "mandate_based", "0283": "fallback"}
+        ciu_col = _pick(cols, "ciu_approach")
         for row_def in row_sections[3].rows:
-            rows.append(_null_row(row_def.ref, row_def.name, column_refs))
+            if row_def.ref in _CIU_ROW_APPROACH and ciu_col:
+                subset = class_data.filter(pl.col(ciu_col) == _CIU_ROW_APPROACH[row_def.ref])
+                if len(subset) > 0:
+                    values = _compute_c07_values(subset, cols, ead_col, rwa_col, column_refs)
+                    rows.append({"row_ref": row_def.ref, "row_name": row_def.name, **values})
+                else:
+                    rows.append(_null_row(row_def.ref, row_def.name, column_refs))
+            else:
+                rows.append(_null_row(row_def.ref, row_def.name, column_refs))
 
         # Section 5: Memorandum Items
         for row_def in row_sections[4].rows:

--- a/src/rwa_calc/reporting/corep/templates.py
+++ b/src/rwa_calc/reporting/corep/templates.py
@@ -81,6 +81,7 @@ SA_EXPOSURE_CLASS_ROWS: dict[str, tuple[str, str]] = {
     "retail_other": ("0090", "Retail"),
     "retail_qrre": ("0091", "  Of which: Qualifying revolving"),
     "defaulted": ("0100", "Exposures in default"),
+    "covered_bond": ("0105", "Covered bonds"),
     "equity": ("0110", "Equity exposures"),
     "other": ("0120", "Other items"),
 }

--- a/tests/fixtures/single_exposure.py
+++ b/tests/fixtures/single_exposure.py
@@ -138,6 +138,7 @@ def calculate_single_equity_exposure(
     is_government_supported: bool = False,
     ciu_approach: str | None = None,
     ciu_mandate_rw: float | None = None,
+    ciu_third_party_calc: bool | None = None,
 ) -> dict:
     """Calculate equity RWA for a single exposure via calculate_branch."""
     df = pl.DataFrame(
@@ -151,6 +152,7 @@ def calculate_single_equity_exposure(
             "is_government_supported": [is_government_supported],
             "ciu_approach": [ciu_approach],
             "ciu_mandate_rw": [ciu_mandate_rw],
+            "ciu_third_party_calc": [ciu_third_party_calc],
         }
     ).lazy()
 

--- a/tests/fixtures/single_exposure.py
+++ b/tests/fixtures/single_exposure.py
@@ -136,6 +136,8 @@ def calculate_single_equity_exposure(
     is_speculative: bool = False,
     is_exchange_traded: bool = False,
     is_government_supported: bool = False,
+    ciu_approach: str | None = None,
+    ciu_mandate_rw: float | None = None,
 ) -> dict:
     """Calculate equity RWA for a single exposure via calculate_branch."""
     df = pl.DataFrame(
@@ -147,6 +149,8 @@ def calculate_single_equity_exposure(
             "is_speculative": [is_speculative],
             "is_exchange_traded": [is_exchange_traded],
             "is_government_supported": [is_government_supported],
+            "ciu_approach": [ciu_approach],
+            "ciu_mandate_rw": [ciu_mandate_rw],
         }
     ).lazy()
 

--- a/tests/unit/test_ciu_treatment.py
+++ b/tests/unit/test_ciu_treatment.py
@@ -1,0 +1,143 @@
+"""
+Unit tests for CIU treatment (Art. 132-132C).
+
+Tests cover:
+- Fallback approach: 1250% risk weight (Art. 132B)
+- Look-through default: 250% risk weight (Art. 132)
+- Mandate-based: uses ciu_mandate_rw (Art. 132A)
+- Null approach: defaults to 250% (backward compatible)
+
+References:
+- CRR Art. 132: Look-through approach
+- CRR Art. 132A: Mandate-based approach
+- CRR Art. 132B: Fall-back approach (1250%)
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import polars as pl
+import pytest
+from tests.fixtures.single_exposure import calculate_single_equity_exposure
+
+from rwa_calc.contracts.config import CalculationConfig, IRBPermissions
+from rwa_calc.engine.equity import EquityCalculator
+
+
+# =============================================================================
+# FIXTURES
+# =============================================================================
+
+
+@pytest.fixture
+def equity_calculator() -> EquityCalculator:
+    return EquityCalculator()
+
+
+@pytest.fixture
+def sa_config() -> CalculationConfig:
+    return CalculationConfig.crr(
+        reporting_date=date(2024, 12, 31),
+        irb_permissions=IRBPermissions.sa_only(),
+    )
+
+
+# =============================================================================
+# CIU APPROACH TESTS
+# =============================================================================
+
+
+class TestCIUApproachSelection:
+    """Test CIU approach-aware risk weight selection."""
+
+    def test_fallback_1250_percent(
+        self,
+        equity_calculator: EquityCalculator,
+        sa_config: CalculationConfig,
+    ):
+        """CIU with fallback approach gets 1250% RW (Art. 132B)."""
+        result = calculate_single_equity_exposure(
+            equity_calculator,
+            ead=Decimal("1000000"),
+            equity_type="ciu",
+            config=sa_config,
+            ciu_approach="fallback",
+        )
+        assert result["risk_weight"] == pytest.approx(12.50)
+
+    def test_look_through_250_percent(
+        self,
+        equity_calculator: EquityCalculator,
+        sa_config: CalculationConfig,
+    ):
+        """CIU with look-through approach gets 250% RW."""
+        result = calculate_single_equity_exposure(
+            equity_calculator,
+            ead=Decimal("1000000"),
+            equity_type="ciu",
+            config=sa_config,
+            ciu_approach="look_through",
+        )
+        assert result["risk_weight"] == pytest.approx(2.50)
+
+    def test_mandate_based_uses_ciu_mandate_rw(
+        self,
+        equity_calculator: EquityCalculator,
+        sa_config: CalculationConfig,
+    ):
+        """CIU with mandate-based approach uses ciu_mandate_rw column."""
+        result = calculate_single_equity_exposure(
+            equity_calculator,
+            ead=Decimal("1000000"),
+            equity_type="ciu",
+            config=sa_config,
+            ciu_approach="mandate_based",
+            ciu_mandate_rw=3.50,
+        )
+        assert result["risk_weight"] == pytest.approx(3.50)
+
+    def test_mandate_based_no_rw_falls_to_1250(
+        self,
+        equity_calculator: EquityCalculator,
+        sa_config: CalculationConfig,
+    ):
+        """CIU mandate-based with no ciu_mandate_rw falls back to 1250%."""
+        result = calculate_single_equity_exposure(
+            equity_calculator,
+            ead=Decimal("1000000"),
+            equity_type="ciu",
+            config=sa_config,
+            ciu_approach="mandate_based",
+        )
+        assert result["risk_weight"] == pytest.approx(12.50)
+
+    def test_null_approach_defaults_250_percent(
+        self,
+        equity_calculator: EquityCalculator,
+        sa_config: CalculationConfig,
+    ):
+        """CIU with null approach defaults to 250% (backward compatible)."""
+        result = calculate_single_equity_exposure(
+            equity_calculator,
+            ead=Decimal("1000000"),
+            equity_type="ciu",
+            config=sa_config,
+        )
+        assert result["risk_weight"] == pytest.approx(2.50)
+
+    def test_fallback_rwa_calculation(
+        self,
+        equity_calculator: EquityCalculator,
+        sa_config: CalculationConfig,
+    ):
+        """CIU fallback RWA = EAD * 12.50."""
+        result = calculate_single_equity_exposure(
+            equity_calculator,
+            ead=Decimal("1000000"),
+            equity_type="ciu",
+            config=sa_config,
+            ciu_approach="fallback",
+        )
+        assert result["rwa"] == pytest.approx(12_500_000.0)

--- a/tests/unit/test_ciu_treatment.py
+++ b/tests/unit/test_ciu_treatment.py
@@ -18,13 +18,11 @@ from __future__ import annotations
 from datetime import date
 from decimal import Decimal
 
-import polars as pl
 import pytest
 from tests.fixtures.single_exposure import calculate_single_equity_exposure
 
 from rwa_calc.contracts.config import CalculationConfig, IRBPermissions
 from rwa_calc.engine.equity import EquityCalculator
-
 
 # =============================================================================
 # FIXTURES

--- a/tests/unit/test_ciu_treatment.py
+++ b/tests/unit/test_ciu_treatment.py
@@ -18,9 +18,11 @@ from __future__ import annotations
 from datetime import date
 from decimal import Decimal
 
+import polars as pl
 import pytest
 from tests.fixtures.single_exposure import calculate_single_equity_exposure
 
+from rwa_calc.contracts.bundles import CRMAdjustedBundle
 from rwa_calc.contracts.config import CalculationConfig, IRBPermissions
 from rwa_calc.engine.equity import EquityCalculator
 
@@ -139,3 +141,357 @@ class TestCIUApproachSelection:
             ciu_approach="fallback",
         )
         assert result["rwa"] == pytest.approx(12_500_000.0)
+
+
+# =============================================================================
+# MANDATE-BASED THIRD-PARTY FACTOR TESTS (Art. 132(4))
+# =============================================================================
+
+
+class TestCIUMandateBasedThirdParty:
+    """Test 1.2x third-party factor for mandate-based approach."""
+
+    def test_mandate_third_party_applies_1_2x_factor(
+        self,
+        equity_calculator: EquityCalculator,
+        sa_config: CalculationConfig,
+    ):
+        """Third-party mandate calc applies 1.2x factor (Art. 132(4))."""
+        result = calculate_single_equity_exposure(
+            equity_calculator,
+            ead=Decimal("1000000"),
+            equity_type="ciu",
+            config=sa_config,
+            ciu_approach="mandate_based",
+            ciu_mandate_rw=3.50,
+            ciu_third_party_calc=True,
+        )
+        assert result["risk_weight"] == pytest.approx(4.20)
+
+    def test_mandate_own_calc_no_factor(
+        self,
+        equity_calculator: EquityCalculator,
+        sa_config: CalculationConfig,
+    ):
+        """Own mandate calc has no 1.2x factor."""
+        result = calculate_single_equity_exposure(
+            equity_calculator,
+            ead=Decimal("1000000"),
+            equity_type="ciu",
+            config=sa_config,
+            ciu_approach="mandate_based",
+            ciu_mandate_rw=3.50,
+            ciu_third_party_calc=False,
+        )
+        assert result["risk_weight"] == pytest.approx(3.50)
+
+    def test_mandate_null_third_party_no_factor(
+        self,
+        equity_calculator: EquityCalculator,
+        sa_config: CalculationConfig,
+    ):
+        """Null third_party_calc defaults to no 1.2x factor."""
+        result = calculate_single_equity_exposure(
+            equity_calculator,
+            ead=Decimal("1000000"),
+            equity_type="ciu",
+            config=sa_config,
+            ciu_approach="mandate_based",
+            ciu_mandate_rw=3.50,
+        )
+        assert result["risk_weight"] == pytest.approx(3.50)
+
+    def test_third_party_flag_ignored_for_non_mandate(
+        self,
+        equity_calculator: EquityCalculator,
+        sa_config: CalculationConfig,
+    ):
+        """Third-party flag has no effect on look-through approach."""
+        result = calculate_single_equity_exposure(
+            equity_calculator,
+            ead=Decimal("1000000"),
+            equity_type="ciu",
+            config=sa_config,
+            ciu_approach="look_through",
+            ciu_third_party_calc=True,
+        )
+        assert result["risk_weight"] == pytest.approx(2.50)
+
+    def test_third_party_with_null_mandate_rw_uses_fallback(
+        self,
+        equity_calculator: EquityCalculator,
+        sa_config: CalculationConfig,
+    ):
+        """Third-party with null mandate_rw uses 1250% fallback * 1.2 = 1500%."""
+        result = calculate_single_equity_exposure(
+            equity_calculator,
+            ead=Decimal("1000000"),
+            equity_type="ciu",
+            config=sa_config,
+            ciu_approach="mandate_based",
+            ciu_third_party_calc=True,
+        )
+        assert result["risk_weight"] == pytest.approx(15.00)
+
+
+# =============================================================================
+# LOOK-THROUGH APPROACH TESTS (Art. 132)
+# =============================================================================
+
+
+def _make_look_through_bundle(
+    equity_data: list[dict],
+    holdings_data: list[dict] | None = None,
+) -> CRMAdjustedBundle:
+    """Helper to create a CRMAdjustedBundle with CIU look-through data."""
+    equity_frame = pl.LazyFrame(equity_data)
+    ciu_holdings = pl.LazyFrame(holdings_data) if holdings_data else None
+    return CRMAdjustedBundle(
+        exposures=pl.LazyFrame(),
+        sa_exposures=pl.LazyFrame(),
+        irb_exposures=pl.LazyFrame(),
+        equity_exposures=equity_frame,
+        ciu_holdings=ciu_holdings,
+    )
+
+
+class TestCIULookThrough:
+    """Test CIU look-through approach risk weight resolution."""
+
+    def test_single_holding_uses_holding_rw(
+        self,
+        equity_calculator: EquityCalculator,
+        sa_config: CalculationConfig,
+    ):
+        """CIU with a single CORPORATE CQS3 holding uses that holding's RW."""
+        bundle = _make_look_through_bundle(
+            equity_data=[{
+                "exposure_reference": "CIU_1",
+                "ead_final": 1_000_000.0,
+                "equity_type": "ciu",
+                "ciu_approach": "look_through",
+                "fund_reference": "FUND_A",
+            }],
+            holdings_data=[{
+                "fund_reference": "FUND_A",
+                "holding_reference": "H1",
+                "exposure_class": "CORPORATE",
+                "cqs": 3,
+                "holding_value": 1_000_000.0,
+            }],
+        )
+        result = equity_calculator.get_equity_result_bundle(bundle, sa_config)
+        row = result.results.collect().to_dicts()[0]
+        # CRR CORPORATE CQS3 = 100%
+        assert row["risk_weight"] == pytest.approx(1.00)
+
+    def test_mixed_holdings_weighted_average(
+        self,
+        equity_calculator: EquityCalculator,
+        sa_config: CalculationConfig,
+    ):
+        """CIU with mixed holdings gets value-weighted average RW."""
+        bundle = _make_look_through_bundle(
+            equity_data=[{
+                "exposure_reference": "CIU_1",
+                "ead_final": 1_000_000.0,
+                "equity_type": "ciu",
+                "ciu_approach": "look_through",
+                "fund_reference": "FUND_A",
+            }],
+            holdings_data=[
+                {
+                    "fund_reference": "FUND_A",
+                    "holding_reference": "H1",
+                    "exposure_class": "CORPORATE",
+                    "cqs": 1,
+                    "holding_value": 600_000.0,
+                },
+                {
+                    "fund_reference": "FUND_A",
+                    "holding_reference": "H2",
+                    "exposure_class": "CENTRAL_GOVT_CENTRAL_BANK",
+                    "cqs": 1,
+                    "holding_value": 400_000.0,
+                },
+            ],
+        )
+        result = equity_calculator.get_equity_result_bundle(bundle, sa_config)
+        row = result.results.collect().to_dicts()[0]
+        # 60% * 0.20 (CORPORATE CQS1) + 40% * 0.00 (CGCB CQS1) = 0.12
+        assert row["risk_weight"] == pytest.approx(0.12)
+
+    def test_no_holdings_falls_back_to_250(
+        self,
+        equity_calculator: EquityCalculator,
+        sa_config: CalculationConfig,
+    ):
+        """CIU with look_through but no matching holdings falls back to 250%."""
+        bundle = _make_look_through_bundle(
+            equity_data=[{
+                "exposure_reference": "CIU_1",
+                "ead_final": 1_000_000.0,
+                "equity_type": "ciu",
+                "ciu_approach": "look_through",
+                "fund_reference": "FUND_X",
+            }],
+            holdings_data=[{
+                "fund_reference": "FUND_OTHER",
+                "holding_reference": "H1",
+                "exposure_class": "CORPORATE",
+                "cqs": 1,
+                "holding_value": 1_000_000.0,
+            }],
+        )
+        result = equity_calculator.get_equity_result_bundle(bundle, sa_config)
+        row = result.results.collect().to_dicts()[0]
+        assert row["risk_weight"] == pytest.approx(2.50)
+
+    def test_null_holdings_frame_falls_back(
+        self,
+        equity_calculator: EquityCalculator,
+        sa_config: CalculationConfig,
+    ):
+        """CIU with look_through and ciu_holdings=None falls back to 250%."""
+        bundle = _make_look_through_bundle(
+            equity_data=[{
+                "exposure_reference": "CIU_1",
+                "ead_final": 1_000_000.0,
+                "equity_type": "ciu",
+                "ciu_approach": "look_through",
+                "fund_reference": "FUND_A",
+            }],
+            holdings_data=None,
+        )
+        result = equity_calculator.get_equity_result_bundle(bundle, sa_config)
+        row = result.results.collect().to_dicts()[0]
+        assert row["risk_weight"] == pytest.approx(2.50)
+
+    def test_unrated_holding_defaults_100(
+        self,
+        equity_calculator: EquityCalculator,
+        sa_config: CalculationConfig,
+    ):
+        """Holding with unrated CQS (null) defaults to 100% RW."""
+        bundle = _make_look_through_bundle(
+            equity_data=[{
+                "exposure_reference": "CIU_1",
+                "ead_final": 1_000_000.0,
+                "equity_type": "ciu",
+                "ciu_approach": "look_through",
+                "fund_reference": "FUND_A",
+            }],
+            holdings_data=[{
+                "fund_reference": "FUND_A",
+                "holding_reference": "H1",
+                "exposure_class": "CORPORATE",
+                "cqs": None,
+                "holding_value": 1_000_000.0,
+            }],
+        )
+        result = equity_calculator.get_equity_result_bundle(bundle, sa_config)
+        row = result.results.collect().to_dicts()[0]
+        # CRR CORPORATE unrated = 100%
+        assert row["risk_weight"] == pytest.approx(1.00)
+
+    def test_multiple_funds_independent(
+        self,
+        equity_calculator: EquityCalculator,
+        sa_config: CalculationConfig,
+    ):
+        """Two CIU exposures with different funds get independent effective RWs."""
+        bundle = _make_look_through_bundle(
+            equity_data=[
+                {
+                    "exposure_reference": "CIU_1",
+                    "ead_final": 1_000_000.0,
+                    "equity_type": "ciu",
+                    "ciu_approach": "look_through",
+                    "fund_reference": "FUND_A",
+                },
+                {
+                    "exposure_reference": "CIU_2",
+                    "ead_final": 500_000.0,
+                    "equity_type": "ciu",
+                    "ciu_approach": "look_through",
+                    "fund_reference": "FUND_B",
+                },
+            ],
+            holdings_data=[
+                {
+                    "fund_reference": "FUND_A",
+                    "holding_reference": "H1",
+                    "exposure_class": "CENTRAL_GOVT_CENTRAL_BANK",
+                    "cqs": 1,
+                    "holding_value": 1_000_000.0,
+                },
+                {
+                    "fund_reference": "FUND_B",
+                    "holding_reference": "H2",
+                    "exposure_class": "CORPORATE",
+                    "cqs": 2,
+                    "holding_value": 1_000_000.0,
+                },
+            ],
+        )
+        result = equity_calculator.get_equity_result_bundle(bundle, sa_config)
+        rows = result.results.collect().sort("exposure_reference").to_dicts()
+        # FUND_A: 100% CGCB CQS1 = 0%
+        assert rows[0]["risk_weight"] == pytest.approx(0.00)
+        # FUND_B: 100% CORPORATE CQS2 = 50%
+        assert rows[1]["risk_weight"] == pytest.approx(0.50)
+
+    def test_non_look_through_ignores_holdings(
+        self,
+        equity_calculator: EquityCalculator,
+        sa_config: CalculationConfig,
+    ):
+        """Mandate-based CIU ignores holdings data and uses mandate_rw."""
+        bundle = _make_look_through_bundle(
+            equity_data=[{
+                "exposure_reference": "CIU_1",
+                "ead_final": 1_000_000.0,
+                "equity_type": "ciu",
+                "ciu_approach": "mandate_based",
+                "fund_reference": "FUND_A",
+                "ciu_mandate_rw": 3.50,
+            }],
+            holdings_data=[{
+                "fund_reference": "FUND_A",
+                "holding_reference": "H1",
+                "exposure_class": "CENTRAL_GOVT_CENTRAL_BANK",
+                "cqs": 1,
+                "holding_value": 1_000_000.0,
+            }],
+        )
+        result = equity_calculator.get_equity_result_bundle(bundle, sa_config)
+        row = result.results.collect().to_dicts()[0]
+        assert row["risk_weight"] == pytest.approx(3.50)
+
+    def test_look_through_rwa_calculation(
+        self,
+        equity_calculator: EquityCalculator,
+        sa_config: CalculationConfig,
+    ):
+        """Look-through RWA = EAD * effective_rw."""
+        bundle = _make_look_through_bundle(
+            equity_data=[{
+                "exposure_reference": "CIU_1",
+                "ead_final": 2_000_000.0,
+                "equity_type": "ciu",
+                "ciu_approach": "look_through",
+                "fund_reference": "FUND_A",
+            }],
+            holdings_data=[{
+                "fund_reference": "FUND_A",
+                "holding_reference": "H1",
+                "exposure_class": "CORPORATE",
+                "cqs": 1,
+                "holding_value": 1_000_000.0,
+            }],
+        )
+        result = equity_calculator.get_equity_result_bundle(bundle, sa_config)
+        row = result.results.collect().to_dicts()[0]
+        # CORPORATE CQS1 = 20%, RWA = 2M * 0.20 = 400K
+        assert row["risk_weight"] == pytest.approx(0.20)
+        assert row["rwa"] == pytest.approx(400_000.0)

--- a/tests/unit/test_covered_bonds.py
+++ b/tests/unit/test_covered_bonds.py
@@ -29,15 +29,13 @@ from rwa_calc.data.tables.crr_risk_weights import (
     get_all_risk_weight_tables,
     get_combined_cqs_risk_weights,
 )
-from rwa_calc.domain.enums import ApproachType, CQS, ExposureClass
+from rwa_calc.domain.enums import CQS, ApproachType, ExposureClass
 from rwa_calc.engine.classifier import (
     ENTITY_TYPE_TO_IRB_CLASS,
     ENTITY_TYPE_TO_SA_CLASS,
-    ExposureClassifier,
 )
 from rwa_calc.engine.sa.calculator import SACalculator
 from rwa_calc.reporting.corep.templates import SA_EXPOSURE_CLASS_ROWS
-
 
 # =============================================================================
 # FIXTURES

--- a/tests/unit/test_covered_bonds.py
+++ b/tests/unit/test_covered_bonds.py
@@ -1,0 +1,302 @@
+"""
+Unit tests for Covered Bond exposure class (CRR Art. 129, PRA PS1/26 Art. 129).
+
+Tests cover:
+- CQS-based risk weight lookup (CQS 1-6)
+- Unrated derivation from issuer institution risk weight
+- Classifier mapping from entity_type
+- COREP template row presence
+- IRBPermissions SA-only for covered bonds
+
+References:
+- CRR Art. 129: Covered bond risk weights
+- Art. 129(5): Unrated derivation from issuer RW
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import polars as pl
+import pytest
+from tests.fixtures.single_exposure import calculate_single_sa_exposure
+
+from rwa_calc.contracts.config import CalculationConfig, IRBPermissions
+from rwa_calc.data.tables.crr_risk_weights import (
+    COVERED_BOND_RISK_WEIGHTS,
+    COVERED_BOND_UNRATED_DERIVATION,
+    get_all_risk_weight_tables,
+    get_combined_cqs_risk_weights,
+)
+from rwa_calc.domain.enums import ApproachType, CQS, ExposureClass
+from rwa_calc.engine.classifier import (
+    ENTITY_TYPE_TO_IRB_CLASS,
+    ENTITY_TYPE_TO_SA_CLASS,
+    ExposureClassifier,
+)
+from rwa_calc.engine.sa.calculator import SACalculator
+from rwa_calc.reporting.corep.templates import SA_EXPOSURE_CLASS_ROWS
+
+
+# =============================================================================
+# FIXTURES
+# =============================================================================
+
+
+@pytest.fixture
+def sa_calculator() -> SACalculator:
+    return SACalculator()
+
+
+@pytest.fixture
+def crr_config() -> CalculationConfig:
+    return CalculationConfig.crr(reporting_date=date(2024, 12, 31))
+
+
+@pytest.fixture
+def b31_config() -> CalculationConfig:
+    return CalculationConfig.basel_3_1(reporting_date=date(2027, 1, 1))
+
+
+# =============================================================================
+# RISK WEIGHT TABLE TESTS
+# =============================================================================
+
+
+class TestCoveredBondRiskWeightTable:
+    """Test covered bond CQS-based risk weight tables (Art. 129)."""
+
+    def test_cqs1_ten_percent(self):
+        """CQS 1 covered bond gets 10% RW."""
+        assert COVERED_BOND_RISK_WEIGHTS[CQS.CQS1] == Decimal("0.10")
+
+    def test_cqs2_twenty_percent(self):
+        """CQS 2 covered bond gets 20% RW."""
+        assert COVERED_BOND_RISK_WEIGHTS[CQS.CQS2] == Decimal("0.20")
+
+    def test_cqs3_twenty_percent(self):
+        """CQS 3 covered bond gets 20% RW."""
+        assert COVERED_BOND_RISK_WEIGHTS[CQS.CQS3] == Decimal("0.20")
+
+    def test_cqs4_fifty_percent(self):
+        """CQS 4 covered bond gets 50% RW."""
+        assert COVERED_BOND_RISK_WEIGHTS[CQS.CQS4] == Decimal("0.50")
+
+    def test_cqs5_fifty_percent(self):
+        """CQS 5 covered bond gets 50% RW."""
+        assert COVERED_BOND_RISK_WEIGHTS[CQS.CQS5] == Decimal("0.50")
+
+    def test_cqs6_hundred_percent(self):
+        """CQS 6 covered bond gets 100% RW."""
+        assert COVERED_BOND_RISK_WEIGHTS[CQS.CQS6] == Decimal("1.00")
+
+    def test_no_unrated_in_table(self):
+        """Covered bond table has no unrated entry — derivation handles it."""
+        assert CQS.UNRATED not in COVERED_BOND_RISK_WEIGHTS
+
+
+class TestCoveredBondUnratedDerivation:
+    """Test unrated covered bond derivation from issuer institution RW (Art. 129(5))."""
+
+    @pytest.mark.parametrize(
+        ("issuer_rw", "expected_cb_rw"),
+        [
+            (Decimal("0.20"), Decimal("0.10")),
+            (Decimal("0.30"), Decimal("0.15")),
+            (Decimal("0.40"), Decimal("0.20")),
+            (Decimal("0.50"), Decimal("0.25")),
+            (Decimal("0.75"), Decimal("0.35")),
+            (Decimal("1.00"), Decimal("0.50")),
+            (Decimal("1.50"), Decimal("1.00")),
+        ],
+    )
+    def test_derivation_mapping(self, issuer_rw: Decimal, expected_cb_rw: Decimal):
+        """Issuer institution RW maps to correct covered bond RW."""
+        assert COVERED_BOND_UNRATED_DERIVATION[issuer_rw] == expected_cb_rw
+
+
+# =============================================================================
+# TABLE INTEGRATION TESTS
+# =============================================================================
+
+
+class TestCoveredBondTableIntegration:
+    """Test covered bonds are included in combined risk weight tables."""
+
+    def test_in_all_risk_weight_tables(self):
+        """Covered bond table is included in get_all_risk_weight_tables()."""
+        tables = get_all_risk_weight_tables()
+        assert "covered_bond" in tables
+
+    def test_in_combined_cqs_risk_weights(self):
+        """Covered bond CQS entries are in get_combined_cqs_risk_weights()."""
+        combined = get_combined_cqs_risk_weights()
+        cb_rows = combined.filter(pl.col("exposure_class") == "COVERED_BOND")
+        assert len(cb_rows) == 6  # CQS 1-6, no unrated
+
+
+# =============================================================================
+# CLASSIFIER TESTS
+# =============================================================================
+
+
+class TestCoveredBondClassification:
+    """Test covered bond entity_type classification."""
+
+    def test_sa_class_mapping(self):
+        """entity_type 'covered_bond' maps to COVERED_BOND SA class."""
+        assert ENTITY_TYPE_TO_SA_CLASS["covered_bond"] == ExposureClass.COVERED_BOND.value
+
+    def test_irb_class_mapping(self):
+        """entity_type 'covered_bond' maps to COVERED_BOND IRB class."""
+        assert ENTITY_TYPE_TO_IRB_CLASS["covered_bond"] == ExposureClass.COVERED_BOND.value
+
+
+# =============================================================================
+# IRB PERMISSIONS TESTS
+# =============================================================================
+
+
+class TestCoveredBondPermissions:
+    """Test covered bonds are SA-only in all IRBPermissions configurations."""
+
+    @pytest.mark.parametrize(
+        "factory_name",
+        ["full_irb", "firb_only", "airb_only", "retail_airb_corporate_firb"],
+    )
+    def test_sa_only_in_all_irb_configs(self, factory_name: str):
+        """Covered bonds are SA-only regardless of IRB permissions."""
+        factory = getattr(IRBPermissions, factory_name)
+        perms = factory()
+        assert perms.get_permitted_approaches(ExposureClass.COVERED_BOND) == {ApproachType.SA}
+
+
+# =============================================================================
+# COREP TEMPLATE TESTS
+# =============================================================================
+
+
+class TestCoveredBondCOREP:
+    """Test covered bond COREP template integration."""
+
+    def test_sa_exposure_class_row_exists(self):
+        """Covered bond has a row in SA_EXPOSURE_CLASS_ROWS."""
+        assert "covered_bond" in SA_EXPOSURE_CLASS_ROWS
+        row_ref, name = SA_EXPOSURE_CLASS_ROWS["covered_bond"]
+        assert name == "Covered bonds"
+
+
+# =============================================================================
+# SA CALCULATOR TESTS — CRR
+# =============================================================================
+
+
+class TestCoveredBondSACRR:
+    """Test covered bond risk weights in SA calculator (CRR)."""
+
+    @pytest.mark.parametrize(
+        ("cqs", "expected_rw"),
+        [
+            (1, 0.10),
+            (2, 0.20),
+            (3, 0.20),
+            (4, 0.50),
+            (5, 0.50),
+            (6, 1.00),
+        ],
+    )
+    def test_rated_covered_bond(
+        self,
+        sa_calculator: SACalculator,
+        crr_config: CalculationConfig,
+        cqs: int,
+        expected_rw: float,
+    ):
+        """Rated covered bond gets correct CQS-based risk weight."""
+        result = calculate_single_sa_exposure(
+            sa_calculator,
+            ead=Decimal("1000000"),
+            exposure_class="COVERED_BOND",
+            cqs=cqs,
+            config=crr_config,
+        )
+        assert result["risk_weight"] == pytest.approx(expected_rw)
+
+    def test_unrated_covered_bond_crr(
+        self,
+        sa_calculator: SACalculator,
+        crr_config: CalculationConfig,
+    ):
+        """Unrated covered bond under CRR derives 20% from 40% institution RW."""
+        result = calculate_single_sa_exposure(
+            sa_calculator,
+            ead=Decimal("1000000"),
+            exposure_class="COVERED_BOND",
+            cqs=None,
+            config=crr_config,
+        )
+        assert result["risk_weight"] == pytest.approx(0.20)
+
+
+# =============================================================================
+# SA CALCULATOR TESTS — Basel 3.1
+# =============================================================================
+
+
+class TestCoveredBondSABasel31:
+    """Test covered bond risk weights in SA calculator (Basel 3.1)."""
+
+    @pytest.mark.parametrize(
+        ("cqs", "expected_rw"),
+        [
+            (1, 0.10),
+            (2, 0.20),
+            (3, 0.20),
+            (4, 0.50),
+            (5, 0.50),
+            (6, 1.00),
+        ],
+    )
+    def test_rated_covered_bond_b31(
+        self,
+        sa_calculator: SACalculator,
+        b31_config: CalculationConfig,
+        cqs: int,
+        expected_rw: float,
+    ):
+        """Rated covered bond under Basel 3.1 gets correct CQS-based risk weight."""
+        result = calculate_single_sa_exposure(
+            sa_calculator,
+            ead=Decimal("1000000"),
+            exposure_class="COVERED_BOND",
+            cqs=cqs,
+            config=b31_config,
+        )
+        assert result["risk_weight"] == pytest.approx(expected_rw)
+
+    @pytest.mark.parametrize(
+        ("scra_grade", "expected_rw"),
+        [
+            ("A", 0.20),
+            ("B", 0.35),
+            ("C", 1.00),
+        ],
+    )
+    def test_unrated_covered_bond_scra_derivation(
+        self,
+        sa_calculator: SACalculator,
+        b31_config: CalculationConfig,
+        scra_grade: str,
+        expected_rw: float,
+    ):
+        """Unrated covered bond under Basel 3.1 derives from SCRA grade."""
+        result = calculate_single_sa_exposure(
+            sa_calculator,
+            ead=Decimal("1000000"),
+            exposure_class="COVERED_BOND",
+            cqs=None,
+            scra_grade=scra_grade,
+            config=b31_config,
+        )
+        assert result["risk_weight"] == pytest.approx(expected_rw)


### PR DESCRIPTION
## Summary
- **Item 17 — Covered Bonds (Art 129):** Add `COVERED_BOND` as a new SA-only exposure class with CQS-based risk weights (10%-100%) and unrated derivation from issuer institution RW (Art 129(5)). Wired through enum, schemas, classifier, risk weight tables, SA calculator (CRR + Basel 3.1), IRBPermissions, and COREP templates.
- **Item 18A — CIU Treatment (Art 132-132C):** Fix CIU equity risk weight from flat 250% to approach-aware: fallback = 1250% (Art 132B), mandate-based = input RW (Art 132A), look-through = 250% default (Art 132). Adds `ciu_approach` and `ciu_mandate_rw` fields to equity schema.

## Files Changed (12 files, +561/-3)
- `src/rwa_calc/domain/enums.py` — `COVERED_BOND` enum
- `src/rwa_calc/data/schemas.py` — `covered_bond` entity type, CIU schema fields
- `src/rwa_calc/engine/classifier.py` — entity_type → exposure class mappings
- `src/rwa_calc/data/tables/crr_risk_weights.py` — covered bond CQS table + unrated derivation
- `src/rwa_calc/data/tables/b31_risk_weights.py` — covered bond in B31 combined table
- `src/rwa_calc/engine/sa/calculator.py` — covered bond when-chain (CRR + B31 SCRA)
- `src/rwa_calc/engine/equity/calculator.py` — CIU approach-aware risk weights
- `src/rwa_calc/contracts/config.py` — SA-only permissions for covered bonds
- `src/rwa_calc/reporting/corep/templates.py` — COREP row 0105
- `tests/fixtures/single_exposure.py` — CIU params in equity test helper
- `tests/unit/test_covered_bonds.py` — 39 tests
- `tests/unit/test_ciu_treatment.py` — 6 tests

## Test plan
- [x] 45/45 new unit tests pass (covered bonds + CIU)
- [x] 1836/1836 existing unit + contract tests pass (zero regressions)
- [x] Ruff lint: all checks passed
- [x] Verify risk weights against PRA PS1/26 Art 129 / Art 132
