### PR TITLE
fix(docs): add missing IRB approach restrictions (Art. 147A)

### DIFF
--- a/.claude/skills/basel31/references/irb-changes.md
+++ b/.claude/skills/basel31/references/irb-changes.md
@@ -58,14 +58,23 @@ All IRB parameter changes from CRR to Basel 3.1.
 | Secured - CRE/RRE | 35% | 20% | -15pp |
 | Secured - other physical | 40% | 25% | -15pp |
 
-## A-IRB Approach Restrictions
+## IRB Approach Restrictions (Art. 147A)
+
+Basel 3.1 restricts IRB in two ways: complete IRB removal (SA only) and A-IRB
+removal (F-IRB only). IPRE/HVCRE specialised lending is restricted to Slotting.
 
 | Exposure Type | CRR | Basel 3.1 |
 |--------------|-----|-----------|
-| Large corporate (>GBP 440m) | F-IRB or A-IRB | **F-IRB only** |
-| Financial sector entities | F-IRB or A-IRB | **F-IRB only** |
+| Central govts, central banks & quasi-sovereigns | F-IRB or A-IRB | **SA only** |
 | Bank / Institution | F-IRB or A-IRB | **F-IRB only** |
+| IPRE / HVCRE (Specialised Lending) | F-IRB, A-IRB, or Slotting | **Slotting only** |
+| Other SL (Object/Project/Commodities) | F-IRB, A-IRB, or Slotting | F-IRB, A-IRB, or Slotting |
+| Financial sector entities | F-IRB or A-IRB | **F-IRB only** |
+| Large corporate (>GBP 440m) | F-IRB or A-IRB | **F-IRB only** |
 | Equity | IRB | **SA only** |
+
+Quasi-sovereign scope (Art. 147(3)): regional govts, local authorities, PSEs,
+MDBs, and international organisations with 0% SA risk weight.
 
 ## Scaling Factor
 

--- a/docs/appendix/changelog.md
+++ b/docs/appendix/changelog.md
@@ -40,6 +40,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Docs**: Add "Why Basel 3.1?" section to framework comparison index — explains the rationale for transitioning from CRR (risk-weight variability, inadequate capital, IRB complexity) and how Basel 3.1 responds
 
 ### Fixed
+- **Docs**: Add missing sovereign (central govts, central banks, quasi-sovereigns) SA-only restriction to IRB approach tables — Art. 147A(1)(a) mandates SA for all sovereign exposures under Basel 3.1, removing F-IRB and A-IRB
+- **Docs**: Add missing IPRE/HVCRE specialised lending Slotting-only restriction — Art. 147A(1)(c); replaces misleading "Specialised Lending (no PD)" row which conflated all SL sub-types
+- **Docs**: Correct large corporate revenue threshold in `basel31.md` from >£500m to >£440m (Art. 147(4C))
 - **Docs**: Correct equity transitional schedule — 2027 starts at 160%/220% (not 130%/160%) after implementation date shifted to 2027
 - **Docs**: Split F-IRB senior LGD into financial entities (45%, unchanged) and other corporates (40%) — previously shown as single 40% row
 - **Docs**: Correct large corporate threshold from >£500m to >£440m (Art. 147(4C))

--- a/docs/framework-comparison/key-differences.md
+++ b/docs/framework-comparison/key-differences.md
@@ -141,14 +141,27 @@ Note: The retail unsecured LGDU used in the LGD* formula for secured exposures i
 
 ### IRB Approach Restrictions
 
-A-IRB (own-LGD estimates) is removed for several exposure types:
+Basel 3.1 introduces two levels of IRB restriction (Art. 147A):
 
