### PR TITLE
Auto-open browser on marimo server startup and improve UI setup

### DIFF
--- a/src/rwa_calc/ui/marimo/__init__.py
+++ b/src/rwa_calc/ui/marimo/__init__.py
@@ -11,7 +11,7 @@ Usage (Multi-App Server - Recommended):
     uv run python src/rwa_calc/ui/marimo/server.py
 
     # Apps available at:
-    #   http://localhost:8000/           (Calculator)
+    #   http://localhost:8000/           (Landing Page)
     #   http://localhost:8000/calculator (Calculator)
     #   http://localhost:8000/results    (Results Explorer)
     #   http://localhost:8000/comparison (Impact Analysis)

--- a/src/rwa_calc/ui/marimo/landing_app.py
+++ b/src/rwa_calc/ui/marimo/landing_app.py
@@ -57,7 +57,7 @@ def _(mo):
 
 @app.cell
 def _(mo):
-    return mo.Html(
+    return mo.md(
         """
 <style>
 /* -------------------------------------------------------

--- a/src/rwa_calc/ui/marimo/server.py
+++ b/src/rwa_calc/ui/marimo/server.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import shutil
 import subprocess
 import sys
+import webbrowser
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -68,6 +69,12 @@ templates_asgi = (
 # FastAPI gateway
 # ---------------------------------------------------------------------------
 gateway = FastAPI(title="RWA Calculator")
+
+
+@gateway.on_event("startup")
+async def _open_browser() -> None:
+    """Open the landing page in the default browser on server start."""
+    webbrowser.open("http://localhost:8000")
 
 
 @gateway.get("/api/templates")
@@ -146,6 +153,7 @@ def main() -> None:
             "--port",
             str(EDIT_SERVER_PORT),
             "--no-token",
+            "--headless",
             str(workspaces_dir),
         ],
     )


### PR DESCRIPTION
## Summary
Automatically open the default browser to the landing page when the marimo server starts, and configure the marimo editor in headless mode for better server integration.

## Changes

### Other
- Added `webbrowser.open()` call in FastAPI startup event to automatically navigate to `http://localhost:8000` when the server starts
- Added `--headless` flag to marimo editor subprocess invocation to run the editor without opening a browser window
- Updated documentation comment to clarify that `http://localhost:8000/` serves the Landing Page (not the Calculator directly)
- Changed `landing_app.py` to use `mo.md()` instead of `mo.Html()` for rendering the landing page content

## Testing
N/A - Configuration and UI initialization changes. Existing server startup tests will validate the changes.

## Breaking Changes
None - These are UX improvements that don't affect the API or data model.
