### PR TITLE
feat(ui): add template workbench with workspace duplication

### DIFF
--- a/docs/appendix/changelog.md
+++ b/docs/appendix/changelog.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **UI**: Add template workbench — duplicate read-only template workbooks into editable user workspace with full Python and SQL support via `marimo edit`
+- **UI**: Add workspace management REST API (`/api/templates`, `/api/workbooks`, `/api/workbooks/duplicate`, `/api/workbooks/{name}`)
+- **UI**: Add "Workbench" link to sidebar navigation in all template apps
+
 ### Changed
 - **API**: Replace `RWAService` + `CalculationRequest` + `quick_calculate` + `create_service` with single `CreditRiskCalc` class. Usage: `CreditRiskCalc(data_path=..., framework=..., reporting_date=...).calculate()`. All response models (`CalculationResponse`, `SummaryStatistics`, etc.) are unchanged.
 - **Config**: Replace granular `IRBPermissions` config (with `sa_only()`, `full_irb()`, `firb_only()`, etc.) with a simple two-mode `PermissionMode` enum (`STANDARDISED` / `IRB`). The `permission_mode` parameter on `CalculationConfig.crr()` and `.basel_3_1()` replaces the old `irb_permissions` parameter. In IRB mode, `model_permissions` input data drives all approach routing (AIRB, FIRB, slotting); without it, the pipeline falls back to SA with a warning. `IRBPermissions` remains as an internal implementation detail but is no longer part of the public API.

--- a/docs/user-guide/interactive-ui.md
+++ b/docs/user-guide/interactive-ui.md
@@ -51,13 +51,15 @@ Once started, open your browser to [http://localhost:8000](http://localhost:8000
 
 ## Available Applications
 
-The UI provides three integrated applications:
+The UI provides four integrated applications plus an editable workbench:
 
 | Application | URL | Purpose |
 |-------------|-----|---------|
 | **RWA Calculator** | `/` or `/calculator` | Run RWA calculations on your data |
 | **Results Explorer** | `/results` | Filter, aggregate, and export results |
+| **Impact Analysis** | `/comparison` | Compare CRR vs Basel 3.1 side-by-side |
 | **Framework Reference** | `/reference` | View regulatory parameters and risk weights |
+| **Workbench** | `http://localhost:8002/` | Editable workbooks — duplicate templates, write Python & SQL |
 
 ---
 
@@ -155,6 +157,51 @@ This reference is useful for:
 - Validating calculation inputs
 - Understanding regulatory differences
 - Quick lookup of risk weights and parameters
+
+---
+
+## Workbench
+
+The Workbench at [http://localhost:8002/](http://localhost:8002/) provides an editable environment for interactive analysis using Python and SQL.
+
+### How It Works
+
+The template applications (Calculator, Results Explorer, etc.) are **read-only** — you can view and interact with their outputs but cannot modify code. The Workbench lets you **duplicate** any template into your own editable workspace.
+
+### Duplicating a Template
+
+Use the REST API to duplicate a template:
+
+```bash
+# Duplicate the calculator template
+curl -X POST "http://localhost:8000/api/workbooks/duplicate?template=calculator"
+
+# Duplicate with a custom name
+curl -X POST "http://localhost:8000/api/workbooks/duplicate?template=results_explorer&name=my_analysis"
+```
+
+The response includes the URL to open the workbook in the Workbench.
+
+### Managing Workbooks
+
+```bash
+# List available templates
+curl http://localhost:8000/api/templates
+
+# List your workbooks
+curl http://localhost:8000/api/workbooks
+
+# Delete a workbook
+curl -X DELETE http://localhost:8000/api/workbooks/my_analysis
+```
+
+### Using the Workbench
+
+Once a workbook is duplicated, open it in the Workbench to:
+
+- **Edit Python cells** — modify calculations, add visualisations, explore data
+- **Add SQL cells** — query Polars DataFrames with SQL using `mo.sql()`
+- **Save changes** — workbooks persist in `workspaces/local/` across server restarts
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ Changelog = "https://github.com/OpenAfterHours/rwa_calculator/blob/master/docs/a
 ui = [
     "marimo>=0.5.0",
     "uvicorn>=0.27.0",
+    "fastapi>=0.115.0",
 ]
 dev = [
     "pytest>=8.0.0",

--- a/src/rwa_calc/ui/marimo/.gitignore
+++ b/src/rwa_calc/ui/marimo/.gitignore
@@ -1,2 +1,5 @@
 # Cache directory for sharing results between apps
 .cache/
+
+# User workspaces (duplicated workbooks)
+workspaces/

--- a/src/rwa_calc/ui/marimo/comparison_app.py
+++ b/src/rwa_calc/ui/marimo/comparison_app.py
@@ -69,6 +69,7 @@ def _(mo):
                     "/results": f"{mo.icon('table')} Results Explorer",
                     "/comparison": f"{mo.icon('git-compare')} Impact Analysis",
                     "/reference": f"{mo.icon('book')} Framework Reference",
+                    "http://localhost:8002": f"{mo.icon('code')} Workbench",
                 },
                 orientation="vertical",
             ),

--- a/src/rwa_calc/ui/marimo/framework_reference.py
+++ b/src/rwa_calc/ui/marimo/framework_reference.py
@@ -40,6 +40,7 @@ def _(mo):
                     "/results": f"{mo.icon('table')} Results Explorer",
                     "/comparison": f"{mo.icon('git-compare')} Impact Analysis",
                     "/reference": f"{mo.icon('book')} Framework Reference",
+                    "http://localhost:8002": f"{mo.icon('code')} Workbench",
                 },
                 orientation="vertical",
             ),

