### PR TITLE
fix(docs): correct skill reference errors D1.13-D1.19

### DIFF
--- a/.claude/skills/basel31/SKILL.md
+++ b/.claude/skills/basel31/SKILL.md
@@ -14,7 +14,7 @@ framework shifts emphasis from risk sensitivity to comparability and floors.
 
 ## Top 10 Changes from CRR
 
-1. **Output floor** — IRB RWA floored at 72.5% of SA-equivalent (phased in 2027-2032)
+1. **Output floor** — IRB RWA floored at 72.5% of SA-equivalent (phased in 2027-2030)
 2. **Supporting factors removed** — no SME (0.7619/0.85) or infrastructure (0.75) relief
 3. **1.06 scaling factor removed** — ~5.7% IRB RWA reduction before output floor
 4. **Differentiated PD floors** — class-specific (0.05%-0.10%) vs CRR uniform 0.03%
@@ -104,12 +104,10 @@ Priority ordering — highest-priority class applies when exposure meets multipl
 
 | Year | Floor % |
 |------|---------|
-| 2027 | 50.0% |
-| 2028 | 55.0% |
-| 2029 | 60.0% |
-| 2030 | 65.0% |
-| 2031 | 70.0% |
-| 2032+ | 72.5% |
+| 2027 | 60.0% |
+| 2028 | 65.0% |
+| 2029 | 70.0% |
+| 2030+ | 72.5% |
 
 ### Equity SA Phase-In (Art. 4.2/4.3)
 

--- a/.claude/skills/basel31/references/crm-changes.md
+++ b/.claude/skills/basel31/references/crm-changes.md
@@ -43,8 +43,8 @@ Maturity bands expand from 3 to 5. Significant increases for equities and long-d
 | Govt bonds CQS 2-3 | 1% | 3% | 4% | 6% | **12%** |
 | Corp bonds CQS 1 | 1% | 4% | 6% | **10%** | **12%** |
 | Corp bonds CQS 2-3 | 2% | 6% | 8% | **15%** | **15%** |
-| Main index equities | **25%** | — | — | — | — |
-| Other equities | **35%** | — | — | — | — |
+| Main index equities | **20%** | — | — | — | — |
+| Other equities | **30%** | — | — | — | — |
 | Gold | 15% | — | — | — | — |
 | Cash | 0% | — | — | — | — |
 
@@ -52,8 +52,8 @@ Maturity bands expand from 3 to 5. Significant increases for equities and long-d
 
 | Collateral | CRR | Basel 3.1 | Change |
 |------------|-----|-----------|--------|
-| Main index equities | 15% | 25% | +10pp |
-| Other listed equities | 25% | 35% | +10pp |
+| Main index equities | 15% | 20% | +5pp |
+| Other listed equities | 25% | 30% | +5pp |
 | Govt bonds CQS 2-3 (10y+) | 6% | 12% | +6pp |
 | Corp bonds CQS 1 (10y+) | 8% | 12% | +4pp |
 | Corp bonds CQS 2-3 (5-10y/10y+) | 12% | 15% | +3pp |

--- a/.claude/skills/basel31/references/irb-changes.md
+++ b/.claude/skills/basel31/references/irb-changes.md
@@ -12,9 +12,9 @@ All IRB parameter changes from CRR to Basel 3.1.
 |----------------|-----|-----------|
 | Corporate | 0.03% | 0.05% |
 | Corporate SME | 0.03% | 0.05% |
-| Retail Mortgage | 0.03% | 0.05% |
+| Retail Mortgage | 0.03% | 0.10% |
 | Retail Other | 0.03% | 0.05% |
-| QRRE (Transactors) | 0.03% | 0.03% |
+| QRRE (Transactors) | 0.03% | 0.05% |
 | QRRE (Revolvers) | 0.03% | 0.10% |
 
 ## A-IRB LGD Floors (CRE32, Art. 161(5), 164(4))
@@ -24,7 +24,6 @@ All IRB parameter changes from CRR to Basel 3.1.
 | Collateral Type | CRR | Basel 3.1 |
 |----------------|-----|-----------|
 | Unsecured (Senior) | None | 25% |
-| Unsecured (Subordinated) | None | 50% |
 | Financial collateral | None | 0% |
 | Receivables | None | 10%* |
 | Commercial RE | None | 10%* |

--- a/.claude/skills/basel31/references/output-floor.md
+++ b/.claude/skills/basel31/references/output-floor.md
@@ -31,12 +31,10 @@ Without OF-ADJ, the floor comparison would not be on a like-for-like basis.
 
 | Year | Floor % |
 |------|---------|
-| 2027 | 50.0% |
-| 2028 | 55.0% |
-| 2029 | 60.0% |
-| 2030 | 65.0% |
-| 2031 | 70.0% |
-| 2032+ | 72.5% |
+| 2027 | 60.0% |
+| 2028 | 65.0% |
+| 2029 | 70.0% |
+| 2030+ | 72.5% |
 
 ## Worked Example
 

