### PR TITLE
refactor(api): replace RWAService with CreditRiskCalc

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,30 +31,16 @@ pip install rwa-calc[ui]
 
 ## Quick Start
 
-**Quickest Start** — one call does everything:
-
-```python
-from rwa_calc.api import quick_calculate
-
-response = quick_calculate("/path/to/data")
-print(f"Total RWA: {response.summary.total_rwa:,.0f}")
-```
-
-**More Control** — choose framework, permission mode, and reporting date:
-
 ```python
 from datetime import date
-from rwa_calc.api import create_service, CalculationRequest
+from rwa_calc.api import CreditRiskCalc
 
-service = create_service()
-response = service.calculate(
-    CalculationRequest(
-        data_path="/path/to/data",
-        framework="CRR",
-        reporting_date=date(2026, 12, 31),
-        permission_mode="irb",
-    )
-)
+response = CreditRiskCalc(
+    data_path="/path/to/data",
+    framework="CRR",
+    reporting_date=date(2026, 12, 31),
+    permission_mode="irb",
+).calculate()
 
 if response.success:
     print(f"Total RWA: {response.summary.total_rwa:,.0f}")

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -6,7 +6,7 @@ This section provides complete API documentation for the RWA calculator modules.
 
 | Module | Purpose |
 |--------|---------|
-| [**Service API**](service.md) | High-level facade: `quick_calculate`, `RWAService`, request/response models |
+| [**Service API**](service.md) | High-level facade: `CreditRiskCalc`, response models |
 | [**Pipeline**](pipeline.md) | Low-level orchestration and custom pipeline construction |
 | [**Configuration**](configuration.md) | Configuration classes and factories |
 | [**Engine**](engine.md) | Calculation components |
@@ -18,28 +18,15 @@ This section provides complete API documentation for the RWA calculator modules.
 ### Main Entry Point
 
 ```python
-from rwa_calc.api import quick_calculate
-
-# One-liner calculation
-response = quick_calculate("/path/to/data")
-print(f"Total RWA: {response.summary.total_rwa:,.0f}")
-```
-
-### Service API (More Control)
-
-```python
 from datetime import date
-from rwa_calc.api import RWAService, CalculationRequest, create_service
+from rwa_calc.api import CreditRiskCalc
 
-service = create_service()
-response = service.calculate(
-    CalculationRequest(
-        data_path="/path/to/data",
-        framework="CRR",
-        reporting_date=date(2026, 12, 31),
-        permission_mode="irb",
-    )
-)
+response = CreditRiskCalc(
+    data_path="/path/to/data",
+    framework="CRR",
+    reporting_date=date(2026, 12, 31),
+    permission_mode="irb",
+).calculate()
 
 if response.success:
     print(f"Total RWA: {response.summary.total_rwa:,.0f}")