-| Exposure Type | CRR | Basel 3.1 |
-|---------------|-----|-----------|
-| Large Corporate (>£440m) | F-IRB or A-IRB | **F-IRB only** |
-| Financial Sector Entities | F-IRB or A-IRB | **F-IRB only** |
-| Bank/Institution | F-IRB or A-IRB | **F-IRB only** |
-| Equity | IRB | **SA only** |
+- **Complete IRB removal** — certain exposure classes must use the Standardised Approach;
+  IRB (both F-IRB and A-IRB) is no longer permitted.
+- **A-IRB removal** — own-LGD estimates are removed; only F-IRB (supervisory LGD) is allowed.
+
+| Exposure Type | CRR | Basel 3.1 | Reference |
+|---------------|-----|-----------|-----------|
+| Central Govts, Central Banks & Quasi-Sovereigns | F-IRB or A-IRB | **SA only** | Art. 147A(1)(a) |
+| Bank/Institution | F-IRB or A-IRB | **F-IRB only** | Art. 147A(1)(b) |
+| IPRE / HVCRE (Specialised Lending) | F-IRB, A-IRB, or Slotting | **Slotting only** | Art. 147A(1)(c) |
+| Other SL (Object/Project/Commodities) | F-IRB, A-IRB, or Slotting | F-IRB, A-IRB, or Slotting | Art. 147A(1)(d) |
+| Financial Sector Entities | F-IRB or A-IRB | **F-IRB only** | Art. 147A(1)(e) |
+| Large Corporate (>£440m) | F-IRB or A-IRB | **F-IRB only** | Art. 147A(1)(e) |
+| Other General Corporates | F-IRB or A-IRB | F-IRB or A-IRB | Art. 147A(1)(f) |
+| Retail (all subclasses) | A-IRB | A-IRB | Art. 147A(1)(g) |
+| Equity | IRB | **SA only** | Art. 147A(1)(h) |
+
+**Quasi-sovereign scope (Art. 147(3)):** The central governments/central banks class includes
+regional governments, local authorities, PSEs, MDBs, and international organisations that
+receive a 0% SA risk weight. Under Basel 3.1, all of these entities are mandatorily SA.
 
 **IRB 10% RW floor for UK residential mortgages (PRA-specific):** Non-defaulted retail exposures
 secured by UK residential property must have a minimum risk weight of **10%** under IRB,

--- a/docs/user-guide/regulatory/basel31.md
+++ b/docs/user-guide/regulatory/basel31.md
@@ -284,16 +284,19 @@ The phase-in allows firms to gradually adjust to the higher capital requirements
 
 ## IRB Restrictions
 
-Basel 3.1 restricts IRB usage for certain exposures. A-IRB (own-LGD estimates)
-is removed for financial sector entities and large corporates:
+Basel 3.1 restricts IRB usage for certain exposures (Art. 147A). For some classes,
+all IRB approaches are removed (SA only). For others, only A-IRB is removed
+(F-IRB with supervisory LGD remains):
 
 | Exposure Type | Allowed Approaches |
 |---------------|-------------------|
-| Large Corporate (Revenue > £500m) | SA or F-IRB only |
+| Central Govts, Central Banks & Quasi-Sovereigns | SA only |
+| Large Corporate (>£440m) | SA or F-IRB only |
 | Financial Sector Entities | SA or F-IRB only |
 | Bank/Institution | SA or F-IRB only |
 | Equity | SA only |
-| Specialised Lending (no PD) | SA or Slotting only |
+| IPRE / HVCRE (Specialised Lending) | SA or Slotting only |
+| Other SL (Object/Project/Commodities) | SA, F-IRB, A-IRB, or Slotting |
 
 **IRB 10% RW floor for UK residential mortgages (PRA-specific):**
 Non-defaulted retail exposures secured by UK residential property must have a minimum risk weight


### PR DESCRIPTION
## Summary
- Add missing **sovereign SA-only** restriction — Art. 147A(1)(a) mandates SA for central govts, central banks and quasi-sovereigns under Basel 3.1 (F-IRB and A-IRB completely removed)
- Add missing **IPRE/HVCRE Slotting-only** restriction — Art. 147A(1)(c); replaces misleading "Specialised Lending (no PD)" row which conflated all SL sub-types
- Correct large corporate threshold in `basel31.md` from >£500m to >£440m (Art. 147(4C))
- Expand the key-differences table to cover all 9 Art. 147A exposure types/subclasses with article references

## Files changed
- `docs/framework-comparison/key-differences.md` — full Art. 147A approach matrix with references
- `docs/user-guide/regulatory/basel31.md` — sovereign + SL split + threshold fix
- `.claude/skills/basel31/references/irb-changes.md` — skill reference updated
- `docs/appendix/changelog.md` — three Fixed entries

## Test plan
- [ ] Verify rendered tables at `/framework-comparison/key-differences/#irb-approach-restrictions`
- [ ] Verify rendered table at `/user-guide/regulatory/basel31/#irb-restrictions`
- [ ] Cross-reference against Art. 147A in PS1/26 Appendix 1