--- a/.claude/skills/basel31/references/slotting-changes.md
+++ b/.claude/skills/basel31/references/slotting-changes.md
@@ -10,12 +10,14 @@ Slotting risk weight restructuring from CRR to Basel 3.1.
 
 **CRR:** 2-table structure (HVCRE vs non-HVCRE) x 2 maturity bands (< 2.5yr, >= 2.5yr)
 
-**Basel 3.1:** 3-table structure (Operational, PF Pre-Operational, HVCRE), no maturity
-differentiation in base weights.
+**Basel 3.1 (PRA):** 2-table structure (Non-HVCRE, HVCRE), no maturity
+differentiation in base weights. PRA does not adopt the BCBS separate pre-operational
+PF table — all non-HVCRE specialised lending (including PF pre-operational) uses the
+standard non-HVCRE table.
 
 ## Basel 3.1 Slotting Tables
 
-### Non-HVCRE Operational (OF, CF, IPRE, PF Operational)
+### Non-HVCRE (OF, CF, IPRE, PF — including pre-operational)
 
 | Category | Risk Weight |
 |----------|-------------|
@@ -23,16 +25,6 @@ differentiation in base weights.
 | Good | 90% |
 | Satisfactory | 115% |
 | Weak | 250% |
-| Default | 0% (EL) |
-
-### Project Finance Pre-Operational
-
-| Category | Risk Weight |
-|----------|-------------|
-| Strong | 80% |
-| Good | 100% |
-| Satisfactory | 120% |
-| Weak | 350% |
 | Default | 0% (EL) |
 
 ### HVCRE
@@ -54,18 +46,18 @@ Within Strong and Good categories, subgrades allow finer differentiation:
 | Strong A / B | 50% / 70% (PF Op) | 70% / 70% |
 | Good C / D | 70% / 90% (PF Op) | 90% / 90% |
 
-## Project Finance Comparison (CRR vs Basel 3.1)
+## Project Finance Comparison (CRR vs Basel 3.1 PRA)
 
-| Category | CRR (>=2.5yr) | CRR (<2.5yr) | B3.1 Pre-Op | B3.1 Operational |
-|----------|---------------|--------------|-------------|------------------|
-| Strong | 70% | 50% | 80% | 70% |
-| Good | 90% | 70% | 100% | 90% |
-| Satisfactory | 115% | 115% | 120% | 115% |
-| Weak | 250% | 250% | 350% | 250% |
-| Default | 0% | 0% | 0% | 0% |
+| Category | CRR (>=2.5yr) | CRR (<2.5yr) | B3.1 (PRA) |
+|----------|---------------|--------------|------------|
+| Strong | 70% | 50% | 70% |
+| Good | 90% | 70% | 90% |
+| Satisfactory | 115% | 115% | 115% |
+| Weak | 250% | 250% | 250% |
+| Default | 0% | 0% | 0% |
 
-Key change: PF pre-operational gets higher weights than CRR (80%/100%/120%/350%),
-while PF operational is broadly unchanged. Weak PF pre-op jumps from 250% to 350%.
+Key change: PRA removes maturity differentiation — the CRR short-maturity discount
+(50%/70% for Strong/Good at <2.5yr) is eliminated. All PF uses the single non-HVCRE table.
 
 ---
 

--- a/.claude/skills/basel31/references/what-changed.md
+++ b/.claude/skills/basel31/references/what-changed.md
@@ -68,8 +68,8 @@ Master delta summary. Every major parameter change in one place.
 | Aspect | CRR | Basel 3.1 | Change |
 |--------|-----|-----------|--------|
 | Haircut maturity bands | 3 (0-1y, 1-5y, 5y+) | 5 (0-1y, 1-3y, 3-5y, 5-10y, 10y+) | More granular |
-| Main index equity haircut | 15% | 25% | +10pp |
-| Other equity haircut | 25% | 35% | +10pp |
+| Main index equity haircut | 15% | 20% | +5pp |
+| Other equity haircut | 25% | 30% | +5pp |
 | Unfunded protection | Cancellable test | +changeable test | Stricter |
 | Method names | Various | FCM, PSM, LGD-AM | Clarified |
 

--- a/.claude/skills/crr/references/credit-risk-mitigation.md
+++ b/.claude/skills/crr/references/credit-risk-mitigation.md
@@ -34,14 +34,6 @@ Quick-reference for collateral haircuts, overcollateralisation, and guarantee su
 | Main index | 15% |
 | Other listed | 25% |
 
-### Non-Financial Collateral
-
-| Type | Haircut |
-|------|---------|
-| Receivables | 20% |
-| Real estate | 0% (handled via LTV, not haircut) |
-| Other physical | 40% |
-
 ## FX Mismatch Haircut (Art. 233)
 
 When collateral currency differs from exposure currency: **8%** additional haircut.