@@ -105,7 +92,7 @@ from rwa_calc.contracts.bundles import (
 
 ## API Sections
 
-- [**Service API**](service.md) - High-level facade (`quick_calculate`, `RWAService`)
+- [**Service API**](service.md) - High-level facade (`CreditRiskCalc`)
 - [**Pipeline API**](pipeline.md) - Pipeline creation and execution
 - [**Configuration API**](configuration.md) - Configuration classes
 - [**Engine API**](engine.md) - Calculation components

--- a/docs/api/service.md
+++ b/docs/api/service.md
@@ -6,186 +6,35 @@ validation, caching, and result formatting.
 
 **Import path:** `from rwa_calc.api import ...`
 
-## quick_calculate
+## CreditRiskCalc
 
-One-liner convenience function for simple use cases.
-
-```python
-from rwa_calc.api import quick_calculate
-
-response = quick_calculate("/path/to/data")
-```
-
-### Signature
-
-```python
-def quick_calculate(
-    data_path: str | Path,
-    framework: Literal["CRR", "BASEL_3_1"] = "CRR",
-    reporting_date: date | None = None,
-    permission_mode: Literal["standardised", "irb"] = "standardised",
-    data_format: Literal["parquet", "csv"] = "parquet",
-    cache_dir: Path | None = None,
-) -> CalculationResponse
-```
-
-### Parameters
-
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `data_path` | `str \| Path` | *required* | Path to directory containing input data files |
-| `framework` | `"CRR" \| "BASEL_3_1"` | `"CRR"` | Regulatory framework |
-| `reporting_date` | `date \| None` | today | As-of date for the calculation |
-| `permission_mode` | `"standardised" \| "irb"` | `"standardised"` | Permission mode: SA-only or IRB with model permissions |
-| `data_format` | `"parquet" \| "csv"` | `"parquet"` | Format of input files |
-| `cache_dir` | `Path \| None` | temp dir | Directory for caching result parquet files |
-
-### Examples
+Single entry point for credit risk RWA calculations. Takes all parameters in the
+constructor and exposes `calculate()` and `validate()` methods.
 
 ```python
 from datetime import date
-from rwa_calc.api import quick_calculate
+from rwa_calc.api import CreditRiskCalc
 
-# Simplest usage — CRR framework, today's date, SA only
-response = quick_calculate("/data/exposures")
-
-# Basel 3.1 with IRB
-response = quick_calculate(
-    "/data/exposures",
-    framework="BASEL_3_1",
-    reporting_date=date(2027, 1, 1),
-    permission_mode="irb",
-)
-
-# CSV input
-response = quick_calculate("/data/csv-exports", data_format="csv")
-```
-
----
-
-## create_service
-
-Factory function to create an `RWAService` instance.
-
-```python
-from rwa_calc.api import create_service
-
-service = create_service()
-```
-
-### Signature
-
-```python
-def create_service(cache_dir: Path | None = None) -> RWAService
-```
-
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `cache_dir` | `Path \| None` | temp dir | Directory for caching result parquet files |
-
----
-
-## RWAService
-
-High-level service for RWA calculations. Wraps the `PipelineOrchestrator` with a
-clean API suitable for UI integration, automation, and scripting.
-
-```python
-from rwa_calc.api import RWAService, create_service
-
-service = create_service()
-# or: service = RWAService(cache_dir=Path(".cache"))
-```
-
-### Methods
-
-#### calculate
-
-Run an RWA calculation with the specified parameters.
-
-```python
-response = service.calculate(request)
-```
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `request` | `CalculationRequest` | Request with all calculation parameters |
-
-**Returns:** `CalculationResponse`
-
-#### validate_data_path
-
-Validate a data directory for calculation readiness.
-
-```python
-from rwa_calc.api import ValidationRequest
-
-validation = service.validate_data_path(
-    ValidationRequest(data_path="/path/to/data")
-)
-```
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `request` | `ValidationRequest` | Request with path and format |
-
-**Returns:** `ValidationResponse`
-
-#### get_supported_frameworks
-
-List available regulatory frameworks.
-
-```python
-frameworks = service.get_supported_frameworks()
-# [{"id": "CRR", "name": "CRR (Basel 3.0)", ...}, ...]
-```
-
-**Returns:** `list[dict[str, str]]`
-
-#### get_default_config
-
-Get default configuration values for a framework.
-
-```python
-defaults = service.get_default_config("CRR", date(2026, 12, 31))
-```
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `framework` | `"CRR" \| "BASEL_3_1"` | Regulatory framework |
-| `reporting_date` | `date` | As-of date |
-
-**Returns:** `dict` with keys like `framework`, `reporting_date`, `pd_floors`, etc.
-
----
-
-## Request Models
-
-### CalculationRequest
-
-Frozen dataclass encapsulating all parameters for a calculation.
-
-```python
-from datetime import date
-from rwa_calc.api import CalculationRequest
-
-request = CalculationRequest(
+response = CreditRiskCalc(
     data_path="/path/to/data",
     framework="CRR",
     reporting_date=date(2026, 12, 31),
     permission_mode="irb",
-)
+).calculate()
 ```
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `data_path` | `str \| Path` | *required* | Path to data directory |
+### Constructor Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `data_path` | `str \| Path` | *required* | Path to directory containing input data files |
 | `framework` | `"CRR" \| "BASEL_3_1"` | *required* | Regulatory framework |
-| `reporting_date` | `date` | *required* | As-of date for calculation |
-| `base_currency` | `str` | `"GBP"` | Reporting currency |
+| `reporting_date` | `date` | *required* | As-of date for the calculation |
 | `permission_mode` | `"standardised" \| "irb"` | `"standardised"` | Permission mode (see table below) |
-| `data_format` | `"parquet" \| "csv"` | `"parquet"` | Input file format |
+| `data_format` | `"parquet" \| "csv"` | `"parquet"` | Format of input files |
+| `base_currency` | `str` | `"GBP"` | Reporting currency |
 | `eur_gbp_rate` | `Decimal` | `0.8732` | EUR/GBP exchange rate |
+| `cache_dir` | `Path \| None` | temp dir | Directory for caching result parquet files |
 
 **Permission mode options:**
 
@@ -203,6 +52,96 @@ request = CalculationRequest(
     fall back to SA with a warning. See
     [Input Schemas — Model Permissions](../data-model/input-schemas.md#model-permissions-schema)
     for the schema.
+
+### Methods
+
+#### calculate
+
+Run the RWA calculation.
+
+```python
+response = calc.calculate()
+```
+
+**Returns:** `CalculationResponse`
+
+#### validate
+
+Validate the data path for calculation readiness.
+
+```python
+validation = calc.validate()
+```
+
+**Returns:** `ValidationResponse`
+
+### Examples
+
+```python
+from datetime import date
+from rwa_calc.api import CreditRiskCalc
+
+# CRR with SA only
+response = CreditRiskCalc(
+    data_path="/data/exposures",
+    framework="CRR",
+    reporting_date=date(2026, 12, 31),
+).calculate()
+
+# Basel 3.1 with IRB
+response = CreditRiskCalc(
+    data_path="/data/exposures",
+    framework="BASEL_3_1",
+    reporting_date=date(2027, 1, 1),
+    permission_mode="irb",
+).calculate()
+
+# CSV input
+response = CreditRiskCalc(
+    data_path="/data/csv-exports",
+    framework="CRR",
+    reporting_date=date(2026, 12, 31),
+    data_format="csv",
+).calculate()
+```
+
+---
+
+## Module Functions
+
+### get_supported_frameworks
+
+List available regulatory frameworks.
+
+```python
+from rwa_calc.api import get_supported_frameworks
+
+frameworks = get_supported_frameworks()
+# [{"id": "CRR", "name": "CRR (Basel 3.0)", ...}, ...]
+```
+
+**Returns:** `list[dict[str, str]]`
+
+### get_default_config
+
+Get default configuration values for a framework.
+
+```python
+from rwa_calc.api import get_default_config
+
+defaults = get_default_config("CRR", date(2026, 12, 31))
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `framework` | `"CRR" \| "BASEL_3_1"` | Regulatory framework |
+| `reporting_date` | `date` | As-of date |
+
+**Returns:** `dict` with keys like `framework`, `reporting_date`, `pd_floors`, etc.
+
+---
+
+## Request Models
 
 ### ValidationRequest
 
@@ -228,7 +167,7 @@ request = ValidationRequest(
 
 ### CalculationResponse
 
-Main response from `RWAService.calculate()` or `quick_calculate()`.
+Main response from `CreditRiskCalc.calculate()`.
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -286,7 +225,7 @@ Aggregated summary metrics from the calculation.
 
 ### ValidationResponse
 
-Response from `validate_data_path()`.
+Response from `CreditRiskCalc.validate()`.
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -363,9 +302,15 @@ Result of an export operation.
 ### Basic Calculation
 
 ```python
-from rwa_calc.api import quick_calculate
+from datetime import date
+from rwa_calc.api import CreditRiskCalc
 
-response = quick_calculate("/data/exposures")
+response = CreditRiskCalc(
+    data_path="/data/exposures",
+    framework="CRR",
+    reporting_date=date(2026, 12, 31),
+).calculate()
+
 if response.success:
     print(f"Total RWA: {response.summary.total_rwa:,.0f}")
 ```
@@ -373,36 +318,35 @@ if response.success:
 ### Validation Before Calculation
 
 ```python
-from rwa_calc.api import create_service, ValidationRequest, CalculationRequest
 from datetime import date
+from rwa_calc.api import CreditRiskCalc
 
-service = create_service()
-
-# Validate first
-validation = service.validate_data_path(
-    ValidationRequest(data_path="/data/exposures")
+calc = CreditRiskCalc(
+    data_path="/data/exposures",
+    framework="CRR",
+    reporting_date=date(2026, 12, 31),
 )
+
+validation = calc.validate()
 if not validation.valid:
     print(f"Missing: {validation.files_missing}")
-    exit(1)
-
-# Then calculate
-response = service.calculate(
-    CalculationRequest(
-        data_path="/data/exposures",
-        framework="CRR",
-        reporting_date=date(2026, 12, 31),
-    )
-)
+else:
+    response = calc.calculate()
 ```
 
 ### Export to Multiple Formats
 
 ```python
+from datetime import date
 from pathlib import Path
-from rwa_calc.api import quick_calculate
+from rwa_calc.api import CreditRiskCalc
 
-response = quick_calculate("/data/exposures", permission_mode="irb")
+response = CreditRiskCalc(
+    data_path="/data/exposures",
+    framework="CRR",
+    reporting_date=date(2026, 12, 31),
+    permission_mode="irb",
+).calculate()
 
 if response.success:
     response.to_parquet(Path("output/parquet/"))
@@ -415,21 +359,21 @@ if response.success:
 
 ```python
 from datetime import date
-from rwa_calc.api import quick_calculate
+from rwa_calc.api import CreditRiskCalc
 
-crr = quick_calculate(
-    "/data/exposures",
+crr = CreditRiskCalc(
+    data_path="/data/exposures",
     framework="CRR",
     reporting_date=date(2026, 12, 31),
     permission_mode="irb",
-)
+).calculate()
 
-b31 = quick_calculate(
-    "/data/exposures",
+b31 = CreditRiskCalc(
+    data_path="/data/exposures",
     framework="BASEL_3_1",
     reporting_date=date(2027, 1, 1),
     permission_mode="irb",
-)
+).calculate()
 
 if crr.success and b31.success:
     delta = b31.summary.total_rwa - crr.summary.total_rwa

--- a/docs/appendix/changelog.md
+++ b/docs/appendix/changelog.md
@@ -8,11 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **API**: Replace `RWAService` + `CalculationRequest` + `quick_calculate` + `create_service` with single `CreditRiskCalc` class. Usage: `CreditRiskCalc(data_path=..., framework=..., reporting_date=...).calculate()`. All response models (`CalculationResponse`, `SummaryStatistics`, etc.) are unchanged.
 - **Config**: Replace granular `IRBPermissions` config (with `sa_only()`, `full_irb()`, `firb_only()`, etc.) with a simple two-mode `PermissionMode` enum (`STANDARDISED` / `IRB`). The `permission_mode` parameter on `CalculationConfig.crr()` and `.basel_3_1()` replaces the old `irb_permissions` parameter. In IRB mode, `model_permissions` input data drives all approach routing (AIRB, FIRB, slotting); without it, the pipeline falls back to SA with a warning. `IRBPermissions` remains as an internal implementation detail but is no longer part of the public API.
 - **Classifier**: Add `model_slotting_permitted` flag to model permissions resolution, enabling slotting to be driven by per-model permissions alongside AIRB and FIRB
 - **Model Permissions**: Add `"slotting"` as a valid `approach` value (alongside `"foundation_irb"` and `"advanced_irb"`)
 - **Comparison**: `TransitionalScheduleRunner.run()` now accepts `permission_mode` instead of `irb_permissions`
-- **API**: Request model uses `permission_mode: Literal["standardised", "irb"]` replacing the old `irb_approach` field
 
 ### Added
 - **Engine**: Add `materialise.py` module with strategy-aware materialization barriers — supports disk-spill (`sink_parquet` → `scan_parquet`) for out-of-core datasets and in-memory (`collect().lazy()`) for backward compatibility, controlled by `config.collect_engine`

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -44,14 +44,19 @@ graph TD
 ## Quick Example
 
 ```python
-from rwa_calc.api import quick_calculate
+from datetime import date
+from rwa_calc.api import CreditRiskCalc
 
-# Run a complete RWA calculation in one call
-response = quick_calculate("/path/to/data")
+response = CreditRiskCalc(
+    data_path="/path/to/data",
+    framework="CRR",
+    reporting_date=date(2026, 12, 31),
+).calculate()
+
 print(f"Total RWA: {response.summary.total_rwa:,.0f}")
 ```
 
-Need more control? Use `RWAService` for framework selection, IRB approach, and export options — see the [Quick Start](quickstart.md).
+Need more control? See the [Quick Start](quickstart.md) for framework selection, IRB mode, and export options.
 
 ## Next Steps
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -49,38 +49,19 @@ For detailed UI documentation, see the [Interactive UI Guide](../user-guide/inte
 
 ## Using the Python API
 
-### Quickest Start
+### Basic Usage
 
-Run a complete RWA calculation in one call:
-
-```python
-from rwa_calc.api import quick_calculate
-
-response = quick_calculate("/path/to/data")
-print(f"Total RWA: {response.summary.total_rwa:,.0f}")
-```
-
-That's it. `quick_calculate` loads your data, runs the full pipeline, and returns a
-`CalculationResponse` with summary statistics and detailed results.
-
-### More Control with RWAService
-
-For more control over framework, permission mode, and reporting date, use `RWAService`:
+Run a complete RWA calculation:
 
 ```python
 from datetime import date
-from pathlib import Path
-from rwa_calc.api import RWAService, CalculationRequest, create_service
+from rwa_calc.api import CreditRiskCalc
 
-service = create_service()
-response = service.calculate(
-    CalculationRequest(
-        data_path="/path/to/data",
-        framework="CRR",
-        reporting_date=date(2026, 12, 31),
-        permission_mode="irb",
-    )
-)
+response = CreditRiskCalc(
+    data_path="/path/to/data",
+    framework="CRR",
+    reporting_date=date(2026, 12, 31),
+).calculate()
 
 if response.success:
     print(f"Total RWA: {response.summary.total_rwa:,.0f}")
@@ -96,21 +77,13 @@ Here's a full script with validation, error handling, and export:
 from datetime import date
 from pathlib import Path
 
-from rwa_calc.api import (
-    RWAService,
-    CalculationRequest,
-    create_service,
-)
+from rwa_calc.api import CreditRiskCalc
 
 
 def calculate_rwa():
-    """Calculate RWA for credit exposures using the Service API."""
+    """Calculate RWA for credit exposures."""
 
-    # Create the service (cache_dir defaults to a temp directory)
-    service = create_service()
-
-    # Build request
-    request = CalculationRequest(
+    calc = CreditRiskCalc(
         data_path="/path/to/data",
         framework="CRR",
         reporting_date=date(2026, 12, 31),
@@ -118,7 +91,7 @@ def calculate_rwa():
     )
 
     # Run calculation
-    response = service.calculate(request)
+    response = calc.calculate()
 
     # Check for errors
     if not response.success:
@@ -166,23 +139,18 @@ if __name__ == "__main__":
 
 ### Specifying Data Format
 
-By default, the service reads Parquet files. To use CSV:
+By default, the calculator reads Parquet files. To use CSV:
 
 ```python
-from rwa_calc.api import quick_calculate
+from datetime import date
+from rwa_calc.api import CreditRiskCalc
 
-response = quick_calculate("/path/to/csv-data", data_format="csv")
-```
-
-Or with `CalculationRequest`:
-
-```python
-request = CalculationRequest(
+response = CreditRiskCalc(
     data_path="/path/to/csv-data",
-    data_format="csv",
     framework="CRR",
     reporting_date=date(2026, 12, 31),
-)
+    data_format="csv",
+).calculate()
 ```
 
 ### Required Data Files
@@ -205,13 +173,16 @@ The calculator expects the following files in your data directory:
 ### Validating Data Before Calculation
 
 ```python
-from rwa_calc.api import create_service, ValidationRequest
+from datetime import date
+from rwa_calc.api import CreditRiskCalc
 
-service = create_service()
-validation = service.validate_data_path(
-    ValidationRequest(data_path="/path/to/data")
+calc = CreditRiskCalc(
+    data_path="/path/to/data",
+    framework="CRR",
+    reporting_date=date(2026, 12, 31),
 )
 
+validation = calc.validate()
 if validation.valid:
     print(f"Ready: {validation.found_count} files found")
 else:
@@ -223,30 +194,36 @@ else:
 ### CRR Framework
 
 ```python
-from rwa_calc.api import quick_calculate
+from datetime import date
+from rwa_calc.api import CreditRiskCalc
 
 # CRR with default settings
-response = quick_calculate("/path/to/data", framework="CRR")
+response = CreditRiskCalc(
+    data_path="/path/to/data",
+    framework="CRR",
+    reporting_date=date(2026, 12, 31),
+).calculate()
 
 # CRR with IRB routing (requires model_permissions input data)
-response = quick_calculate(
-    "/path/to/data",
+response = CreditRiskCalc(
+    data_path="/path/to/data",
     framework="CRR",
     reporting_date=date(2026, 12, 31),
     permission_mode="irb",
-)
+).calculate()
 ```
 
 ### Basel 3.1 Framework
 
 ```python
-from rwa_calc.api import quick_calculate
+from datetime import date
+from rwa_calc.api import CreditRiskCalc
 
-response = quick_calculate(
-    "/path/to/data",
+response = CreditRiskCalc(
+    data_path="/path/to/data",
     framework="BASEL_3_1",
     reporting_date=date(2027, 1, 1),
-)
+).calculate()
 ```
 
 ### Permission Mode
@@ -268,8 +245,6 @@ The `CalculationResponse` provides several ways to access results:
 ### Summary Statistics
 
 ```python
-response = quick_calculate("/path/to/data")
-
 summary = response.summary
 summary.total_rwa           # Total risk-weighted assets
 summary.total_ead           # Total exposure at default
@@ -328,8 +303,6 @@ response.to_corep(Path("output/corep.xlsx"))
 The calculator accumulates errors rather than failing fast:
 
 ```python
-response = quick_calculate("/path/to/data")
-
 # Check overall success
 if not response.success:
     print("Calculation failed")

--- a/docs/specifications/interfaces.md
+++ b/docs/specifications/interfaces.md
@@ -4,7 +4,7 @@
 
 | ID | Requirement | Priority | Status |
 |----|-------------|----------|--------|
-| FR-6.1 | Python API: `create_pipeline()` and `RWAService` for programmatic access | P0 | Done |
+| FR-6.1 | Python API: `create_pipeline()` and `CreditRiskCalc` for programmatic access | P0 | Done |
 | FR-6.2 | Interactive web UI via Marimo for scenario analysis, exploration, and dual-framework comparison | P1 | Done |
 | FR-6.3 | CLI entry point (`rwa-calc-ui`) for launching the web interface | P2 | Done |
 | FR-6.4 | API input validation with clear error messages | P1 | Done |
@@ -12,7 +12,7 @@
 ## Python API
 
 - `create_pipeline()` — primary entry point for programmatic RWA calculation
-- `RWAService` — higher-level service wrapper
+- `CreditRiskCalc` — higher-level service wrapper
 
 ## Marimo Web UI
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -98,13 +98,23 @@ config = CalculationConfig.crr(
 When using the Service API, pass the string values `"standardised"` or `"irb"`:
 
 ```python
-from rwa_calc.api import quick_calculate
+from datetime import date
+from rwa_calc.api import CreditRiskCalc
 
 # SA-only (default)
-response = quick_calculate("/path/to/data")
+response = CreditRiskCalc(
+    data_path="/path/to/data",
+    framework="CRR",
+    reporting_date=date(2026, 12, 31),
+).calculate()
 
 # IRB mode
-response = quick_calculate("/path/to/data", permission_mode="irb")
+response = CreditRiskCalc(
+    data_path="/path/to/data",
+    framework="CRR",
+    reporting_date=date(2026, 12, 31),
+    permission_mode="irb",
+).calculate()
 ```
 
 !!! note "Model permissions required for IRB mode"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,12 @@ python-version = "3.13"
 
 [tool.ty.src]
 # Marimo UI module excluded from type checking (equivalent to mypy ignore_errors)
-exclude = ["src/rwa_calc/ui/marimo/"]
+exclude = [
+    "src/rwa_calc/ui/marimo/",
+    "workbooks",
+    "tests/fixtures/generate_all.py",
+    "tests/fixtures/*/generate_all.py",
+]
 
 [tool.ty.rules]
 # Polars custom namespaces (register_lazyframe_namespace) produce false positives

--- a/src/rwa_calc/api/__init__.py
+++ b/src/rwa_calc/api/__init__.py
@@ -2,25 +2,21 @@
 RWA Calculator API Module.
 
 Public API for RWA calculations providing:
-- RWAService: Main service facade for calculations
-- Request/Response models: Clean interface contracts
+- CreditRiskCalc: Single entry point for calculations
+- Response models: Clean interface contracts
 - ResultsCache: Memory-efficient parquet caching
 - Validation utilities: Data path validation
 
 Usage:
-    from rwa_calc.api import RWAService, CalculationRequest
     from datetime import date
-    from pathlib import Path
+    from rwa_calc.api import CreditRiskCalc
 
-    service = RWAService(cache_dir=Path(".cache"))
-    response = service.calculate(
-        CalculationRequest(
-            data_path="/path/to/data",
-            framework="CRR",
-            reporting_date=date(2024, 12, 31),
-            permission_mode="irb",
-        )
-    )
+    response = CreditRiskCalc(
+        data_path="/path/to/data",
+        framework="CRR",
+        reporting_date=date(2024, 12, 31),
+        permission_mode="irb",
+    ).calculate()
 
     if response.success:
         print(f"Total RWA: {response.summary.total_rwa:,.0f}")
@@ -34,7 +30,6 @@ from rwa_calc.api.export import (
 )
 from rwa_calc.api.models import (
     APIError,
-    CalculationRequest,
     CalculationResponse,
     PerformanceMetrics,
     SummaryStatistics,
@@ -46,9 +41,9 @@ from rwa_calc.api.results_cache import (
     ResultsCache,
 )
 from rwa_calc.api.service import (
-    RWAService,
-    create_service,
-    quick_calculate,
+    CreditRiskCalc,
+    get_default_config,
+    get_supported_frameworks,
 )
 from rwa_calc.api.validation import (
     DataPathValidator,
@@ -58,11 +53,11 @@ from rwa_calc.api.validation import (
 
 __all__ = [
     # Service
-    "RWAService",
-    "create_service",
-    "quick_calculate",
+    "CreditRiskCalc",
+    # Utilities
+    "get_supported_frameworks",
+    "get_default_config",
     # Request models
-    "CalculationRequest",
     "ValidationRequest",
     # Response models
     "CalculationResponse",

--- a/src/rwa_calc/api/models.py
+++ b/src/rwa_calc/api/models.py
@@ -1,8 +1,7 @@
 """
 API request and response models for RWA Calculator.
 
-RWAService uses these models for clean interface contracts:
-- CalculationRequest: Input parameters for RWA calculation
+Models for clean interface contracts:
 - ValidationRequest: Input for data path validation
 - CalculationResponse: Calculation results with summary statistics
 - ValidationResponse: Data path validation results
@@ -30,51 +29,7 @@ if TYPE_CHECKING:
 
 
 @dataclass(frozen=True)
-class BaseRequest:
-    """Base class for API requests involving file paths."""
-
-    data_path: str | Path
-
-    @property
-    def path(self) -> Path:
-        """Get data_path as Path object."""
-        return Path(self.data_path)
-
-
-@dataclass(frozen=True)
-class CalculationRequest(BaseRequest):
-    """
-    Request model for RWA calculation.
-
-    Encapsulates all parameters needed to run a calculation,
-    providing a clean API surface for callers.
-
-    Attributes:
-        data_path: Path to directory containing input data files
-        framework: Regulatory framework ("CRR" or "BASEL_3_1")
-        reporting_date: As-of date for the calculation
-        base_currency: Currency for reporting (default GBP)
-        permission_mode: "standardised" (all SA) or "irb" (model permissions drive routing)
-        data_format: Format of input files ("parquet" or "csv")
-        eur_gbp_rate: EUR/GBP exchange rate for threshold conversion
-
-    When ``permission_mode`` is ``"irb"``, approach routing is driven by the
-    ``model_permissions`` input table. Each model's approved approach (AIRB,
-    FIRB, slotting) is resolved per-exposure. Exposures without a matching
-    model permission fall back to SA. If no ``model_permissions`` file exists,
-    all exposures fall back to SA with a warning.
-    """
-
-    framework: Literal["CRR", "BASEL_3_1"]
-    reporting_date: date
-    base_currency: str = "GBP"
-    permission_mode: Literal["standardised", "irb"] = "standardised"
-    data_format: Literal["parquet", "csv"] = "parquet"
-    eur_gbp_rate: Decimal = field(default_factory=lambda: Decimal("0.8732"))
-
-
-@dataclass(frozen=True)
-class ValidationRequest(BaseRequest):
+class ValidationRequest:
     """
     Request model for data path validation.
 
@@ -86,7 +41,13 @@ class ValidationRequest(BaseRequest):
         data_format: Expected format of files ("parquet" or "csv")
     """
 
+    data_path: str | Path
     data_format: Literal["parquet", "csv"] = "parquet"
+
+    @property
+    def path(self) -> Path:
+        """Get data_path as Path object."""
+        return Path(self.data_path)
 
 
 # =============================================================================

--- a/src/rwa_calc/api/service.py
+++ b/src/rwa_calc/api/service.py
@@ -1,25 +1,27 @@
 """
 RWA Calculator API Service.
 
-RWAService provides a clean facade for RWA calculations:
-- calculate: Run RWA calculation with pre-validated data
-- validate_data_path: Check data directory before calculation
-- get_supported_frameworks: List available regulatory frameworks
-- get_default_config: Get default configuration for a framework
+CreditRiskCalc is the single entry point for RWA calculations:
 
-This is the main entry point for UI and CLI integration.
+    from rwa_calc.api import CreditRiskCalc
+
+    response = CreditRiskCalc(
+        data_path="/path/to/data",
+        framework="CRR",
+        reporting_date=date(2024, 12, 31),
+    ).calculate()
 """
 
 from __future__ import annotations
 
 from datetime import date, datetime
+from decimal import Decimal
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 from rwa_calc.api.errors import create_load_error
 from rwa_calc.api.formatters import ResultFormatter
 from rwa_calc.api.models import (
-    CalculationRequest,
     CalculationResponse,
     ValidationRequest,
     ValidationResponse,
@@ -28,17 +30,17 @@ from rwa_calc.api.results_cache import ResultsCache
 from rwa_calc.api.validation import DataPathValidator
 
 # =============================================================================
-# RWA Service
+# CreditRiskCalc
 # =============================================================================
 
 
-class RWAService:
+class CreditRiskCalc:
     """
-    High-level service for RWA calculations.
+    Single entry point for credit risk RWA calculations.
 
-    Wraps the PipelineOrchestrator with a clean API surface suitable
-    for UI integration. Handles configuration setup, data loading,
-    and result formatting.
+    Encapsulates all parameters and orchestration needed to run a calculation.
+    Handles configuration setup, data loading, pipeline execution, and result
+    formatting.
 
     Permission Modes:
         - **standardised**: All exposures use SA. Model permissions ignored.
@@ -49,44 +51,55 @@ class RWAService:
           all exposures fall back to SA with a warning.
 
     Usage:
-        from rwa_calc.api import RWAService, CalculationRequest
         from datetime import date
+        from rwa_calc.api import CreditRiskCalc
 
-        service = RWAService()
-        response = service.calculate(
-            CalculationRequest(
-                data_path="/path/to/data",
-                framework="CRR",
-                reporting_date=date(2024, 12, 31),
-                permission_mode="irb",
-            )
-        )
+        response = CreditRiskCalc(
+            data_path="/path/to/data",
+            framework="CRR",
+            reporting_date=date(2024, 12, 31),
+            permission_mode="irb",
+        ).calculate()
 
         if response.success:
             print(f"Total RWA: {response.summary.total_rwa:,.0f}")
             print(response.collect_results())
     """
 
-    def __init__(self, cache_dir: Path) -> None:
-        """
-        Initialize RWAService with cache directory.
+    def __init__(
+        self,
+        data_path: str | Path,
+        framework: Literal["CRR", "BASEL_3_1"],
+        reporting_date: date,
+        permission_mode: Literal["standardised", "irb"] = "standardised",
+        data_format: Literal["parquet", "csv"] = "parquet",
+        base_currency: str = "GBP",
+        eur_gbp_rate: Decimal = Decimal("0.8732"),
+        cache_dir: Path | None = None,
+    ) -> None:
+        self.data_path = Path(data_path)
+        self.framework = framework
+        self.reporting_date = reporting_date
+        self.permission_mode = permission_mode
+        self.data_format = data_format
+        self.base_currency = base_currency
+        self.eur_gbp_rate = eur_gbp_rate
 
-        Args:
-            cache_dir: Directory for caching results as parquet files
-        """
+        if cache_dir is None:
+            import tempfile
+
+            cache_dir = Path(tempfile.mkdtemp(prefix="rwa_cache_"))
+
         self._validator = DataPathValidator()
         self._formatter = ResultFormatter()
         self._cache = ResultsCache(cache_dir)
 
-    def calculate(self, request: CalculationRequest) -> CalculationResponse:
+    def calculate(self) -> CalculationResponse:
         """
-        Run RWA calculation with the specified parameters.
+        Run the RWA calculation.
 
-        Creates pipeline configuration from request, loads data,
-        runs calculation, and formats results.
-
-        Args:
-            request: CalculationRequest with all parameters
+        Creates pipeline configuration, loads data, runs calculation,
+        and formats results.
 
         Returns:
             CalculationResponse with results or errors
@@ -95,22 +108,22 @@ class RWAService:
 
         validation = self._validator.validate(
             ValidationRequest(
-                data_path=request.data_path,
-                data_format=request.data_format,
+                data_path=self.data_path,
+                data_format=self.data_format,
             )
         )
         if not validation.valid:
             return self._formatter.format_error_response(
                 errors=validation.errors,
                 cache=self._cache,
-                framework=request.framework,
-                reporting_date=request.reporting_date,
+                framework=self.framework,
+                reporting_date=self.reporting_date,
                 started_at=started_at,
             )
 
         try:
-            config = self._create_config(request)
-            loader = self._create_loader(request)
+            config = self._create_config()
+            loader = self._create_loader()
             pipeline = self._create_pipeline(loader)
 
             result_bundle = pipeline.run(config)
@@ -118,8 +131,8 @@ class RWAService:
             return self._formatter.format_response(
                 bundle=result_bundle,
                 cache=self._cache,
-                framework=request.framework,
-                reporting_date=request.reporting_date,
+                framework=self.framework,
+                reporting_date=self.reporting_date,
                 started_at=started_at,
             )
 
@@ -128,138 +141,57 @@ class RWAService:
             return self._formatter.format_error_response(
                 errors=[error],
                 cache=self._cache,
-                framework=request.framework,
-                reporting_date=request.reporting_date,
+                framework=self.framework,
+                reporting_date=self.reporting_date,
                 started_at=started_at,
             )
 
-    def validate_data_path(self, request: ValidationRequest) -> ValidationResponse:
+    def validate(self) -> ValidationResponse:
         """
-        Validate a data path for calculation readiness.
+        Validate the data path for calculation readiness.
 
         Checks that the directory exists and contains required files.
-
-        Args:
-            request: ValidationRequest with path and format
 
         Returns:
             ValidationResponse with validation results
         """
-        return self._validator.validate(request)
+        return self._validator.validate(
+            ValidationRequest(
+                data_path=self.data_path,
+                data_format=self.data_format,
+            )
+        )
 
-    def get_supported_frameworks(self) -> list[dict[str, str]]:
-        """
-        Get list of supported regulatory frameworks.
-
-        Returns:
-            List of framework descriptors with id, name, and description
-        """
-        return [
-            {
-                "id": "CRR",
-                "name": "CRR (Basel 3.0)",
-                "description": "Capital Requirements Regulation - effective until Dec 2026",
-            },
-            {
-                "id": "BASEL_3_1",
-                "name": "Basel 3.1",
-                "description": "PRA PS1/26 UK implementation - effective from Jan 2027",
-            },
-        ]
-
-    def get_default_config(
-        self,
-        framework: Literal["CRR", "BASEL_3_1"],
-        reporting_date: date,
-    ) -> dict:
-        """
-        Get default configuration values for a framework.
-
-        Args:
-            framework: Regulatory framework
-            reporting_date: As-of date for calculation
-
-        Returns:
-            Dictionary of default configuration values
-        """
-        from rwa_calc.contracts.config import CalculationConfig
-
-        if framework == "CRR":
-            config = CalculationConfig.crr(reporting_date=reporting_date)
-        else:
-            config = CalculationConfig.basel_3_1(reporting_date=reporting_date)
-
-        return {
-            "framework": config.framework.value,
-            "reporting_date": config.reporting_date.isoformat(),
-            "base_currency": config.base_currency,
-            "scaling_factor": str(config.scaling_factor),
-            "eur_gbp_rate": str(config.eur_gbp_rate),
-            "pd_floors": {
-                "corporate": str(config.pd_floors.corporate),
-                "retail_mortgage": str(config.pd_floors.retail_mortgage),
-            },
-            "supporting_factors_enabled": config.supporting_factors.enabled,
-            "output_floor_enabled": config.output_floor.enabled,
-            "output_floor_percentage": str(
-                config.output_floor.get_floor_percentage(reporting_date)
-            ),
-        }
-
-    def _create_config(self, request: CalculationRequest) -> CalculationConfig:
-        """
-        Create CalculationConfig from request parameters.
-
-        Args:
-            request: CalculationRequest with parameters
-
-        Returns:
-            Configured CalculationConfig
-        """
+    def _create_config(self) -> CalculationConfig:
+        """Create CalculationConfig from instance parameters."""
         from rwa_calc.contracts.config import CalculationConfig
         from rwa_calc.domain.enums import PermissionMode
 
-        mode = PermissionMode(request.permission_mode)
+        mode = PermissionMode(self.permission_mode)
 
-        if request.framework == "CRR":
+        if self.framework == "CRR":
             return CalculationConfig.crr(
-                reporting_date=request.reporting_date,
+                reporting_date=self.reporting_date,
                 permission_mode=mode,
-                eur_gbp_rate=request.eur_gbp_rate,
+                eur_gbp_rate=self.eur_gbp_rate,
             )
         else:
             return CalculationConfig.basel_3_1(
-                reporting_date=request.reporting_date,
+                reporting_date=self.reporting_date,
                 permission_mode=mode,
             )
 
-    def _create_loader(self, request: CalculationRequest) -> LoaderProtocol:
-        """
-        Create data loader based on request format.
-
-        Args:
-            request: CalculationRequest with data path and format
-
-        Returns:
-            Appropriate loader instance
-        """
+    def _create_loader(self) -> LoaderProtocol:
+        """Create data loader based on data format."""
         from rwa_calc.engine.loader import CSVLoader, ParquetLoader
 
-        if request.data_format == "csv":
-            return CSVLoader(base_path=request.path)
+        if self.data_format == "csv":
+            return CSVLoader(base_path=self.data_path)
         else:
-            return ParquetLoader(base_path=request.path)
+            return ParquetLoader(base_path=self.data_path)
 
     def _create_pipeline(self, loader: LoaderProtocol) -> PipelineOrchestrator:
-        """
-        Create pipeline orchestrator with loader.
-
-        Args:
-            loader: Data loader instance
-
-        Returns:
-            Configured PipelineOrchestrator
-        """
+        """Create pipeline orchestrator with loader."""
         from rwa_calc.engine.pipeline import PipelineOrchestrator
 
         return PipelineOrchestrator(loader=loader)
@@ -277,61 +209,63 @@ if TYPE_CHECKING:
 
 
 # =============================================================================
-# Convenience Functions
+# Module-Level Utilities
 # =============================================================================
 
 
-def create_service(cache_dir: Path | None = None) -> RWAService:
+def get_supported_frameworks() -> list[dict[str, str]]:
     """
-    Factory function to create RWAService instance.
-
-    Args:
-        cache_dir: Directory for caching results. Defaults to a temp directory.
+    Get list of supported regulatory frameworks.
 
     Returns:
-        Configured RWAService
+        List of framework descriptors with id, name, and description
     """
-    if cache_dir is None:
-        import tempfile
+    return [
+        {
+            "id": "CRR",
+            "name": "CRR (Basel 3.0)",
+            "description": "Capital Requirements Regulation - effective until Dec 2026",
+        },
+        {
+            "id": "BASEL_3_1",
+            "name": "Basel 3.1",
+            "description": "PRA PS1/26 UK implementation - effective from Jan 2027",
+        },
+    ]
 
-        cache_dir = Path(tempfile.mkdtemp(prefix="rwa_cache_"))
-    return RWAService(cache_dir=cache_dir)
 
-
-def quick_calculate(
-    data_path: str | Path,
-    framework: Literal["CRR", "BASEL_3_1"] = "CRR",
-    reporting_date: date | None = None,
-    permission_mode: Literal["standardised", "irb"] = "standardised",
-    data_format: Literal["parquet", "csv"] = "parquet",
-    cache_dir: Path | None = None,
-) -> CalculationResponse:
+def get_default_config(
+    framework: Literal["CRR", "BASEL_3_1"],
+    reporting_date: date,
+) -> dict:
     """
-    Run a quick calculation with minimal configuration.
-
-    Convenience function for simple use cases.
+    Get default configuration values for a framework.
 
     Args:
-        data_path: Path to data directory
         framework: Regulatory framework
-        reporting_date: As-of date (defaults to today)
-        permission_mode: "standardised" (all SA) or "irb" (model permissions drive routing)
-        data_format: Format of input files
-        cache_dir: Directory for caching results. Defaults to a temp directory.
+        reporting_date: As-of date for calculation
 
     Returns:
-        CalculationResponse with results
-
-    Example:
-        response = quick_calculate("/path/to/data", framework="CRR")
-        print(f"Total RWA: {response.summary.total_rwa:,.0f}")
+        Dictionary of default configuration values
     """
-    service = create_service(cache_dir=cache_dir)
-    request = CalculationRequest(
-        data_path=data_path,
-        framework=framework,
-        reporting_date=reporting_date or date.today(),
-        permission_mode=permission_mode,
-        data_format=data_format,
-    )
-    return service.calculate(request)
+    from rwa_calc.contracts.config import CalculationConfig
+
+    if framework == "CRR":
+        config = CalculationConfig.crr(reporting_date=reporting_date)
+    else:
+        config = CalculationConfig.basel_3_1(reporting_date=reporting_date)
+
+    return {
+        "framework": config.framework.value,
+        "reporting_date": config.reporting_date.isoformat(),
+        "base_currency": config.base_currency,
+        "scaling_factor": str(config.scaling_factor),
+        "eur_gbp_rate": str(config.eur_gbp_rate),
+        "pd_floors": {
+            "corporate": str(config.pd_floors.corporate),
+            "retail_mortgage": str(config.pd_floors.retail_mortgage),
+        },
+        "supporting_factors_enabled": config.supporting_factors.enabled,
+        "output_floor_enabled": config.output_floor.enabled,
+        "output_floor_percentage": str(config.output_floor.get_floor_percentage(reporting_date)),
+    }

--- a/src/rwa_calc/engine/materialise.py
+++ b/src/rwa_calc/engine/materialise.py
@@ -90,7 +90,8 @@ def materialise_branches(
         List of DataFrames in the same order as input branches
     """
     if config.collect_engine == "cpu":
-        return pl.collect_all(branches)
+        result: list[pl.DataFrame] = pl.collect_all(branches)
+        return result
 
     # Streaming mode: sink each branch individually
     results: list[pl.DataFrame] = []

--- a/src/rwa_calc/engine/pipeline.py
+++ b/src/rwa_calc/engine/pipeline.py
@@ -231,17 +231,12 @@ class PipelineOrchestrator:
             self._validate_input_data(data)
 
             # IRB mode requires model_permissions data; without it, fall back to SA
-            if (
-                config.permission_mode == PermissionMode.IRB
-                and data.model_permissions is None
-            ):
+            if config.permission_mode == PermissionMode.IRB and data.model_permissions is None:
                 logger.warning(
                     "IRB permission mode selected but no model_permissions data provided. "
                     "All exposures will fall back to Standardised Approach."
                 )
-                config = dataclasses.replace(
-                    config, permission_mode=PermissionMode.STANDARDISED
-                )
+                config = dataclasses.replace(config, permission_mode=PermissionMode.STANDARDISED)
 
             # Stage 2: Resolve hierarchies
             resolved = self._run_hierarchy_resolver(data, config)

--- a/src/rwa_calc/ui/marimo/rwa_app.py
+++ b/src/rwa_calc/ui/marimo/rwa_app.py
@@ -1,7 +1,7 @@
 """
 RWA Calculator Marimo Application.
 
-Interactive UI for running RWA calculations using the RWAService API.
+Interactive UI for running RWA calculations using the CreditRiskCalc API.
 
 Usage:
     uv run marimo edit src/rwa_calc/ui/marimo/rwa_app.py
@@ -229,28 +229,25 @@ def _(
 ):
     from datetime import date as date_type
 
-    from rwa_calc.api import CalculationRequest, RWAService
+    from rwa_calc.api import CreditRiskCalc
 
     calculation_response = None
     calculation_error = None
 
     if run_button.value:
         try:
-            service = RWAService(cache_dir=cache_dir)
-
             rd = reporting_date_input.value
             if not isinstance(rd, date_type):
                 rd = date_type.fromisoformat(str(rd))
 
-            request = CalculationRequest(
+            calculation_response = CreditRiskCalc(
                 data_path=data_path_input.value,
                 framework=framework_dropdown.value,
                 reporting_date=rd,
-                irb_approach=irb_approach_dropdown.value,
+                permission_mode=irb_approach_dropdown.value,
                 data_format=format_dropdown.value,
-            )
-
-            calculation_response = service.calculate(request)
+                cache_dir=cache_dir,
+            ).calculate()
 
         except Exception as e:
             calculation_error = str(e)

--- a/tests/acceptance/basel31/conftest.py
+++ b/tests/acceptance/basel31/conftest.py
@@ -373,11 +373,9 @@ def irb_raw_data_bundle(load_test_fixtures):
     Enriches internal ratings with model_id and creates full-coverage
     model_permissions so the pipeline routes exposures to IRB approaches.
     """
-    from rwa_calc.contracts.bundles import RawDataBundle
 
     from tests.fixtures.irb_test_helpers import (
         create_full_irb_model_permissions,
-        enrich_ratings_with_model_id,
     )
 
     fixtures = load_test_fixtures
@@ -407,9 +405,9 @@ def slotting_raw_data_bundle(load_test_fixtures):
 
 def _make_irb_bundle(fixtures, model_permissions):
     """Build RawDataBundle with enriched ratings and given model_permissions."""
-    from rwa_calc.contracts.bundles import RawDataBundle
-
     from tests.fixtures.irb_test_helpers import enrich_ratings_with_model_id
+
+    from rwa_calc.contracts.bundles import RawDataBundle
 
     return RawDataBundle(
         facilities=fixtures.facilities,

--- a/tests/acceptance/comparison/conftest.py
+++ b/tests/acceptance/comparison/conftest.py
@@ -121,7 +121,6 @@ def raw_data_bundle(load_test_fixtures):
 @pytest.fixture(scope="session")
 def irb_raw_data_bundle(load_test_fixtures):
     """Convert test fixtures to RawDataBundle with model permissions for IRB testing."""
-    from rwa_calc.contracts.bundles import RawDataBundle
 
     from tests.fixtures.irb_test_helpers import create_firb_only_model_permissions
 
@@ -130,9 +129,9 @@ def irb_raw_data_bundle(load_test_fixtures):
 
 def _make_irb_bundle(fixtures, model_permissions):
     """Build RawDataBundle with enriched ratings and given model_permissions."""
-    from rwa_calc.contracts.bundles import RawDataBundle
-
     from tests.fixtures.irb_test_helpers import enrich_ratings_with_model_id
+
+    from rwa_calc.contracts.bundles import RawDataBundle
 
     return RawDataBundle(
         facilities=fixtures.facilities,

--- a/tests/acceptance/comparison/test_scenario_m32_capital_impact.py
+++ b/tests/acceptance/comparison/test_scenario_m32_capital_impact.py
@@ -146,7 +146,7 @@ class TestM32_FIRB_Attribution:
     ) -> None:
         """M3.2-F5: Output floor can only add RWA, never reduce it."""
         min_floor = firb_impact_attribution_df["output_floor_impact"].min()
-        assert min_floor >= -1.0  # Tolerance for floating point
+        assert float(min_floor) >= -1.0  # Tolerance for floating point
 
 
 # =============================================================================

--- a/tests/acceptance/crr/conftest.py
+++ b/tests/acceptance/crr/conftest.py
@@ -439,7 +439,6 @@ def irb_raw_data_bundle(load_test_fixtures):
     """
     Convert test fixtures to RawDataBundle with model permissions for IRB testing.
     """
-    from rwa_calc.contracts.bundles import RawDataBundle
 
     from tests.fixtures.irb_test_helpers import create_full_irb_model_permissions
 
@@ -456,9 +455,9 @@ def slotting_raw_data_bundle(load_test_fixtures):
 
 def _make_irb_bundle(fixtures, model_permissions):
     """Build RawDataBundle with enriched ratings and given model_permissions."""
-    from rwa_calc.contracts.bundles import RawDataBundle
-
     from tests.fixtures.irb_test_helpers import enrich_ratings_with_model_id
+
+    from rwa_calc.contracts.bundles import RawDataBundle
 
     return RawDataBundle(
         facilities=fixtures.facilities,

--- a/tests/benchmarks/profile_stages.py
+++ b/tests/benchmarks/profile_stages.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import argparse
 import time
 from datetime import date
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar
 
 import polars as pl
 
@@ -47,7 +47,11 @@ from rwa_calc.engine.slotting.calculator import SlottingCalculator
 from rwa_calc.engine.utils import has_required_columns
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from rwa_calc.contracts.bundles import ClassifiedExposuresBundle, RawDataBundle
+
+_T = TypeVar("_T")
 
 
 # ---------------------------------------------------------------------------
@@ -55,7 +59,7 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 
-def _time(fn, label: str, results: list[tuple[str, float]]) -> object:
+def _time(fn: Callable[[], _T], label: str, results: list[tuple[str, float]]) -> _T:
     """Time a function call, append (label, elapsed_ms) to results, return fn result."""
     t0 = time.perf_counter()
     result = fn()

--- a/tests/contracts/test_validation.py
+++ b/tests/contracts/test_validation.py
@@ -579,6 +579,7 @@ class TestValidateBundleValues:
         errors = validate_bundle_values(bundle)
 
         assert len(errors) == 1
+        assert errors[0].field_name is not None
         assert "entity_type" in errors[0].field_name
         assert "INVALID_TYPE" in errors[0].message
 

--- a/tests/fixtures/irb_test_helpers.py
+++ b/tests/fixtures/irb_test_helpers.py
@@ -45,29 +45,37 @@ def create_full_irb_model_permissions() -> pl.LazyFrame:
             ExposureClass.RETAIL_QRRE,
             ExposureClass.RETAIL_OTHER,
         ):
-            rows.append({
+            rows.append(
+                {
+                    "model_id": _TEST_MODEL_ID,
+                    "exposure_class": ec.value,
+                    "approach": ApproachType.FIRB.value,
+                }
+            )
+        # Grant AIRB
+        rows.append(
+            {
                 "model_id": _TEST_MODEL_ID,
                 "exposure_class": ec.value,
-                "approach": ApproachType.FIRB.value,
-            })
-        # Grant AIRB
-        rows.append({
-            "model_id": _TEST_MODEL_ID,
-            "exposure_class": ec.value,
-            "approach": ApproachType.AIRB.value,
-        })
+                "approach": ApproachType.AIRB.value,
+            }
+        )
     # Grant slotting for specialised lending
-    rows.append({
-        "model_id": _TEST_MODEL_ID,
-        "exposure_class": ExposureClass.SPECIALISED_LENDING.value,
-        "approach": ApproachType.SLOTTING.value,
-    })
+    rows.append(
+        {
+            "model_id": _TEST_MODEL_ID,
+            "exposure_class": ExposureClass.SPECIALISED_LENDING.value,
+            "approach": ApproachType.SLOTTING.value,
+        }
+    )
 
-    return pl.LazyFrame(rows).cast({
-        "model_id": pl.String,
-        "exposure_class": pl.String,
-        "approach": pl.String,
-    })
+    return pl.LazyFrame(rows).cast(
+        {
+            "model_id": pl.String,
+            "exposure_class": pl.String,
+            "approach": pl.String,
+        }
+    )
 
 
 def create_firb_only_model_permissions() -> pl.LazyFrame:
@@ -84,23 +92,29 @@ def create_firb_only_model_permissions() -> pl.LazyFrame:
             ExposureClass.RETAIL_OTHER,
         ):
             continue  # FIRB not permitted for retail
-        rows.append({
-            "model_id": _TEST_MODEL_ID,
-            "exposure_class": ec.value,
-            "approach": ApproachType.FIRB.value,
-        })
+        rows.append(
+            {
+                "model_id": _TEST_MODEL_ID,
+                "exposure_class": ec.value,
+                "approach": ApproachType.FIRB.value,
+            }
+        )
     # Slotting for specialised lending
-    rows.append({
-        "model_id": _TEST_MODEL_ID,
-        "exposure_class": ExposureClass.SPECIALISED_LENDING.value,
-        "approach": ApproachType.SLOTTING.value,
-    })
+    rows.append(
+        {
+            "model_id": _TEST_MODEL_ID,
+            "exposure_class": ExposureClass.SPECIALISED_LENDING.value,
+            "approach": ApproachType.SLOTTING.value,
+        }
+    )
 
-    return pl.LazyFrame(rows).cast({
-        "model_id": pl.String,
-        "exposure_class": pl.String,
-        "approach": pl.String,
-    })
+    return pl.LazyFrame(rows).cast(
+        {
+            "model_id": pl.String,
+            "exposure_class": pl.String,
+            "approach": pl.String,
+        }
+    )
 
 
 def create_slotting_only_model_permissions() -> pl.LazyFrame:
@@ -108,16 +122,20 @@ def create_slotting_only_model_permissions() -> pl.LazyFrame:
 
     Used for slotting-specific acceptance tests.
     """
-    rows = [{
-        "model_id": _TEST_MODEL_ID,
-        "exposure_class": ExposureClass.SPECIALISED_LENDING.value,
-        "approach": ApproachType.SLOTTING.value,
-    }]
-    return pl.LazyFrame(rows).cast({
-        "model_id": pl.String,
-        "exposure_class": pl.String,
-        "approach": pl.String,
-    })
+    rows = [
+        {
+            "model_id": _TEST_MODEL_ID,
+            "exposure_class": ExposureClass.SPECIALISED_LENDING.value,
+            "approach": ApproachType.SLOTTING.value,
+        }
+    ]
+    return pl.LazyFrame(rows).cast(
+        {
+            "model_id": pl.String,
+            "exposure_class": pl.String,
+            "approach": pl.String,
+        }
+    )
 
 
 def enrich_ratings_with_model_id(ratings: pl.LazyFrame) -> pl.LazyFrame:
@@ -127,9 +145,7 @@ def enrich_ratings_with_model_id(ratings: pl.LazyFrame) -> pl.LazyFrame:
     so they can be matched against model_permissions.
     """
     return ratings.with_columns(
-        pl.when(
-            (pl.col("rating_type") == "internal") & pl.col("model_id").is_null()
-        )
+        pl.when((pl.col("rating_type") == "internal") & pl.col("model_id").is_null())
         .then(pl.lit(_TEST_MODEL_ID))
         .otherwise(pl.col("model_id"))
         .alias("model_id")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -22,7 +22,6 @@ import pytest
 
 from rwa_calc.contracts.bundles import RawDataBundle
 from rwa_calc.contracts.config import CalculationConfig
-from rwa_calc.domain.enums import PermissionMode
 from rwa_calc.data.schemas import (
     CONTINGENTS_SCHEMA,
     COUNTERPARTY_SCHEMA,
@@ -35,6 +34,7 @@ from rwa_calc.data.schemas import (
     ORG_MAPPING_SCHEMA,
     RATINGS_SCHEMA,
 )
+from rwa_calc.domain.enums import PermissionMode
 from rwa_calc.engine.classifier import ExposureClassifier
 from rwa_calc.engine.crm.processor import CRMProcessor
 from rwa_calc.engine.equity.calculator import EquityCalculator

--- a/tests/integration/test_hierarchy_to_classifier.py
+++ b/tests/integration/test_hierarchy_to_classifier.py
@@ -41,7 +41,8 @@ def _run_pipeline(
     """Run hierarchy + classifier and collect all_exposures."""
     resolved = resolver.resolve(bundle, config)
     classified = classifier.classify(resolved, config)
-    return classified.all_exposures.collect()
+    result: pl.DataFrame = classified.all_exposures.collect()
+    return result
 
 
 # =============================================================================

--- a/tests/integration/test_model_permissions_pipeline.py
+++ b/tests/integration/test_model_permissions_pipeline.py
@@ -100,7 +100,8 @@ def _run_to_classified(
     """Run hierarchy + classifier and collect all_exposures."""
     resolved = resolver.resolve(bundle, config)
     classified = classifier.classify(resolved, config)
-    return classified.all_exposures.collect()
+    result: pl.DataFrame = classified.all_exposures.collect()
+    return result
 
 
 # =============================================================================

--- a/tests/unit/api/test_export.py
+++ b/tests/unit/api/test_export.py
@@ -32,8 +32,10 @@ from rwa_calc.api.results_cache import ResultsCache
 # Fixtures
 # =============================================================================
 
+import importlib.util
+
 XLSXWRITER_AVAILABLE = bool(sys.modules.get("xlsxwriter")) or (
-    __import__("importlib").util.find_spec("xlsxwriter") is not None
+    importlib.util.find_spec("xlsxwriter") is not None
 )
 
 

--- a/tests/unit/api/test_models.py
+++ b/tests/unit/api/test_models.py
@@ -1,7 +1,6 @@
 """Unit tests for the API models module.
 
 Tests cover:
-- CalculationRequest dataclass
 - ValidationRequest dataclass
 - SummaryStatistics dataclass
 - APIError dataclass
@@ -21,85 +20,12 @@ import pytest
 
 from rwa_calc.api.models import (
     APIError,
-    CalculationRequest,
     CalculationResponse,
     PerformanceMetrics,
     SummaryStatistics,
     ValidationRequest,
     ValidationResponse,
 )
-
-# =============================================================================
-# CalculationRequest Tests
-# =============================================================================
-
-
-class TestCalculationRequest:
-    """Tests for CalculationRequest dataclass."""
-
-    def test_create_with_required_fields(self) -> None:
-        """Request should be created with required fields."""
-        request = CalculationRequest(
-            data_path="/path/to/data",
-            framework="CRR",
-            reporting_date=date(2024, 12, 31),
-        )
-        assert request.data_path == "/path/to/data"
-        assert request.framework == "CRR"
-        assert request.reporting_date == date(2024, 12, 31)
-
-    def test_default_values(self) -> None:
-        """Default values should be set correctly."""
-        request = CalculationRequest(
-            data_path="/path/to/data",
-            framework="CRR",
-            reporting_date=date(2024, 12, 31),
-        )
-        assert request.base_currency == "GBP"
-        assert request.permission_mode == "standardised"
-        assert request.data_format == "parquet"
-        assert request.eur_gbp_rate == Decimal("0.8732")
-
-    def test_path_property_returns_path_object(self) -> None:
-        """Path property should return Path object."""
-        request = CalculationRequest(
-            data_path="/path/to/data",
-            framework="CRR",
-            reporting_date=date(2024, 12, 31),
-        )
-        assert isinstance(request.path, Path)
-        # Compare parts to handle platform differences
-        assert request.path.parts[-3:] == ("path", "to", "data")
-
-    def test_frozen_dataclass(self) -> None:
-        """Request should be immutable."""
-        request = CalculationRequest(
-            data_path="/path/to/data",
-            framework="CRR",
-            reporting_date=date(2024, 12, 31),
-        )
-        with pytest.raises(AttributeError):  # FrozenInstanceError
-            request.data_path = "/new/path"  # type: ignore
-
-    def test_basel_31_framework(self) -> None:
-        """Should accept BASEL_3_1 framework."""
-        request = CalculationRequest(
-            data_path="/path/to/data",
-            framework="BASEL_3_1",
-            reporting_date=date(2027, 1, 1),
-        )
-        assert request.framework == "BASEL_3_1"
-
-    def test_csv_format(self) -> None:
-        """Should accept csv data format."""
-        request = CalculationRequest(
-            data_path="/path/to/data",
-            framework="CRR",
-            reporting_date=date(2024, 12, 31),
-            data_format="csv",
-        )
-        assert request.data_format == "csv"
-
 
 # =============================================================================
 # ValidationRequest Tests

--- a/tests/unit/api/test_service.py
+++ b/tests/unit/api/test_service.py
@@ -1,9 +1,8 @@
 """Unit tests for the API service module.
 
 Tests cover:
-- RWAService class
-- create_service factory function
-- quick_calculate convenience function
+- CreditRiskCalc class
+- get_supported_frameworks / get_default_config module functions
 """
 
 from __future__ import annotations
@@ -16,15 +15,13 @@ import polars as pl
 import pytest
 
 from rwa_calc.api.models import (
-    CalculationRequest,
     CalculationResponse,
-    ValidationRequest,
     ValidationResponse,
 )
 from rwa_calc.api.service import (
-    RWAService,
-    create_service,
-    quick_calculate,
+    CreditRiskCalc,
+    get_default_config,
+    get_supported_frameworks,
 )
 
 # =============================================================================
@@ -69,119 +66,91 @@ def temp_valid_dir(tmp_path: Path) -> Path:
     return tmp_path
 
 
-@pytest.fixture
-def service(tmp_path: Path) -> RWAService:
-    """Create an RWAService instance with a temp cache directory."""
-    return RWAService(cache_dir=tmp_path / "service_cache")
-
-
 # =============================================================================
-# RWAService Tests
+# CreditRiskCalc Tests
 # =============================================================================
 
 
-class TestRWAServiceInit:
-    """Tests for RWAService initialization."""
+class TestCreditRiskCalcInit:
+    """Tests for CreditRiskCalc initialization."""
 
-    def test_creates_with_default_components(self, tmp_path: Path) -> None:
-        """Should create service with default components."""
-        service = RWAService(cache_dir=tmp_path / "cache")
-        assert service._validator is not None
-        assert service._formatter is not None
-        assert service._cache is not None
-
-
-class TestRWAServiceValidateDataPath:
-    """Tests for RWAService.validate_data_path method."""
-
-    def test_valid_path(self, service: RWAService, temp_valid_dir: Path) -> None:
-        """Should return valid response for valid path."""
-        response = service.validate_data_path(ValidationRequest(data_path=temp_valid_dir))
-        assert isinstance(response, ValidationResponse)
-        assert response.valid is True
-
-    def test_invalid_path(self, service: RWAService, tmp_path: Path) -> None:
-        """Should return invalid response for non-existent path."""
-        response = service.validate_data_path(ValidationRequest(data_path=tmp_path / "nonexistent"))
-        assert response.valid is False
-        assert len(response.errors) > 0
-
-
-class TestRWAServiceGetSupportedFrameworks:
-    """Tests for RWAService.get_supported_frameworks method."""
-
-    def test_returns_frameworks_list(self, service: RWAService) -> None:
-        """Should return list of supported frameworks."""
-        frameworks = service.get_supported_frameworks()
-
-        assert isinstance(frameworks, list)
-        assert len(frameworks) == 2
-
-    def test_includes_crr(self, service: RWAService) -> None:
-        """Should include CRR framework."""
-        frameworks = service.get_supported_frameworks()
-        crr = next((f for f in frameworks if f["id"] == "CRR"), None)
-
-        assert crr is not None
-        assert "Basel 3.0" in crr["name"]
-
-    def test_includes_basel_31(self, service: RWAService) -> None:
-        """Should include Basel 3.1 framework."""
-        frameworks = service.get_supported_frameworks()
-        basel = next((f for f in frameworks if f["id"] == "BASEL_3_1"), None)
-
-        assert basel is not None
-        assert "Basel 3.1" in basel["name"]
-
-
-class TestRWAServiceGetDefaultConfig:
-    """Tests for RWAService.get_default_config method."""
-
-    def test_crr_config(self, service: RWAService) -> None:
-        """Should return CRR default configuration."""
-        config = service.get_default_config(
+    def test_creates_with_required_fields(self) -> None:
+        """Should create instance with required fields."""
+        calc = CreditRiskCalc(
+            data_path="/path/to/data",
             framework="CRR",
             reporting_date=date(2024, 12, 31),
         )
+        assert calc.data_path == Path("/path/to/data")
+        assert calc.framework == "CRR"
+        assert calc.reporting_date == date(2024, 12, 31)
 
-        assert config["framework"] == "CRR"
-        assert config["base_currency"] == "GBP"
-        assert config["supporting_factors_enabled"] is True
-        assert config["output_floor_enabled"] is False
-
-    def test_basel_31_config(self, service: RWAService) -> None:
-        """Should return Basel 3.1 default configuration."""
-        config = service.get_default_config(
-            framework="BASEL_3_1",
-            reporting_date=date(2027, 1, 1),
+    def test_default_values(self) -> None:
+        """Default values should be set correctly."""
+        calc = CreditRiskCalc(
+            data_path="/path/to/data",
+            framework="CRR",
+            reporting_date=date(2024, 12, 31),
         )
+        assert calc.permission_mode == "standardised"
+        assert calc.data_format == "parquet"
+        assert calc.base_currency == "GBP"
 
-        assert config["framework"] == "BASEL_3_1"
-        assert config["supporting_factors_enabled"] is False
-        assert config["output_floor_enabled"] is True
+    def test_creates_internal_components(self) -> None:
+        """Should create internal components."""
+        calc = CreditRiskCalc(
+            data_path="/path/to/data",
+            framework="CRR",
+            reporting_date=date(2024, 12, 31),
+        )
+        assert calc._validator is not None
+        assert calc._formatter is not None
+        assert calc._cache is not None
 
 
-class TestRWAServiceCalculate:
-    """Tests for RWAService.calculate method."""
+class TestCreditRiskCalcValidate:
+    """Tests for CreditRiskCalc.validate method."""
 
-    def test_invalid_path_returns_error(self, service: RWAService, tmp_path: Path) -> None:
-        """Should return error response for invalid path."""
-        request = CalculationRequest(
+    def test_valid_path(self, temp_valid_dir: Path) -> None:
+        """Should return valid response for valid path."""
+        calc = CreditRiskCalc(
+            data_path=temp_valid_dir,
+            framework="CRR",
+            reporting_date=date(2024, 12, 31),
+        )
+        response = calc.validate()
+        assert isinstance(response, ValidationResponse)
+        assert response.valid is True
+
+    def test_invalid_path(self, tmp_path: Path) -> None:
+        """Should return invalid response for non-existent path."""
+        calc = CreditRiskCalc(
             data_path=tmp_path / "nonexistent",
             framework="CRR",
             reporting_date=date(2024, 12, 31),
         )
+        response = calc.validate()
+        assert response.valid is False
+        assert len(response.errors) > 0
 
-        response = service.calculate(request)
 
+class TestCreditRiskCalcCalculate:
+    """Tests for CreditRiskCalc.calculate method."""
+
+    def test_invalid_path_returns_error(self, tmp_path: Path) -> None:
+        """Should return error response for invalid path."""
+        calc = CreditRiskCalc(
+            data_path=tmp_path / "nonexistent",
+            framework="CRR",
+            reporting_date=date(2024, 12, 31),
+            cache_dir=tmp_path / "cache",
+        )
+        response = calc.calculate()
         assert response.success is False
         assert len(response.errors) > 0
 
-    def test_calculation_response_structure(
-        self, service: RWAService, temp_valid_dir: Path
-    ) -> None:
+    def test_calculation_response_structure(self, temp_valid_dir: Path) -> None:
         """Should return properly structured response."""
-        # Mock the pipeline to avoid full calculation
         mock_bundle = MagicMock()
         mock_bundle.results = pl.LazyFrame(
             {
@@ -198,146 +167,141 @@ class TestRWAServiceCalculate:
         mock_bundle.summary_by_approach = None
         mock_bundle.errors = []
 
-        with patch.object(service, "_create_pipeline") as mock_pipeline:
+        calc = CreditRiskCalc(
+            data_path=temp_valid_dir,
+            framework="CRR",
+            reporting_date=date(2024, 12, 31),
+        )
+
+        with patch.object(calc, "_create_pipeline") as mock_pipeline:
             mock_pipeline.return_value.run.return_value = mock_bundle
-
-            request = CalculationRequest(
-                data_path=temp_valid_dir,
-                framework="CRR",
-                reporting_date=date(2024, 12, 31),
-            )
-
-            response = service.calculate(request)
+            response = calc.calculate()
 
             assert isinstance(response, CalculationResponse)
             assert response.framework == "CRR"
             assert response.reporting_date == date(2024, 12, 31)
 
 
-class TestRWAServiceCreateConfig:
-    """Tests for RWAService._create_config method."""
+class TestCreditRiskCalcCreateConfig:
+    """Tests for CreditRiskCalc._create_config method."""
 
-    def test_crr_config(self, service: RWAService) -> None:
+    def test_crr_config(self) -> None:
         """Should create CRR configuration."""
         from rwa_calc.contracts.config import CalculationConfig
 
-        request = CalculationRequest(
+        calc = CreditRiskCalc(
             data_path="/path/to/data",
             framework="CRR",
             reporting_date=date(2024, 12, 31),
         )
-
-        config = service._create_config(request)
+        config = calc._create_config()
 
         assert isinstance(config, CalculationConfig)
         assert config.is_crr
 
-    def test_basel_31_config(self, service: RWAService) -> None:
+    def test_basel_31_config(self) -> None:
         """Should create Basel 3.1 configuration."""
-        request = CalculationRequest(
+        calc = CreditRiskCalc(
             data_path="/path/to/data",
             framework="BASEL_3_1",
             reporting_date=date(2027, 1, 1),
         )
-
-        config = service._create_config(request)
-
+        config = calc._create_config()
         assert config.is_basel_3_1
 
-    def test_irb_enabled(self, service: RWAService) -> None:
+    def test_irb_enabled(self) -> None:
         """Should enable IRB permissions when requested."""
         from rwa_calc.domain.enums import PermissionMode
 
-        request = CalculationRequest(
+        calc = CreditRiskCalc(
             data_path="/path/to/data",
             framework="CRR",
             reporting_date=date(2024, 12, 31),
             permission_mode="irb",
         )
-
-        config = service._create_config(request)
-
+        config = calc._create_config()
         assert config.permission_mode == PermissionMode.IRB
 
 
-class TestRWAServiceCreateLoader:
-    """Tests for RWAService._create_loader method."""
+class TestCreditRiskCalcCreateLoader:
+    """Tests for CreditRiskCalc._create_loader method."""
 
-    def test_parquet_loader(self, service: RWAService, temp_valid_dir: Path) -> None:
+    def test_parquet_loader(self, temp_valid_dir: Path) -> None:
         """Should create ParquetLoader for parquet format."""
         from rwa_calc.engine.loader import ParquetLoader
 
-        request = CalculationRequest(
+        calc = CreditRiskCalc(
             data_path=temp_valid_dir,
             framework="CRR",
             reporting_date=date(2024, 12, 31),
             data_format="parquet",
         )
-
-        loader = service._create_loader(request)
-
+        loader = calc._create_loader()
         assert isinstance(loader, ParquetLoader)
 
-    def test_csv_loader(self, service: RWAService, temp_valid_dir: Path) -> None:
+    def test_csv_loader(self, temp_valid_dir: Path) -> None:
         """Should create CSVLoader for csv format."""
         from rwa_calc.engine.loader import CSVLoader
 
-        request = CalculationRequest(
+        calc = CreditRiskCalc(
             data_path=temp_valid_dir,
             framework="CRR",
             reporting_date=date(2024, 12, 31),
             data_format="csv",
         )
-
-        loader = service._create_loader(request)
-
+        loader = calc._create_loader()
         assert isinstance(loader, CSVLoader)
 
 
 # =============================================================================
-# Factory Function Tests
+# Module-Level Function Tests
 # =============================================================================
 
 
-class TestCreateService:
-    """Tests for create_service factory function."""
+class TestGetSupportedFrameworks:
+    """Tests for get_supported_frameworks function."""
 
-    def test_creates_service_instance(self) -> None:
-        """Should create RWAService instance."""
-        service = create_service()
-        assert isinstance(service, RWAService)
+    def test_returns_frameworks_list(self) -> None:
+        """Should return list of supported frameworks."""
+        frameworks = get_supported_frameworks()
+        assert isinstance(frameworks, list)
+        assert len(frameworks) == 2
+
+    def test_includes_crr(self) -> None:
+        """Should include CRR framework."""
+        frameworks = get_supported_frameworks()
+        crr = next((f for f in frameworks if f["id"] == "CRR"), None)
+        assert crr is not None
+        assert "Basel 3.0" in crr["name"]
+
+    def test_includes_basel_31(self) -> None:
+        """Should include Basel 3.1 framework."""
+        frameworks = get_supported_frameworks()
+        basel = next((f for f in frameworks if f["id"] == "BASEL_3_1"), None)
+        assert basel is not None
+        assert "Basel 3.1" in basel["name"]
 
 
-# =============================================================================
-# Quick Calculate Tests
-# =============================================================================
+class TestGetDefaultConfig:
+    """Tests for get_default_config function."""
 
-
-class TestQuickCalculate:
-    """Tests for quick_calculate convenience function."""
-
-    def test_invalid_path(self, tmp_path: Path) -> None:
-        """Should return error for invalid path."""
-        response = quick_calculate(
-            data_path=tmp_path / "nonexistent",
+    def test_crr_config(self) -> None:
+        """Should return CRR default configuration."""
+        config = get_default_config(
             framework="CRR",
-            cache_dir=tmp_path / "cache",
+            reporting_date=date(2024, 12, 31),
         )
+        assert config["framework"] == "CRR"
+        assert config["base_currency"] == "GBP"
+        assert config["supporting_factors_enabled"] is True
+        assert config["output_floor_enabled"] is False
 
-        assert response.success is False
-
-    def test_default_parameters(self, temp_valid_dir: Path) -> None:
-        """Should use default parameters when not specified."""
-        # Mock to avoid full calculation
-        with patch.object(RWAService, "calculate") as mock_calc:
-            mock_response = MagicMock()
-            mock_response.success = True
-            mock_calc.return_value = mock_response
-
-            quick_calculate(temp_valid_dir)
-
-            # Check default values were used
-            call_args = mock_calc.call_args[0][0]
-            assert call_args.framework == "CRR"
-            assert call_args.permission_mode == "standardised"
-            assert call_args.data_format == "parquet"
+    def test_basel_31_config(self) -> None:
+        """Should return Basel 3.1 default configuration."""
+        config = get_default_config(
+            framework="BASEL_3_1",
+            reporting_date=date(2027, 1, 1),
+        )
+        assert config["framework"] == "BASEL_3_1"
+        assert config["supporting_factors_enabled"] is False
+        assert config["output_floor_enabled"] is True

--- a/tests/unit/crm/test_cross_approach_ccf.py
+++ b/tests/unit/crm/test_cross_approach_ccf.py
@@ -181,7 +181,8 @@ def _run_crm(
 
     bundle = _make_bundle(exposures, guarantees, counterparties, rating_inheritance)
     result = processor.get_crm_adjusted_bundle(bundle, config)
-    return result.exposures.collect()
+    df: pl.DataFrame = result.exposures.collect()
+    return df
 
 
 # =============================================================================

--- a/tests/unit/crm/test_multi_level_sa_collateral.py
+++ b/tests/unit/crm/test_multi_level_sa_collateral.py
@@ -202,7 +202,8 @@ def _run_crm(
     collateral = pl.LazyFrame(collateral_rows, schema=collateral_schema)
     bundle = _make_bundle(exposures, collateral)
     result = processor.get_crm_adjusted_bundle(bundle, config)
-    return result.exposures.collect()
+    df: pl.DataFrame = result.exposures.collect()
+    return df
 
 
 # =============================================================================

--- a/tests/unit/crm/test_netting.py
+++ b/tests/unit/crm/test_netting.py
@@ -155,7 +155,8 @@ def _run_crm(
     exposures = pl.LazyFrame(exposure_rows)
     bundle = _make_bundle(exposures, collateral)
     result = processor.get_crm_adjusted_bundle(bundle, config)
-    return result.exposures.collect()
+    df: pl.DataFrame = result.exposures.collect()
+    return df
 
 
 # =============================================================================

--- a/tests/unit/crm/test_pledge_percentage.py
+++ b/tests/unit/crm/test_pledge_percentage.py
@@ -141,7 +141,8 @@ def _run_resolve(
     direct_lookup, facility_lookup, cp_lookup = _build_exposure_lookups(exposures)
     joined = _join_collateral_to_lookups(collateral, direct_lookup, facility_lookup, cp_lookup)
     resolved = _resolve_pledge_from_joined(joined)
-    return resolved.collect()
+    df: pl.DataFrame = resolved.collect()
+    return df
 
 
 # =============================================================================

--- a/tests/unit/crr/test_crr_equity.py
+++ b/tests/unit/crr/test_crr_equity.py
@@ -30,12 +30,12 @@ from tests.fixtures.single_exposure import calculate_single_equity_exposure
 
 from rwa_calc.contracts.bundles import CRMAdjustedBundle, EquityResultBundle
 from rwa_calc.contracts.config import CalculationConfig
-from rwa_calc.domain.enums import PermissionMode
 from rwa_calc.contracts.errors import LazyFrameResult
 from rwa_calc.data.tables.crr_equity_rw import (
     get_equity_rw_table,
     lookup_equity_rw,
 )
+from rwa_calc.domain.enums import PermissionMode
 from rwa_calc.engine.equity import EquityCalculator, create_equity_calculator
 
 # =============================================================================

--- a/tests/unit/test_ciu_treatment.py
+++ b/tests/unit/test_ciu_treatment.py
@@ -23,7 +23,7 @@ import pytest
 from tests.fixtures.single_exposure import calculate_single_equity_exposure
 
 from rwa_calc.contracts.bundles import CRMAdjustedBundle
-from rwa_calc.contracts.config import CalculationConfig, IRBPermissions
+from rwa_calc.contracts.config import CalculationConfig
 from rwa_calc.engine.equity import EquityCalculator
 
 # =============================================================================
@@ -40,7 +40,6 @@ def equity_calculator() -> EquityCalculator:
 def sa_config() -> CalculationConfig:
     return CalculationConfig.crr(
         reporting_date=date(2024, 12, 31),
-        irb_permissions=IRBPermissions.sa_only(),
     )
 
 
@@ -265,20 +264,24 @@ class TestCIULookThrough:
     ):
         """CIU with a single CORPORATE CQS3 holding uses that holding's RW."""
         bundle = _make_look_through_bundle(
-            equity_data=[{
-                "exposure_reference": "CIU_1",
-                "ead_final": 1_000_000.0,
-                "equity_type": "ciu",
-                "ciu_approach": "look_through",
-                "fund_reference": "FUND_A",
-            }],
-            holdings_data=[{
-                "fund_reference": "FUND_A",
-                "holding_reference": "H1",
-                "exposure_class": "CORPORATE",
-                "cqs": 3,
-                "holding_value": 1_000_000.0,
-            }],
+            equity_data=[
+                {
+                    "exposure_reference": "CIU_1",
+                    "ead_final": 1_000_000.0,
+                    "equity_type": "ciu",
+                    "ciu_approach": "look_through",
+                    "fund_reference": "FUND_A",
+                }
+            ],
+            holdings_data=[
+                {
+                    "fund_reference": "FUND_A",
+                    "holding_reference": "H1",
+                    "exposure_class": "CORPORATE",
+                    "cqs": 3,
+                    "holding_value": 1_000_000.0,
+                }
+            ],
         )
         result = equity_calculator.get_equity_result_bundle(bundle, sa_config)
         row = result.results.collect().to_dicts()[0]
@@ -292,13 +295,15 @@ class TestCIULookThrough:
     ):
         """CIU with mixed holdings gets value-weighted average RW."""
         bundle = _make_look_through_bundle(
-            equity_data=[{
-                "exposure_reference": "CIU_1",
-                "ead_final": 1_000_000.0,
-                "equity_type": "ciu",
-                "ciu_approach": "look_through",
-                "fund_reference": "FUND_A",
-            }],
+            equity_data=[
+                {
+                    "exposure_reference": "CIU_1",
+                    "ead_final": 1_000_000.0,
+                    "equity_type": "ciu",
+                    "ciu_approach": "look_through",
+                    "fund_reference": "FUND_A",
+                }
+            ],
             holdings_data=[
                 {
                     "fund_reference": "FUND_A",
@@ -328,20 +333,24 @@ class TestCIULookThrough:
     ):
         """CIU with look_through but no matching holdings falls back to 250%."""
         bundle = _make_look_through_bundle(
-            equity_data=[{
-                "exposure_reference": "CIU_1",
-                "ead_final": 1_000_000.0,
-                "equity_type": "ciu",
-                "ciu_approach": "look_through",
-                "fund_reference": "FUND_X",
-            }],
-            holdings_data=[{
-                "fund_reference": "FUND_OTHER",
-                "holding_reference": "H1",
-                "exposure_class": "CORPORATE",
-                "cqs": 1,
-                "holding_value": 1_000_000.0,
-            }],
+            equity_data=[
+                {
+                    "exposure_reference": "CIU_1",
+                    "ead_final": 1_000_000.0,
+                    "equity_type": "ciu",
+                    "ciu_approach": "look_through",
+                    "fund_reference": "FUND_X",
+                }
+            ],
+            holdings_data=[
+                {
+                    "fund_reference": "FUND_OTHER",
+                    "holding_reference": "H1",
+                    "exposure_class": "CORPORATE",
+                    "cqs": 1,
+                    "holding_value": 1_000_000.0,
+                }
+            ],
         )
         result = equity_calculator.get_equity_result_bundle(bundle, sa_config)
         row = result.results.collect().to_dicts()[0]
@@ -354,13 +363,15 @@ class TestCIULookThrough:
     ):
         """CIU with look_through and ciu_holdings=None falls back to 250%."""
         bundle = _make_look_through_bundle(
-            equity_data=[{
-                "exposure_reference": "CIU_1",
-                "ead_final": 1_000_000.0,
-                "equity_type": "ciu",
-                "ciu_approach": "look_through",
-                "fund_reference": "FUND_A",
-            }],
+            equity_data=[
+                {
+                    "exposure_reference": "CIU_1",
+                    "ead_final": 1_000_000.0,
+                    "equity_type": "ciu",
+                    "ciu_approach": "look_through",
+                    "fund_reference": "FUND_A",
+                }
+            ],
             holdings_data=None,
         )
         result = equity_calculator.get_equity_result_bundle(bundle, sa_config)
@@ -374,20 +385,24 @@ class TestCIULookThrough:
     ):
         """Holding with unrated CQS (null) defaults to 100% RW."""
         bundle = _make_look_through_bundle(
-            equity_data=[{
-                "exposure_reference": "CIU_1",
-                "ead_final": 1_000_000.0,
-                "equity_type": "ciu",
-                "ciu_approach": "look_through",
-                "fund_reference": "FUND_A",
-            }],
-            holdings_data=[{
-                "fund_reference": "FUND_A",
-                "holding_reference": "H1",
-                "exposure_class": "CORPORATE",
-                "cqs": None,
-                "holding_value": 1_000_000.0,
-            }],
+            equity_data=[
+                {
+                    "exposure_reference": "CIU_1",
+                    "ead_final": 1_000_000.0,
+                    "equity_type": "ciu",
+                    "ciu_approach": "look_through",
+                    "fund_reference": "FUND_A",
+                }
+            ],
+            holdings_data=[
+                {
+                    "fund_reference": "FUND_A",
+                    "holding_reference": "H1",
+                    "exposure_class": "CORPORATE",
+                    "cqs": None,
+                    "holding_value": 1_000_000.0,
+                }
+            ],
         )
         result = equity_calculator.get_equity_result_bundle(bundle, sa_config)
         row = result.results.collect().to_dicts()[0]
@@ -448,21 +463,25 @@ class TestCIULookThrough:
     ):
         """Mandate-based CIU ignores holdings data and uses mandate_rw."""
         bundle = _make_look_through_bundle(
-            equity_data=[{
-                "exposure_reference": "CIU_1",
-                "ead_final": 1_000_000.0,
-                "equity_type": "ciu",
-                "ciu_approach": "mandate_based",
-                "fund_reference": "FUND_A",
-                "ciu_mandate_rw": 3.50,
-            }],
-            holdings_data=[{
-                "fund_reference": "FUND_A",
-                "holding_reference": "H1",
-                "exposure_class": "CENTRAL_GOVT_CENTRAL_BANK",
-                "cqs": 1,
-                "holding_value": 1_000_000.0,
-            }],
+            equity_data=[
+                {
+                    "exposure_reference": "CIU_1",
+                    "ead_final": 1_000_000.0,
+                    "equity_type": "ciu",
+                    "ciu_approach": "mandate_based",
+                    "fund_reference": "FUND_A",
+                    "ciu_mandate_rw": 3.50,
+                }
+            ],
+            holdings_data=[
+                {
+                    "fund_reference": "FUND_A",
+                    "holding_reference": "H1",
+                    "exposure_class": "CENTRAL_GOVT_CENTRAL_BANK",
+                    "cqs": 1,
+                    "holding_value": 1_000_000.0,
+                }
+            ],
         )
         result = equity_calculator.get_equity_result_bundle(bundle, sa_config)
         row = result.results.collect().to_dicts()[0]
@@ -475,20 +494,24 @@ class TestCIULookThrough:
     ):
         """Look-through RWA = EAD * effective_rw."""
         bundle = _make_look_through_bundle(
-            equity_data=[{
-                "exposure_reference": "CIU_1",
-                "ead_final": 2_000_000.0,
-                "equity_type": "ciu",
-                "ciu_approach": "look_through",
-                "fund_reference": "FUND_A",
-            }],
-            holdings_data=[{
-                "fund_reference": "FUND_A",
-                "holding_reference": "H1",
-                "exposure_class": "CORPORATE",
-                "cqs": 1,
-                "holding_value": 1_000_000.0,
-            }],
+            equity_data=[
+                {
+                    "exposure_reference": "CIU_1",
+                    "ead_final": 2_000_000.0,
+                    "equity_type": "ciu",
+                    "ciu_approach": "look_through",
+                    "fund_reference": "FUND_A",
+                }
+            ],
+            holdings_data=[
+                {
+                    "fund_reference": "FUND_A",
+                    "holding_reference": "H1",
+                    "exposure_class": "CORPORATE",
+                    "cqs": 1,
+                    "holding_value": 1_000_000.0,
+                }
+            ],
         )
         result = equity_calculator.get_equity_result_bundle(bundle, sa_config)
         row = result.results.collect().to_dicts()[0]

--- a/tests/unit/test_corep.py
+++ b/tests/unit/test_corep.py
@@ -45,8 +45,10 @@ from rwa_calc.reporting.corep.templates import (
     get_sa_row_sections,
 )
 
+import importlib.util
+
 XLSXWRITER_AVAILABLE = bool(sys.modules.get("xlsxwriter")) or (
-    __import__("importlib").util.find_spec("xlsxwriter") is not None
+    importlib.util.find_spec("xlsxwriter") is not None
 )
 
 # =============================================================================
@@ -1428,7 +1430,7 @@ class TestExcelExport:
         gen.export_to_excel(bundle, output)
 
         sheets = pl.read_excel(output, sheet_id=0)
-        sheet_names = list(sheets.keys()) if isinstance(sheets, dict) else []
+        sheet_names: list[str] = list(sheets.keys()) if isinstance(sheets, dict) else []
 
         # Should have C 07.00 sheets for SA classes
         assert any("C 07.00" in s for s in sheet_names)

--- a/tests/unit/test_covered_bonds.py
+++ b/tests/unit/test_covered_bonds.py
@@ -161,7 +161,7 @@ class TestCoveredBondPermissions:
 
     @pytest.mark.parametrize(
         "factory_name",
-        ["full_irb", "firb_only", "airb_only", "retail_airb_corporate_firb"],
+        ["sa_only", "full_irb"],
     )
     def test_sa_only_in_all_irb_configs(self, factory_name: str):
         """Covered bonds are SA-only regardless of IRB permissions."""

--- a/tests/unit/test_guarantor_exposure_class_rw.py
+++ b/tests/unit/test_guarantor_exposure_class_rw.py
@@ -65,7 +65,8 @@ def _sa_guarantee_result(
     calc = _make_sa_calculator()
     # Call the private method directly for isolated testing
     result_lf = calc._apply_guarantee_substitution(lf, config)
-    return result_lf.collect()
+    result: pl.DataFrame = result_lf.collect()
+    return result
 
 
 def _irb_guarantee_result(

--- a/tests/unit/test_irb_approach_selection.py
+++ b/tests/unit/test_irb_approach_selection.py
@@ -2,21 +2,18 @@
 
 Tests cover:
 - PermissionMode enum values
-- CalculationRequest permission_mode field
-- RWAService._create_config() with permission modes
+- CreditRiskCalc._create_config() with permission modes
 - CCF behavior under different approach selections (FIRB 75% vs SA 50%)
 """
 
 from __future__ import annotations
 
 from datetime import date
-from pathlib import Path
 
 import polars as pl
 import pytest
 
-from rwa_calc.api.models import CalculationRequest
-from rwa_calc.api.service import RWAService
+from rwa_calc.api.service import CreditRiskCalc
 from rwa_calc.contracts.config import CalculationConfig
 from rwa_calc.domain.enums import ApproachType, ExposureClass, PermissionMode
 
@@ -52,12 +49,8 @@ class TestCalculationConfigPermissionMode:
             reporting_date=date(2024, 12, 31),
             permission_mode=PermissionMode.STANDARDISED,
         )
-        assert not config.irb_permissions.is_permitted(
-            ExposureClass.CORPORATE, ApproachType.FIRB
-        )
-        assert not config.irb_permissions.is_permitted(
-            ExposureClass.CORPORATE, ApproachType.AIRB
-        )
+        assert not config.irb_permissions.is_permitted(ExposureClass.CORPORATE, ApproachType.FIRB)
+        assert not config.irb_permissions.is_permitted(ExposureClass.CORPORATE, ApproachType.AIRB)
 
     def test_irb_derives_full_irb(self) -> None:
         """IRB mode should derive full_irb irb_permissions."""
@@ -75,103 +68,58 @@ class TestCalculationConfigPermissionMode:
 
 
 # =============================================================================
-# CalculationRequest Tests
-# =============================================================================
-
-
-class TestCalculationRequestPermissionMode:
-    """Tests for CalculationRequest with permission_mode field."""
-
-    def test_request_with_standardised(self) -> None:
-        """CalculationRequest should accept permission_mode='standardised'."""
-        request = CalculationRequest(
-            data_path="/test/path",
-            framework="CRR",
-            reporting_date=date(2024, 12, 31),
-            permission_mode="standardised",
-        )
-        assert request.permission_mode == "standardised"
-
-    def test_request_with_irb(self) -> None:
-        """CalculationRequest should accept permission_mode='irb'."""
-        request = CalculationRequest(
-            data_path="/test/path",
-            framework="CRR",
-            reporting_date=date(2024, 12, 31),
-            permission_mode="irb",
-        )
-        assert request.permission_mode == "irb"
-
-    def test_request_defaults_to_standardised(self) -> None:
-        """CalculationRequest should default permission_mode to 'standardised'."""
-        request = CalculationRequest(
-            data_path="/test/path",
-            framework="CRR",
-            reporting_date=date(2024, 12, 31),
-        )
-        assert request.permission_mode == "standardised"
-
-
-# =============================================================================
-# RWAService._create_config Tests
+# CreditRiskCalc._create_config Tests
 # =============================================================================
 
 
 class TestServiceCreateConfig:
-    """Tests for RWAService._create_config() with permission modes."""
+    """Tests for CreditRiskCalc._create_config() with permission modes."""
 
-    @pytest.fixture
-    def service(self, tmp_path: Path) -> RWAService:
-        """Return an RWAService instance."""
-        return RWAService(cache_dir=tmp_path / "cache")
-
-    def test_create_config_standardised(self, service: RWAService) -> None:
+    def test_create_config_standardised(self) -> None:
         """_create_config with 'standardised' should use sa_only permissions."""
-        request = CalculationRequest(
+        calc = CreditRiskCalc(
             data_path="/test/path",
             framework="CRR",
             reporting_date=date(2024, 12, 31),
             permission_mode="standardised",
         )
-        config = service._create_config(request)
+        config = calc._create_config()
         assert config.permission_mode == PermissionMode.STANDARDISED
-        assert not config.irb_permissions.is_permitted(
-            ExposureClass.CORPORATE, ApproachType.FIRB
-        )
+        assert not config.irb_permissions.is_permitted(ExposureClass.CORPORATE, ApproachType.FIRB)
 
-    def test_create_config_irb(self, service: RWAService) -> None:
+    def test_create_config_irb(self) -> None:
         """_create_config with 'irb' should use full_irb permissions."""
-        request = CalculationRequest(
+        calc = CreditRiskCalc(
             data_path="/test/path",
             framework="CRR",
             reporting_date=date(2024, 12, 31),
             permission_mode="irb",
         )
-        config = service._create_config(request)
+        config = calc._create_config()
         assert config.permission_mode == PermissionMode.IRB
         assert config.irb_permissions.is_permitted(ExposureClass.CORPORATE, ApproachType.FIRB)
         assert config.irb_permissions.is_permitted(ExposureClass.CORPORATE, ApproachType.AIRB)
 
-    def test_create_config_crr_framework(self, service: RWAService) -> None:
+    def test_create_config_crr_framework(self) -> None:
         """_create_config should create CRR config when framework='CRR'."""
-        request = CalculationRequest(
+        calc = CreditRiskCalc(
             data_path="/test/path",
             framework="CRR",
             reporting_date=date(2024, 12, 31),
             permission_mode="irb",
         )
-        config = service._create_config(request)
+        config = calc._create_config()
         assert config.is_crr
 
-    def test_create_config_basel_3_1_framework(self, service: RWAService) -> None:
+    def test_create_config_basel_3_1_framework(self) -> None:
         """_create_config should create Basel 3.1 config when framework='BASEL_3_1'."""
-        request = CalculationRequest(
+        calc = CreditRiskCalc(
             data_path="/test/path",
             framework="BASEL_3_1",
             reporting_date=date(2027, 6, 30),
             permission_mode="irb",
         )
-        config = service._create_config(request)
+        config = calc._create_config()
         assert config.is_basel_3_1
 
 


### PR DESCRIPTION
## Summary
- Replace `RWAService` + `CalculationRequest` + `quick_calculate` + `create_service` with a single `CreditRiskCalc` class that takes all parameters in its constructor and exposes `calculate()` and `validate()` methods
- Fix all 53 `ty check` diagnostics: unresolved fixture imports (config exclusion), `.collect()` return type casts, unsupported operator narrowing, pre-existing `PermissionMode` migration issues in `test_ciu_treatment.py` and `test_covered_bonds.py`
- Update all documentation (README, quickstart, API reference, configuration guide) to use the new API

### New usage
```python
from datetime import date
from rwa_calc.api import CreditRiskCalc

response = CreditRiskCalc(
    data_path="/path/to/data",
    framework="CRR",
    reporting_date=date(2026, 12, 31),
    permission_mode="irb",
).calculate()
```

## Test plan
- [x] `uv tool run ty check` — 0 errors (was 53)
- [x] `uv run pytest tests/` — 2301 passed, 14 skipped
- [x] Grep for `RWAService`, `quick_calculate`, `create_service`, `CalculationRequest` — no remaining references in `.py` files
