### PR TITLE
fix(hierarchy): stop external ratings inheriting down org hierarchy

### DIFF
--- a/src/rwa_calc/engine/hierarchy.py
+++ b/src/rwa_calc/engine/hierarchy.py
@@ -278,14 +278,16 @@ class HierarchyResolver:
         Build rating lookup with dual per-type resolution and inheritance.
 
         Resolves the best internal and best external rating separately per
-        counterparty, then inherits each type independently from the ultimate
-        parent when the entity has no own rating of that type.
+        counterparty, then inherits internal ratings from the ultimate parent
+        when the entity has no own internal rating. External ratings are NOT
+        inherited — they apply only to the counterparty explicitly rated by
+        the agency.
 
         Returns LazyFrame with columns:
         - counterparty_reference: The entity
         - internal_pd: Best internal PD (own or inherited from parent)
         - internal_model_id: Model ID for the internal rating
-        - external_cqs: Best external CQS (own or inherited from parent)
+        - external_cqs: Best external CQS (own only — not inherited)
         - cqs: Alias of external_cqs
         - pd: Alias of internal_pd
         """
@@ -368,21 +370,8 @@ class HierarchyResolver:
             how="left",
         )
 
-        # Parent's best external
-        parent_external = best_external.select(
-            [
-                pl.col("_ext_cp").alias("_p_ext_cp"),
-                pl.col("external_cqs").alias("parent_external_cqs"),
-            ]
-        )
-        result = result.join(
-            parent_external,
-            left_on="ultimate_parent_reference",
-            right_on="_p_ext_cp",
-            how="left",
-        )
-
-        # Per-type inheritance: coalesce own → parent for each type
+        # Internal-only inheritance: coalesce own → parent for internal ratings
+        # External ratings are NOT inherited — they stay as the entity's own value
         result = result.with_columns(
             [
                 pl.coalesce(pl.col("internal_pd"), pl.col("parent_internal_pd")).alias(
@@ -390,9 +379,6 @@ class HierarchyResolver:
                 ),
                 pl.coalesce(pl.col("internal_model_id"), pl.col("parent_internal_model_id")).alias(
                     "internal_model_id"
-                ),
-                pl.coalesce(pl.col("external_cqs"), pl.col("parent_external_cqs")).alias(
-                    "external_cqs"
                 ),
             ]
         )

--- a/tests/fixtures/ratings/ratings.py
+++ b/tests/fixtures/ratings/ratings.py
@@ -251,7 +251,7 @@ def _corporate_external_ratings() -> list[Rating]:
             RATING_DATE,
             True,
         ),
-        # Group 1 subsidiaries intentionally have NO external rating - test inheritance
+        # Group 1 subsidiaries have NO external rating — external ratings are not inherited
         # Group 2 Ultimate Parent - rated CQS 1 for multi-level inheritance
         Rating(
             "RTG_CORP_GRP2_ULTIMATE",
@@ -264,7 +264,7 @@ def _corporate_external_ratings() -> list[Rating]:
             RATING_DATE,
             True,
         ),
-        # Group 2 intermediate and operating subs have NO external rating - test inheritance
+        # Group 2 intermediate and operating subs have NO external rating — not inherited
         # Group 3 SME Parent - rated CQS 3
         Rating(
             "RTG_CORP_GRP3_PARENT",

--- a/tests/integration/test_hierarchy_to_classifier.py
+++ b/tests/integration/test_hierarchy_to_classifier.py
@@ -403,11 +403,11 @@ class TestParentChildHierarchy:
     def test_parent_rating_inherited_when_own_missing(
         self, hierarchy_resolver, classifier, crr_full_irb_config
     ):
-        """Child counterparty inherits parent's rating via hierarchy resolution.
+        """Child counterparty is classified even without its own ratings.
 
-        When a child has no rating but parent does, the hierarchy resolver
-        propagates the parent's rating. The classifier then uses the
-        inherited rating for approach determination.
+        Hierarchy resolver builds parent mappings. Only internal ratings
+        inherit from parent to child; external ratings do not. The
+        classifier determines approach based on available ratings.
         """
         bundle = make_raw_data_bundle(
             counterparties=[

--- a/tests/unit/test_hierarchy.py
+++ b/tests/unit/test_hierarchy.py
@@ -101,18 +101,18 @@ def multi_level_org_mappings() -> pl.LazyFrame:
 
 @pytest.fixture
 def simple_ratings() -> pl.LazyFrame:
-    """Simple ratings - only parent has rating."""
+    """Simple ratings - parent has both internal and external ratings."""
     return pl.DataFrame(
         {
-            "rating_reference": ["RAT001"],
-            "counterparty_reference": ["CP001"],
-            "rating_type": ["external"],
-            "rating_agency": ["MOODYS"],
-            "rating_value": ["A2"],
-            "cqs": [2],
-            "pd": [0.001],
-            "rating_date": [date(2024, 6, 1)],
-            "is_solicited": [True],
+            "rating_reference": ["RAT001", "RAT002"],
+            "counterparty_reference": ["CP001", "CP001"],
+            "rating_type": ["external", "internal"],
+            "rating_agency": ["MOODYS", "INT"],
+            "rating_value": ["A2", "INT_A"],
+            "cqs": [2, None],
+            "pd": [None, 0.001],
+            "rating_date": [date(2024, 6, 1), date(2024, 6, 1)],
+            "is_solicited": [True, True],
         }
     ).lazy()
 
@@ -347,7 +347,7 @@ class TestBuildRatingInheritanceLazy:
         simple_ratings: pl.LazyFrame,
         simple_org_mappings: pl.LazyFrame,
     ) -> None:
-        """Entity with own rating should not inherit."""
+        """Entity with own rating should use its own ratings."""
         ultimate_parents = resolver._build_ultimate_parent_lazy(simple_org_mappings)
 
         rating_inheritance = resolver._build_rating_inheritance_lazy(
@@ -357,18 +357,19 @@ class TestBuildRatingInheritanceLazy:
         )
         df = rating_inheritance.collect()
 
-        # CP001 has own rating
+        # CP001 has own external and internal ratings
         cp001 = df.filter(pl.col("counterparty_reference") == "CP001")
         assert cp001["cqs"][0] == 2
+        assert cp001["internal_pd"][0] == pytest.approx(0.001)
 
-    def test_entity_inherits_from_parent(
+    def test_internal_rating_inherits_from_parent(
         self,
         resolver: HierarchyResolver,
         simple_counterparties: pl.LazyFrame,
         simple_ratings: pl.LazyFrame,
         simple_org_mappings: pl.LazyFrame,
     ) -> None:
-        """Unrated child should inherit parent rating."""
+        """Unrated child inherits parent's internal rating but not external."""
         ultimate_parents = resolver._build_ultimate_parent_lazy(simple_org_mappings)
 
         rating_inheritance = resolver._build_rating_inheritance_lazy(
@@ -378,9 +379,12 @@ class TestBuildRatingInheritanceLazy:
         )
         df = rating_inheritance.collect()
 
-        # CP002 inherits from CP001
+        # CP002 inherits internal from CP001 but NOT external
         cp002 = df.filter(pl.col("counterparty_reference") == "CP002")
-        assert cp002["cqs"][0] == 2
+        assert cp002["internal_pd"][0] == pytest.approx(0.001)
+        assert cp002["pd"][0] == pytest.approx(0.001)
+        assert cp002["cqs"][0] is None
+        assert cp002["external_cqs"][0] is None
 
     def test_standalone_unrated_entity(
         self,
@@ -493,7 +497,7 @@ class TestDualRatingResolution:
         self,
         resolver: HierarchyResolver,
     ) -> None:
-        """Child has own internal, parent has external → child gets both."""
+        """Child keeps own internal; parent's external does not inherit."""
         counterparties = pl.DataFrame({"counterparty_reference": ["PARENT", "CHILD"]}).lazy()
         ratings = pl.DataFrame(
             {
@@ -520,13 +524,61 @@ class TestDualRatingResolution:
         ).collect()
 
         child = result.filter(pl.col("counterparty_reference") == "CHILD")
-        # Own internal
+        # Own internal retained
         assert child["internal_pd"][0] == pytest.approx(0.003)
-        # Inherited external from parent
-        assert child["external_cqs"][0] == 1
-        # Derived
-        assert child["cqs"][0] == 1  # External-first
-        assert child["pd"][0] == pytest.approx(0.003)  # Internal PD
+        assert child["pd"][0] == pytest.approx(0.003)
+        # External does NOT inherit from parent
+        assert child["external_cqs"][0] is None
+        assert child["cqs"][0] is None
+
+    def test_external_rating_does_not_inherit(
+        self,
+        resolver: HierarchyResolver,
+    ) -> None:
+        """External ratings must not inherit from parent to child.
+
+        External ratings (from agencies like S&P, Fitch) are specific to
+        the counterparty they were assigned to. Only internal ratings
+        inherit down the org hierarchy.
+        """
+        counterparties = pl.DataFrame(
+            {"counterparty_reference": ["PARENT", "CHILD"]}
+        ).lazy()
+        ratings = pl.DataFrame(
+            {
+                "rating_reference": ["PARENT_EXT"],
+                "counterparty_reference": ["PARENT"],
+                "rating_type": ["external"],
+                "rating_agency": ["SP"],
+                "rating_value": ["A+"],
+                "cqs": [1],
+                "pd": [None],
+                "rating_date": [date(2024, 6, 1)],
+            }
+        ).lazy()
+        org_mappings = pl.DataFrame(
+            {
+                "parent_counterparty_reference": ["PARENT"],
+                "child_counterparty_reference": ["CHILD"],
+            }
+        ).lazy()
+        ultimate_parents = resolver._build_ultimate_parent_lazy(org_mappings)
+
+        result = resolver._build_rating_inheritance_lazy(
+            counterparties, ratings, ultimate_parents
+        ).collect()
+
+        # Parent keeps own external rating
+        parent = result.filter(pl.col("counterparty_reference") == "PARENT")
+        assert parent["external_cqs"][0] == 1
+        assert parent["cqs"][0] == 1
+
+        # Child must NOT inherit parent's external rating
+        child = result.filter(pl.col("counterparty_reference") == "CHILD")
+        assert child["external_cqs"][0] is None
+        assert child["cqs"][0] is None
+        assert child["internal_pd"][0] is None
+        assert child["pd"][0] is None
 
     def test_external_only_counterparty(
         self,


### PR DESCRIPTION
## Summary
- External ratings (from agencies like S&P, Fitch) were incorrectly inherited from parent to child counterparties via `coalesce()` in `_build_rating_inheritance_lazy()`
- Only internal ratings (assigned by the firm's own process) should inherit down the org hierarchy — external ratings are specific to the entity the agency rated
- Removed the parent external join and `coalesce(external_cqs, parent_external_cqs)` so children without their own external rating correctly get unrated SA treatment

## Test plan
- [x] All 8 rating inheritance unit tests pass (2 fixed, 1 new, 5 unchanged)
- [x] 71 hierarchy unit tests pass
- [x] 19 hierarchy→classifier integration tests pass
- [x] Full suite: 2,308 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)