--- a/.claude/skills/crr/references/provisions-and-el.md
+++ b/.claude/skills/crr/references/provisions-and-el.md
@@ -2,7 +2,7 @@
 
 Quick-reference for provision treatment under SA and IRB.
 
-**Regulatory Reference:** CRR Articles 110, 111(2), 158-159
+**Regulatory Reference:** CRR Articles 110, 111(1)(a)-(b), 158-159
 
 ---
 
@@ -24,7 +24,7 @@ resolve_provisions -> CCF -> initialize_ead -> collateral -> guarantees -> final
 
 Direct allocations applied first; facility and counterparty distributed proportionally.
 
-## SA Approach (Art. 110, 111(2))
+## SA Approach (Art. 110, 111(1)(a)-(b))
 
 Drawn-first deduction:
 

--- a/.claude/skills/crr/references/slotting-and-equity.md
+++ b/.claude/skills/crr/references/slotting-and-equity.md
@@ -46,7 +46,6 @@ Quick-reference for specialised lending slotting risk weights and equity treatme
 |-------------|-------------|
 | Central bank / sovereign | 0% |
 | Listed / exchange-traded | 100% |
-| Government-supported | 100% |
 
 ### IRB Simple (Art. 155)
 

--- a/docs/specifications/crr/credit-conversion-factors.md
+++ b/docs/specifications/crr/credit-conversion-factors.md
@@ -146,7 +146,7 @@ Where:
 - **Accrued Interest**: Interest due but not yet paid
 - **Undrawn Amount**: Committed but undrawn facility limit minus drawn amount
 
-### Provision-Adjusted EAD (Art. 111(2))
+### Provision-Adjusted EAD (Art. 111(1)(a)-(b))
 
 When provisions are present (SA only), they are resolved **before** CCF application using a drawn-first deduction:
 
@@ -159,7 +159,7 @@ EAD = (max(0, Drawn Amount) - provision_on_drawn) + Accrued Interest
       + (nominal_after_provision × CCF)
 ```
 
-This ensures that provisions reduce the nominal amount before the CCF multiplier is applied, compliant with CRR Art. 111(2). For IRB/Slotting exposures, provisions are tracked but not deducted — the standard EAD formula applies.
+This ensures that provisions reduce the nominal amount before the CCF multiplier is applied, compliant with CRR Art. 111(1)(a)-(b). For IRB/Slotting exposures, provisions are tracked but not deducted — the standard EAD formula applies.
 
 ## Key Scenarios
 

--- a/docs/user-guide/methodology/crm.md
+++ b/docs/user-guide/methodology/crm.md
@@ -371,7 +371,7 @@ CRR Article 153(3) and CRE31.4 — when a guarantee provides credit protection, 
 
 ## Provisions
 
-### SA Treatment (Art. 111(2) Compliant)
+### SA Treatment (Art. 111(1)(a)-(b) Compliant)
 
 Provisions are resolved **before** CCF application using a drawn-first deduction approach:
 
@@ -436,7 +436,7 @@ Provisions can be allocated at different levels:
 When multiple CRM types are available, provisions are resolved first (before CCF), then the remaining CRM is applied after EAD initialization:
 
 ```python
-# Order of application (Art. 111(2) compliant)
+# Order of application (Art. 111(1)(a)-(b) compliant)
 1. Resolve provisions (before CCF) — drawn-first deduction, adjusts nominal
 2. Apply CCFs (uses nominal_after_provision for off-balance sheet conversion)
 3. Initialize EAD waterfall


### PR DESCRIPTION
## Summary

- **D1.13** — IRB PD floors: retail mortgage 0.05%→0.10%, QRRE transactors 0.03%→0.05%, removed subordinated 50% LGD row
- **D1.14** — Equity haircuts: BCBS 25%/35%→PRA 20%/30% (Art. 224 Table 3) in crm-changes.md and what-changed.md
- **D1.15** — Output floor: BCBS 6-year schedule (50%-72.5%, 2027-2032)→PRA 4-year (60%-72.5%, 2027-2030) in output-floor.md and SKILL.md
- **D1.16** — Slotting: removed BCBS pre-op PF table (80/100/120/350%), PRA uses single non-HVCRE table for all including pre-op
- **D1.17** — CRR CRM: removed fabricated non-financial collateral Art. 224 haircuts (receivables 20%, other physical 40%) — these use Foundation Collateral Method (Art. 230)
- **D1.18** — CRR equity: removed invented "Government-supported: 100%" SA category (not in Art. 133)
- **D1.19** — Provision article: Art. 111(2)→Art. 111(1)(a)-(b) across skill file, user guide, and CCF spec (Art. 111(2) governs derivative exposure values, not provision deduction)

## Test plan

- [x] Verify corrected values against PRA PS1/26 Appendix 1 source PDF
- [x] No code changes — documentation/skill references only
