### PR TITLE
fix(workbench): resolve sidebar/css imports for nested workbooks

### DIFF
--- a/src/rwa_calc/ui/marimo/.gitignore
+++ b/src/rwa_calc/ui/marimo/.gitignore
@@ -4,6 +4,4 @@
 # User workspaces (local workbooks, not templates)
 workspaces/local/
 
-# Auto-copied shared assets in team workspace (regenerated on server start)
-workspaces/team/shared/
 workspaces/team/**/__pycache__/

--- a/src/rwa_calc/ui/marimo/server.py
+++ b/src/rwa_calc/ui/marimo/server.py
@@ -161,21 +161,6 @@ def _list_items(base: Path, folder: str = "") -> list[dict[str, str]]:
     return items
 
 
-def _sync_shared_into(target_dir: Path) -> None:
-    """Copy the canonical ``shared/`` assets into *target_dir* / ``shared/``."""
-    shared_src = apps_dir / "shared"
-    if shared_src.exists():
-        shutil.copytree(shared_src, target_dir / "shared", dirs_exist_ok=True)
-
-
-def _sync_shared_recursive(base: Path) -> None:
-    """Copy ``shared/`` into *base* and every subfolder that is not itself ``shared``."""
-    _sync_shared_into(base)
-    for sub in base.iterdir():
-        if sub.is_dir() and sub.name not in _SKIP_DIRS:
-            _sync_shared_into(sub)
-
-
 # ---------------------------------------------------------------------------
 # Template API
 # ---------------------------------------------------------------------------
@@ -264,7 +249,6 @@ async def create_folder(name: str, workspace: str = "local") -> dict[str, str]:
     if target.exists():
         raise HTTPException(status_code=409, detail="Folder already exists")
     target.mkdir()
-    _sync_shared_into(target)
     return {"folder": sanitised, "workspace": workspace}
 
 
@@ -330,7 +314,6 @@ async def publish_to_team(name: str, folder: str = "") -> dict[str, str]:
 
     dest_parent = _validate_workspace_path(team_dir, folder) if folder else team_dir
     dest_parent.mkdir(parents=True, exist_ok=True)
-    _sync_shared_into(dest_parent)
 
     dest = publish(src, dest_parent)
     rel = f"team/{folder}/{dest.name}" if folder else f"team/{dest.name}"
@@ -399,10 +382,6 @@ def main() -> None:
 
     print("Starting RWA Calculator server...")
     print()
-
-    # Sync shared assets into both workspaces and their subfolders
-    _sync_shared_recursive(workspaces_dir)
-    _sync_shared_recursive(team_dir)
 
     # Launch marimo edit server for workbench (separate process/port)
     # Points at workspaces/ parent so both local/ and team/ are accessible

--- a/src/rwa_calc/ui/marimo/workbench_app.py
+++ b/src/rwa_calc/ui/marimo/workbench_app.py
@@ -634,7 +634,7 @@ def _(Path, create_btn, current_folder, mo, new_name, set_refresh, shutil):
 
 
 @app.cell
-def _(Path, create_folder_btn, folder_name, mo, set_refresh, shutil):
+def _(Path, create_folder_btn, folder_name, mo, set_refresh):
     mo.stop(not create_folder_btn.value)
 
     _name = folder_name.value.strip() or "new_folder"
@@ -645,10 +645,6 @@ def _(Path, create_folder_btn, folder_name, mo, set_refresh, shutil):
         mo.callout(mo.md(f"Folder **{_name}** already exists."), kind="warn")
     else:
         _target.mkdir(parents=True, exist_ok=True)
-        # Copy shared assets into the new folder
-        _shared_src = Path(__file__).parent / "shared"
-        if _shared_src.exists():
-            shutil.copytree(_shared_src, _target / "shared", dirs_exist_ok=True)
         set_refresh(lambda n: n + 1)
         mo.callout(mo.md(f"Created folder **{_name}**."), kind="success")
     return

--- a/src/rwa_calc/ui/marimo/workspaces/templates/starter.py
+++ b/src/rwa_calc/ui/marimo/workspaces/templates/starter.py
@@ -14,10 +14,25 @@ Usage:
     Opened for editing at http://localhost:8002.
 """
 
+from pathlib import Path as _Path
+
 import marimo
 
+# Resolve shared assets via absolute paths so this works at any nesting depth
+# under workspaces/. Walks up to find pyproject.toml as the project-root marker.
+_here = _Path(__file__).resolve()
+_project_root = next(
+    (p for p in _here.parents if (p / "pyproject.toml").exists()),
+    _here.parents[-1],
+)
+_shared_dir = _project_root / "src" / "rwa_calc" / "ui" / "marimo" / "shared"
+
 __generated_with = "0.19.4"
-app = marimo.App(width="medium", css_file="shared/theme.css", html_head_file="shared/head.html")
+app = marimo.App(
+    width="medium",
+    css_file=str(_shared_dir / "theme.css"),
+    html_head_file=str(_shared_dir / "head.html"),
+)
 
 
 @app.cell(hide_code=True)
@@ -30,11 +45,13 @@ def _():
     import marimo as mo
     import polars as pl
 
-    project_root = Path(__file__).parent
-    for _ in range(6):
-        if (project_root / "src").exists():
-            break
-        project_root = project_root.parent
+    # Locate project root by walking up parents to find pyproject.toml.
+    # Robust to any workbook nesting depth under workspaces/.
+    _here = Path(__file__).resolve()
+    project_root = next(
+        (p for p in _here.parents if (p / "pyproject.toml").exists()),
+        _here.parents[-1],
+    )
     if str(project_root) not in sys.path:
         sys.path.insert(0, str(project_root))
 


### PR DESCRIPTION
## Summary

- The starter template's `project_root` walk-up was a fixed 6-iteration loop that never reached the project root for workbooks one folder deep, causing `ModuleNotFoundError: No module named 'sidebar'` on open. Replaced with a `pyproject.toml` sentinel search that's robust to any nesting depth.
- Switched `marimo.App(css_file=..., html_head_file=...)` in the starter template to absolute paths (computed at module level), so workbooks no longer depend on per-folder `shared/` copies.
- Removed the now-dead `_sync_shared_into` / `_sync_shared_recursive` helpers and their callsites in `server.py`, the matching `shutil.copytree(_shared_src, ...)` block in `workbench_app.py`, and the stale `workspaces/team/shared/` line in `.gitignore`.

## Why

Creating a workbook from `/workbench` into a folder produced a workbook that crashed on open. Root-level workbooks happened to work only by accident — the 6-hop walk landed on the project root by coincidence; the `break` never fired for any workbook at any depth. The previous workaround tried to mask the bug by copying `shared/` into every folder on server start, which both papered over the real issue and created a maintenance trap (any edit to `shared/sidebar.py` would have needed mirroring to every per-folder copy).

## Test plan

- [ ] Restart the server (`uv run rwa-calc-ui`) and confirm no per-folder `shared/` directories get recreated under `workspaces/local/` or `workspaces/team/`
- [ ] From `/workbench`, create a brand-new folder, create a brand-new workbook in it, and open it in the editor — the sidebar should render and no `ModuleNotFoundError` should appear
- [ ] Open an existing root-level workbook (e.g. one in `workspaces/local/` directly) — confirm it still loads with sidebar and theme intact
- [ ] Confirm `theme.css` and `head.html` styling are applied (header logo, fonts) for both root-level and folder-nested workbooks