--- a/src/rwa_calc/ui/marimo/results_explorer.py
+++ b/src/rwa_calc/ui/marimo/results_explorer.py
@@ -46,6 +46,7 @@ def _(mo):
                     "/results": f"{mo.icon('table')} Results Explorer",
                     "/comparison": f"{mo.icon('git-compare')} Impact Analysis",
                     "/reference": f"{mo.icon('book')} Framework Reference",
+                    "http://localhost:8002": f"{mo.icon('code')} Workbench",
                 },
                 orientation="vertical",
             ),

--- a/src/rwa_calc/ui/marimo/rwa_app.py
+++ b/src/rwa_calc/ui/marimo/rwa_app.py
@@ -55,6 +55,7 @@ def _(mo):
                     "/results": f"{mo.icon('table')} Results Explorer",
                     "/comparison": f"{mo.icon('git-compare')} Impact Analysis",
                     "/reference": f"{mo.icon('book')} Framework Reference",
+                    "http://localhost:8002": f"{mo.icon('code')} Workbench",
                 },
                 orientation="vertical",
             ),

--- a/src/rwa_calc/ui/marimo/server.py
+++ b/src/rwa_calc/ui/marimo/server.py
@@ -1,7 +1,13 @@
 """
-RWA Calculator Multi-App Server.
+RWA Calculator Multi-App Server with Template Workbench.
 
-Serves all Marimo applications with proper navigation between them.
+Pipeline position:
+    Standalone UI server — serves read-only templates and editable workbench.
+
+Key responsibilities:
+- Serve template apps in read-only run mode (existing behaviour)
+- Manage user workspace (duplicate, list, delete workbooks)
+- Launch marimo edit subprocess for interactive workbench on separate port
 
 Usage (installed from PyPI):
     rwa-calc-ui
@@ -9,19 +15,44 @@ Usage (installed from PyPI):
 Usage (from source):
     uv run python src/rwa_calc/ui/marimo/server.py
 
-Or with uvicorn directly:
+Or with uvicorn directly (templates only, no workbench):
     uvicorn rwa_calc.ui.marimo.server:app --host 127.0.0.1 --port 8000
 """
+from __future__ import annotations
 
+import shutil
+import subprocess
+import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import marimo
+import uvicorn
+from fastapi import FastAPI, HTTPException
 
