### PR TITLE
Simplify IRB approach dropdown to standardised vs IRB modes

### DIFF
--- a/src/rwa_calc/ui/marimo/rwa_app.py
+++ b/src/rwa_calc/ui/marimo/rwa_app.py
@@ -120,14 +120,11 @@ def _(mo):
 
     irb_approach_dropdown = mo.ui.dropdown(
         options={
-            "SA Only (No IRB)": "sa_only",
-            "Foundation IRB (F-IRB)": "firb",
-            "Advanced IRB (A-IRB)": "airb",
-            "Full IRB (A-IRB preferred)": "full_irb",
-            "Retail A-IRB / Corporate F-IRB": "retail_airb_corporate_firb",
+            "Standardised (All SA)": "standardised",
+            "IRB (Model Permissions)": "irb",
         },
-        value="SA Only (No IRB)",
-        label="IRB Approach",
+        value="Standardised (All SA)",
+        label="Permission Mode",
     )
 
     mo.output.replace(


### PR DESCRIPTION
## Summary
Simplified the IRB approach dropdown in the marimo UI from five granular options (SA Only, F-IRB, A-IRB, Full IRB, Retail/Corporate hybrid) to two high-level permission modes: "Standardised (All SA)" and "IRB (Model Permissions)". Updated the label from "IRB Approach" to "Permission Mode" to reflect the simplified conceptual model.

## Regulatory Context
This change aligns with Basel 3.1's two primary capital calculation frameworks: the Standardised Approach (SA) and the Internal Ratings-Based (IRB) Approach. The previous granular breakdown of IRB variants (Foundation, Advanced, Full) is consolidated into a single IRB option, simplifying the user interface while maintaining the core regulatory distinction.

## Changes

### UI/UX
- Reduced dropdown options from 5 to 2 for improved usability
- Updated option labels to reflect higher-level permission modes rather than specific IRB methodologies
- Changed dropdown label from "IRB Approach" to "Permission Mode"
- Updated default selection to "Standardised (All SA)"

### Data Model
- Simplified internal option values: `"standardised"` and `"irb"` (replacing `sa_only`, `firb`, `airb`, `full_irb`, `retail_airb_corporate_firb`)

## Testing
N/A - UI configuration change with no calculation logic impact. Existing tests remain valid as the underlying dropdown mechanism is unchanged.

## Breaking Changes
- Users with saved preferences for specific IRB variants (F-IRB, A-IRB, Full IRB, Retail/Corporate) will need to re-select between the two new modes
- Any external code referencing the old option values will need to be updated to use `"standardised"` or `"irb"`

## Related
Simplifies the permission mode selection for end users while maintaining regulatory compliance with Basel 3.1 framework requirements.