### PR TITLE
Add base_url parameter to sidebar for workbench navigation

### DIFF
--- a/src/rwa_calc/ui/marimo/shared/sidebar.py
+++ b/src/rwa_calc/ui/marimo/shared/sidebar.py
@@ -13,7 +13,7 @@ _MARIMO_DIR = Path(__file__).parent.parent
 _WORKSPACES_DIR = _MARIMO_DIR / "workspaces" / "local"
 
 
-def create_sidebar(mo: object, *, version: str = "v1.0") -> object:
+def create_sidebar(mo: object, *, version: str = "v1.0", base_url: str = "") -> object:
     """Build the standard RWA Calculator sidebar.
 
     Must be used as the last expression in a marimo cell, e.g.::
@@ -25,6 +25,9 @@ def create_sidebar(mo: object, *, version: str = "v1.0") -> object:
     Args:
         mo: The marimo module (passed from the calling cell).
         version: Version string shown in the footer.
+        base_url: URL prefix for nav links. Use ``"http://localhost:8000"``
+            when rendering from the workbench edit server (port 8002) so
+            that sidebar links navigate back to the main template apps.
 
     Returns:
         The ``mo.sidebar`` element (must be the cell's last expression).
@@ -42,12 +45,12 @@ def create_sidebar(mo: object, *, version: str = "v1.0") -> object:
         mo.md("# 🕵️🤖 RWA Calculator"),
         mo.nav_menu(
             {
-                "/": f"{mo.icon('home')} Home",
-                "/calculator": f"{mo.icon('calculator')} Calculator",
-                "/results": f"{mo.icon('table')} Results Explorer",
-                "/comparison": f"{mo.icon('git-compare')} Impact Analysis",
-                "/reference": f"{mo.icon('book')} Framework Reference",
-                "/workbench": f"{mo.icon('code')} Workbench",
+                f"{base_url}/": f"{mo.icon('home')} Home",
+                f"{base_url}/calculator": f"{mo.icon('calculator')} Calculator",
+                f"{base_url}/results": f"{mo.icon('table')} Results Explorer",
+                f"{base_url}/comparison": f"{mo.icon('git-compare')} Impact Analysis",
+                f"{base_url}/reference": f"{mo.icon('book')} Framework Reference",
+                f"{base_url}/workbench": f"{mo.icon('code')} Workbench",
             },
             orientation="vertical",
         ),

--- a/src/rwa_calc/ui/marimo/workspaces/templates/starter.py
+++ b/src/rwa_calc/ui/marimo/workspaces/templates/starter.py
@@ -56,7 +56,7 @@ def _(mo, project_root):
         _sys.path.insert(0, _shared)
     from sidebar import create_sidebar as _create_sidebar
 
-    _create_sidebar(mo)
+    _create_sidebar(mo, base_url="http://localhost:8000")
     return
 
 


### PR DESCRIPTION
## Summary
Add configurable `base_url` parameter to the sidebar component to support navigation from the workbench edit server back to main template apps.

## Changes

### Other
- Added `base_url` parameter to `create_sidebar()` function with default empty string for backward compatibility
- Updated all navigation menu links to prepend the `base_url` prefix using f-string formatting
- Updated the starter template workspace to pass `base_url="http://localhost:8000"` when rendering from the workbench edit server (port 8002)
- Enhanced docstring to document the new parameter and its use case

## Testing
N/A - Configuration change with no calculation logic affected. Existing sidebar functionality remains unchanged when `base_url` is not provided (default empty string).

## Breaking Changes
None - The `base_url` parameter is optional with a default value that preserves existing behavior.

## Related
Enables workbench users to navigate back to the main RWA Calculator applications via sidebar links.

https://claude.ai/code/session_014NhPxdS3a5atog7xiyMWAr