-# Get the directory containing the apps
+if TYPE_CHECKING:
+    pass
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
 apps_dir = Path(__file__).parent
+workspaces_dir = apps_dir / "workspaces" / "local"
+workspaces_dir.mkdir(parents=True, exist_ok=True)
 
-# Create marimo ASGI app with all notebooks and build it
-app = (
+EDIT_SERVER_PORT = 8002
+
+TEMPLATE_REGISTRY: dict[str, str] = {
+    "calculator": "rwa_app.py",
+    "results_explorer": "results_explorer.py",
+    "comparison": "comparison_app.py",
+    "reference": "framework_reference.py",
+}
+
+# ---------------------------------------------------------------------------
+# Read-only templates (run mode via create_asgi_app)
+# ---------------------------------------------------------------------------
+templates_asgi = (
     marimo.create_asgi_app()
     .with_app(path="", root=str(apps_dir / "rwa_app.py"))
     .with_app(path="/calculator", root=str(apps_dir / "rwa_app.py"))
@@ -31,19 +62,115 @@ app = (
     .build()
 )
 
+# ---------------------------------------------------------------------------
+# FastAPI gateway
+# ---------------------------------------------------------------------------
+gateway = FastAPI(title="RWA Calculator")
 
-def main():
-    """Start the RWA Calculator UI server."""
-    import uvicorn
+
+@gateway.get("/api/templates")
+async def list_templates() -> dict[str, list[str]]:
+    """Return available template names."""
+    return {"templates": list(TEMPLATE_REGISTRY.keys())}
+
+
+@gateway.get("/api/workbooks")
+async def list_workbooks() -> dict[str, list[str]]:
+    """Return user workbooks in the local workspace."""
+    workbooks = [f.stem for f in workspaces_dir.glob("*.py") if f.stem != "__init__"]
+    return {"workbooks": sorted(workbooks)}
+
+
+@gateway.post("/api/workbooks/duplicate")
+async def duplicate_template(
+    template: str, name: str | None = None
+) -> dict[str, str]:
+    """Duplicate a template into the user workspace."""
+    if template not in TEMPLATE_REGISTRY:
+        raise HTTPException(status_code=400, detail=f"Unknown template: {template}")
+
+    source = apps_dir / TEMPLATE_REGISTRY[template]
+    target_name = name or template
+    target = workspaces_dir / f"{target_name}.py"
+    counter = 1
+    while target.exists():
+        target = workspaces_dir / f"{target_name}_{counter}.py"
+        counter += 1
+
+    shutil.copy2(source, target)
+    workbook_name = target.stem
+    return {
+        "workbook": workbook_name,
+        "url": f"http://localhost:{EDIT_SERVER_PORT}/?file={workbook_name}.py",
+    }
+
+
+@gateway.delete("/api/workbooks/{name}")
+async def delete_workbook(name: str) -> dict[str, str]:
+    """Delete a user workbook."""
+    target = workspaces_dir / f"{name}.py"
+    if not target.exists():
+        raise HTTPException(status_code=404, detail="Workbook not found")
+    target.unlink()
+    return {"deleted": name}
+
+
+# Mount read-only templates at root (catch-all — must be registered last)
+gateway.mount("/", templates_asgi)
+
+# Expose for `uvicorn rwa_calc.ui.marimo.server:app`
+app = gateway
+
+# ---------------------------------------------------------------------------
+# Server launcher
+# ---------------------------------------------------------------------------
+_edit_process: subprocess.Popen[bytes] | None = None
+
+
+def main() -> None:
+    """Start the RWA Calculator UI server and marimo edit workbench."""
+    global _edit_process  # noqa: PLW0603
 
     print("Starting RWA Calculator server...")
-    print("Apps available at:")
-    print("  - http://localhost:8000/           (Calculator)")
-    print("  - http://localhost:8000/calculator (Calculator)")
-    print("  - http://localhost:8000/results    (Results Explorer)")
-    print("  - http://localhost:8000/comparison (Impact Analysis)")
-    print("  - http://localhost:8000/reference  (Framework Reference)")
-    uvicorn.run(app, host="127.0.0.1", port=8000)
+    print()
+
+    # Launch marimo edit server for workbench (separate process/port)
+    _edit_process = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "marimo",
+            "edit",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(EDIT_SERVER_PORT),
+            "--no-token",
+            str(workspaces_dir),
+        ],
+    )
+
+    print("Templates (read-only):")
+    print("  http://localhost:8000/            (Calculator)")
+    print("  http://localhost:8000/calculator  (Calculator)")
+    print("  http://localhost:8000/results     (Results Explorer)")
+    print("  http://localhost:8000/comparison  (Impact Analysis)")
+    print("  http://localhost:8000/reference   (Framework Reference)")
+    print()
+    print(f"Workbench (editable):  http://localhost:{EDIT_SERVER_PORT}/")
+    print()
+    print("API:")
+    print("  GET    /api/templates             List available templates")
+    print("  GET    /api/workbooks             List your workbooks")
+    print("  POST   /api/workbooks/duplicate   Duplicate a template")
+    print("  DELETE /api/workbooks/{name}      Delete a workbook")
+    print()
+
+    try:
+        uvicorn.run(gateway, host="127.0.0.1", port=8000)
+    finally:
+        if _edit_process:
+            _edit_process.terminate()
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,24 @@ revision = 3
 requires-python = ">=3.13"
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -112,6 +130,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.135.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/e6/7adb4c5fa231e82c35b8f5741a9f2d055f520c29af5546fd70d3e8e1cd2e/fastapi-0.135.3.tar.gz", hash = "sha256:bd6d7caf1a2bdd8d676843cdcd2287729572a1ef524fc4d65c17ae002a1be654", size = 396524, upload-time = "2026-04-01T16:23:58.188Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/a4/5caa2de7f917a04ada20018eccf60d6cc6145b0199d55ca3711b0fc08312/fastapi-0.135.3-py3-none-any.whl", hash = "sha256:9b0f590c813acd13d0ab43dd8494138eb58e484bfac405db1f3187cfc5810d98", size = 117734, upload-time = "2026-04-01T16:23:59.328Z" },
 ]
 
 [[package]]
@@ -668,6 +702,74 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/06/8806241ff1f70d9939f9af039c6c35f2360cf16e93c2ca76f184e76b1564/pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9", size = 2120403, upload-time = "2025-11-04T13:40:25.248Z" },
+    { url = "https://files.pythonhosted.org/packages/94/02/abfa0e0bda67faa65fef1c84971c7e45928e108fe24333c81f3bfe35d5f5/pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34", size = 1896206, upload-time = "2025-11-04T13:40:27.099Z" },
+    { url = "https://files.pythonhosted.org/packages/15/df/a4c740c0943e93e6500f9eb23f4ca7ec9bf71b19e608ae5b579678c8d02f/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0", size = 1919307, upload-time = "2025-11-04T13:40:29.806Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e3/6324802931ae1d123528988e0e86587c2072ac2e5394b4bc2bc34b61ff6e/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33", size = 2063258, upload-time = "2025-11-04T13:40:33.544Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d4/2230d7151d4957dd79c3044ea26346c148c98fbf0ee6ebd41056f2d62ab5/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e", size = 2214917, upload-time = "2025-11-04T13:40:35.479Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9f/eaac5df17a3672fef0081b6c1bb0b82b33ee89aa5cec0d7b05f52fd4a1fa/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2", size = 2332186, upload-time = "2025-11-04T13:40:37.436Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4e/35a80cae583a37cf15604b44240e45c05e04e86f9cfd766623149297e971/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586", size = 2073164, upload-time = "2025-11-04T13:40:40.289Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e3/f6e262673c6140dd3305d144d032f7bd5f7497d3871c1428521f19f9efa2/pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d", size = 2179146, upload-time = "2025-11-04T13:40:42.809Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c7/20bd7fc05f0c6ea2056a4565c6f36f8968c0924f19b7d97bbfea55780e73/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740", size = 2137788, upload-time = "2025-11-04T13:40:44.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8d/34318ef985c45196e004bc46c6eab2eda437e744c124ef0dbe1ff2c9d06b/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e", size = 2340133, upload-time = "2025-11-04T13:40:46.66Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/013626bf8c78a5a5d9350d12e7697d3d4de951a75565496abd40ccd46bee/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858", size = 2324852, upload-time = "2025-11-04T13:40:48.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36", size = 1994679, upload-time = "2025-11-04T13:40:50.619Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11", size = 2019766, upload-time = "2025-11-04T13:40:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd", size = 1981005, upload-time = "2025-11-04T13:40:54.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/28/46b7c5c9635ae96ea0fbb779e271a38129df2550f763937659ee6c5dbc65/pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a", size = 2119622, upload-time = "2025-11-04T13:40:56.68Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1a/145646e5687e8d9a1e8d09acb278c8535ebe9e972e1f162ed338a622f193/pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14", size = 1891725, upload-time = "2025-11-04T13:40:58.807Z" },
+    { url = "https://files.pythonhosted.org/packages/23/04/e89c29e267b8060b40dca97bfc64a19b2a3cf99018167ea1677d96368273/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1", size = 1915040, upload-time = "2025-11-04T13:41:00.853Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a3/15a82ac7bd97992a82257f777b3583d3e84bdb06ba6858f745daa2ec8a85/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66", size = 2063691, upload-time = "2025-11-04T13:41:03.504Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/0046701313c6ef08c0c1cf0e028c67c770a4e1275ca73131563c5f2a310a/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869", size = 2213897, upload-time = "2025-11-04T13:41:05.804Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cd/6bac76ecd1b27e75a95ca3a9a559c643b3afcd2dd62086d4b7a32a18b169/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2", size = 2333302, upload-time = "2025-11-04T13:41:07.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375", size = 2064877, upload-time = "2025-11-04T13:41:09.827Z" },
+    { url = "https://files.pythonhosted.org/packages/18/66/e9db17a9a763d72f03de903883c057b2592c09509ccfe468187f2a2eef29/pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553", size = 2180680, upload-time = "2025-11-04T13:41:12.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9e/3ce66cebb929f3ced22be85d4c2399b8e85b622db77dad36b73c5387f8f8/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90", size = 2138960, upload-time = "2025-11-04T13:41:14.627Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/205a998f4327d2079326b01abee48e502ea739d174f0a89295c481a2272e/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07", size = 2339102, upload-time = "2025-11-04T13:41:16.868Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/0d/f05e79471e889d74d3d88f5bd20d0ed189ad94c2423d81ff8d0000aab4ff/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb", size = 2326039, upload-time = "2025-11-04T13:41:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/e08a6208bb100da7e0c4b288eed624a703f4d129bde2da475721a80cab32/pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23", size = 1995126, upload-time = "2025-11-04T13:41:21.418Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5d/56ba7b24e9557f99c9237e29f5c09913c81eeb2f3217e40e922353668092/pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf", size = 2015489, upload-time = "2025-11-04T13:41:24.076Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/bb/f7a190991ec9e3e0ba22e4993d8755bbc4a32925c0b5b42775c03e8148f9/pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0", size = 1977288, upload-time = "2025-11-04T13:41:26.33Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ed/77542d0c51538e32e15afe7899d79efce4b81eee631d99850edc2f5e9349/pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a", size = 2120255, upload-time = "2025-11-04T13:41:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/3d/6913dde84d5be21e284439676168b28d8bbba5600d838b9dca99de0fad71/pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3", size = 1863760, upload-time = "2025-11-04T13:41:31.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f0/e5e6b99d4191da102f2b0eb9687aaa7f5bea5d9964071a84effc3e40f997/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c", size = 1878092, upload-time = "2025-11-04T13:41:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/71/48/36fb760642d568925953bcc8116455513d6e34c4beaa37544118c36aba6d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612", size = 2053385, upload-time = "2025-11-04T13:41:35.508Z" },
+    { url = "https://files.pythonhosted.org/packages/20/25/92dc684dd8eb75a234bc1c764b4210cf2646479d54b47bf46061657292a8/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d", size = 2218832, upload-time = "2025-11-04T13:41:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/09/f53e0b05023d3e30357d82eb35835d0f6340ca344720a4599cd663dca599/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9", size = 2327585, upload-time = "2025-11-04T13:41:40Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4e/2ae1aa85d6af35a39b236b1b1641de73f5a6ac4d5a7509f77b814885760c/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660", size = 2041078, upload-time = "2025-11-04T13:41:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/13/2e215f17f0ef326fc72afe94776edb77525142c693767fc347ed6288728d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9", size = 2173914, upload-time = "2025-11-04T13:41:45.221Z" },
+    { url = "https://files.pythonhosted.org/packages/02/7a/f999a6dcbcd0e5660bc348a3991c8915ce6599f4f2c6ac22f01d7a10816c/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3", size = 2129560, upload-time = "2025-11-04T13:41:47.474Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/b1/6c990ac65e3b4c079a4fb9f5b05f5b013afa0f4ed6780a3dd236d2cbdc64/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf", size = 2329244, upload-time = "2025-11-04T13:41:49.992Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/02/3c562f3a51afd4d88fff8dffb1771b30cfdfd79befd9883ee094f5b6c0d8/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470", size = 2331955, upload-time = "2025-11-04T13:41:54.079Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -848,6 +950,7 @@ dependencies = [
 
 [package.optional-dependencies]
 all = [
+    { name = "fastapi" },
     { name = "marimo" },
     { name = "mkdocstrings", extra = ["python"] },
     { name = "numpy" },
@@ -870,6 +973,7 @@ dev = [
     { name = "zensical" },
 ]
 ui = [
+    { name = "fastapi" },
     { name = "marimo" },
     { name = "uvicorn" },
 ]
@@ -885,6 +989,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "fastapi", marker = "extra == 'ui'", specifier = ">=0.115.0" },
     { name = "fastexcel", specifier = ">=0.19.0" },
     { name = "marimo", marker = "extra == 'ui'", specifier = ">=0.5.0" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'dev'", specifier = ">=0.24.0" },
@@ -965,6 +1070,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/21/16/0a56b8667296e2989b9d48095472d98ebf57a0006c71f2a101bbc62a142d/ty-0.0.26-py3-none-win32.whl", hash = "sha256:943c998c5523ed6b519c899c0c39b26b4c751a9759e460fb964765a44cde226f", size = 9912378, upload-time = "2026-03-26T16:27:08.999Z" },
     { url = "https://files.pythonhosted.org/packages/60/c2/fef0d4bba9cd89a82d725b3b1a66efb1b36629ecf0fb1d8e916cb75b8829/ty-0.0.26-py3-none-win_amd64.whl", hash = "sha256:19c856d343efeb1ecad8ee220848f5d2c424daf7b2feda357763ad3036e2172f", size = 10863737, upload-time = "2026-03-26T16:27:27.06Z" },
     { url = "https://files.pythonhosted.org/packages/4d/05/888ebcb3c4d3b6b72d5d3241fddd299142caa3c516e6d26a9cd887dfed3b/ty-0.0.26-py3-none-win_arm64.whl", hash = "sha256:2cde58ccffa046db1223dc28f3e7d4f2c7da8267e97cc5cd186af6fe85f1758a", size = 10285408, upload-time = "2026-03-26T16:27:16.432Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add a dual-server architecture for the Marimo UI:
- Port 8000: FastAPI gateway serving read-only templates + REST API
- Port 8002: marimo edit server for editable user workbooks

Users can duplicate any template (calculator, results explorer, comparison,
reference) into a persistent workspace and interact with data using full
Python and SQL editing via marimo's edit mode.

API endpoints:
- GET /api/templates — list available templates
- GET /api/workbooks — list user workbooks
- POST /api/workbooks/duplicate — duplicate a template
- DELETE /api/workbooks/{name} — delete a workbook

https://claude.ai/code/session_01GbUgWAxm1UPvUbhHYrt2cN