### PR TITLE
Refactor pipeline: remove dead calculator code and rename methods

### DIFF
--- a/docs/appendix/changelog.md
+++ b/docs/appendix/changelog.md
@@ -5,6 +5,12 @@ All notable changes to the RWA Calculator are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.182] — 2026-04-10
+
+### Changed
+- **Pipeline**: Renamed private methods in `PipelineOrchestrator` to remove stale fan-out/single-pass terminology: `_run_crm_processor_unified` -> `_run_crm_processor`, `_run_single_pass` -> `_run_calculators`, `_aggregate_single_pass` -> `_aggregate_results`. Section header renamed from "Single-Pass Pipeline" to "Calculation".
+- **Pipeline**: Removed dead code `_run_sa_calculator` and `_run_irb_calculator` (never called from production; superseded by `calculate_branch()` in the single-pass path). Associated tests removed.
+
 ## [0.1.181] — 2026-04-09
 
 ### Fixed

--- a/docs/architecture/pipeline-collect-barriers.md
+++ b/docs/architecture/pipeline-collect-barriers.md
@@ -85,7 +85,7 @@ LAZY ─────────────────────────
   CRM: collateral allocation, guarantees, finalize_ead
     │   (no final CRM collect — plan tree is shallow post-collateral)
     │
-  Pipeline: _run_single_pass()
+  Pipeline: _run_calculators()
     │
 EAGER ─── COLLECT #3: pre-branch flatten ── Category 1 ───────
     │   (pipeline.py:631 — materialise CRM output before split)

--- a/docs/architecture/pipeline.md
+++ b/docs/architecture/pipeline.md
@@ -46,7 +46,7 @@ flowchart TD
     end
 
     subgraph Stage6[Stage 6: Aggregation]
-        I["_aggregate_single_pass()"]
+        I["_aggregate_results()"]
         I1[AggregatedResultBundle]
     end
 

--- a/src/rwa_calc/engine/pipeline.py
+++ b/src/rwa_calc/engine/pipeline.py
@@ -38,10 +38,8 @@ from rwa_calc.contracts.bundles import (
     ClassifiedExposuresBundle,
     CRMAdjustedBundle,
     EquityResultBundle,
-    IRBResultBundle,
     RawDataBundle,
     ResolvedHierarchyBundle,
-    SAResultBundle,
 )
 from rwa_calc.contracts.protocols import (
     ClassifierProtocol,
@@ -262,13 +260,13 @@ class PipelineOrchestrator:
             if classified is None:
                 return self._create_error_result()
 
-            # Stage 4: Apply CRM (unified — no fan-out split)
-            crm_adjusted = self._run_crm_processor_unified(classified, config)
+            # Stage 4: Apply CRM
+            crm_adjusted = self._run_crm_processor(classified, config)
             if crm_adjusted is None:
                 return self._create_error_result()
 
-            # Stages 5-8: Single-pass calculation and aggregation
-            result = self._run_single_pass(crm_adjusted, config)
+            # Stages 5-8: Calculation and aggregation
+            result = self._run_calculators(crm_adjusted, config)
 
             # Add pipeline errors to result
             if self._errors:
@@ -422,64 +420,6 @@ class PipelineOrchestrator:
             )
             return None
 
-    def _run_sa_calculator(
-        self,
-        data: CRMAdjustedBundle,
-        config: CalculationConfig,
-    ) -> SAResultBundle | None:
-        """Run SA calculation stage."""
-        try:
-            result = self._sa_calculator.get_sa_result_bundle(data, config)
-            # Accumulate SA errors
-            if result.errors:
-                for error in result.errors:
-                    self._errors.append(
-                        PipelineError(
-                            stage="sa_calculator",
-                            error_type=getattr(error, "error_type", "unknown"),
-                            message=getattr(error, "message", str(error)),
-                        )
-                    )
-            return result
-        except Exception as e:
-            self._errors.append(
-                PipelineError(
-                    stage="sa_calculator",
-                    error_type="sa_calculation_error",
-                    message=str(e),
-                )
-            )
-            return None
-
-    def _run_irb_calculator(
-        self,
-        data: CRMAdjustedBundle,
-        config: CalculationConfig,
-    ) -> IRBResultBundle | None:
-        """Run IRB calculation stage."""
-        try:
-            result = self._irb_calculator.get_irb_result_bundle(data, config)
-            # Accumulate IRB errors
-            if result.errors:
-                for error in result.errors:
-                    self._errors.append(
-                        PipelineError(
-                            stage="irb_calculator",
-                            error_type=getattr(error, "error_type", "unknown"),
-                            message=getattr(error, "message", str(error)),
-                        )
-                    )
-            return result
-        except Exception as e:
-            self._errors.append(
-                PipelineError(
-                    stage="irb_calculator",
-                    error_type="irb_calculation_error",
-                    message=str(e),
-                )
-            )
-            return None
-
     def _run_equity_calculator(
         self,
         data: CRMAdjustedBundle,
@@ -510,15 +450,15 @@ class PipelineOrchestrator:
             return None
 
     # =========================================================================
-    # Private Methods - Single-Pass Pipeline
+    # Private Methods - Calculation
     # =========================================================================
 
-    def _run_crm_processor_unified(
+    def _run_crm_processor(
         self,
         data: ClassifiedExposuresBundle,
         config: CalculationConfig,
     ) -> CRMAdjustedBundle | None:
-        """Run CRM processing without fan-out split (single-pass mode)."""
+        """Run CRM processing on the unified exposure frame."""
         try:
             result = self._crm_processor.get_crm_unified_bundle(data, config)
             if result.crm_errors:
@@ -541,7 +481,7 @@ class PipelineOrchestrator:
             )
             return None
 
-    def _run_single_pass(
+    def _run_calculators(
         self,
         crm_adjusted: CRMAdjustedBundle,
         config: CalculationConfig,
@@ -608,12 +548,12 @@ class PipelineOrchestrator:
             equity_bundle = self._run_equity_calculator(crm_adjusted, config)
 
             # Aggregate from already-collected DataFrames
-            return self._aggregate_single_pass(sa_df, irb_df, slotting_df, equity_bundle, config)
+            return self._aggregate_results(sa_df, irb_df, slotting_df, equity_bundle, config)
         except Exception as e:
             self._errors.append(
                 PipelineError(
-                    stage="single_pass",
-                    error_type="single_pass_error",
+                    stage="calculators",
+                    error_type="calculation_error",
                     message=str(e),
                 )
             )
@@ -643,7 +583,7 @@ class PipelineOrchestrator:
 
         return exposures
 
-    def _aggregate_single_pass(
+    def _aggregate_results(
         self,
         sa_df: pl.DataFrame,
         irb_df: pl.DataFrame,

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -24,7 +24,6 @@ from rwa_calc.contracts.bundles import (
     CRMAdjustedBundle,
     RawDataBundle,
     ResolvedHierarchyBundle,
-    SAResultBundle,
     create_empty_raw_data_bundle,
 )
 from rwa_calc.contracts.config import CalculationConfig
@@ -539,32 +538,9 @@ class TestPipelineStageExecution:
         pipeline = PipelineOrchestrator()
         pipeline._ensure_components_initialized()
 
-        result = pipeline._run_crm_processor_unified(mock_classified_bundle, crr_config)
+        result = pipeline._run_crm_processor(mock_classified_bundle, crr_config)
 
         assert isinstance(result, CRMAdjustedBundle)
-
-    def test_sa_calculator_stage(self, mock_crm_bundle, crr_config):
-        """Test SA calculator stage runs correctly."""
-        pipeline = PipelineOrchestrator()
-        pipeline._ensure_components_initialized()
-
-        result = pipeline._run_sa_calculator(mock_crm_bundle, crr_config)
-
-        assert isinstance(result, SAResultBundle)
-        assert result.results is not None
-
-    def test_irb_calculator_stage_empty(self, mock_crm_bundle, crr_config):
-        """Test IRB calculator stage with no IRB exposures."""
-        pipeline = PipelineOrchestrator()
-        pipeline._ensure_components_initialized()
-
-        # mock_crm_bundle has all SA exposures, no IRB
-        result = pipeline._run_irb_calculator(mock_crm_bundle, crr_config)
-
-        # With no IRB rows, calculator runs on empty data — returns empty bundle or None
-        if result is not None:
-            collected = result.results.collect()
-            assert collected.height == 0
 
     def test_slotting_calculator_stage_empty(self, mock_crm_bundle, crr_config):
         """Test slotting calculator stage with no slotting exposures."""


### PR DESCRIPTION
## Summary
Remove unused SA and IRB calculator methods from the pipeline orchestrator and rename private methods to eliminate stale fan-out/single-pass terminology that no longer reflects the current architecture.

## Changes

### Calculation Logic
None — this is a refactoring of internal pipeline structure with no changes to RWA calculation logic.

### Data Model
None — no changes to data structures or schemas.

### Other
**Pipeline refactoring:**
- Removed `_run_sa_calculator()` and `_run_irb_calculator()` private methods from `PipelineOrchestrator`. These methods were dead code—never called from the production pipeline path (superseded by `calculate_branch()` in the unified single-pass calculation flow).
- Renamed private methods to clarify current architecture:
  - `_run_crm_processor_unified()` → `_run_crm_processor()`
  - `_run_single_pass()` → `_run_calculators()`
  - `_aggregate_single_pass()` → `_aggregate_results()`
- Updated section header from "Single-Pass Pipeline" to "Calculation"
- Updated docstrings and error stage names to match new terminology
- Removed unused imports: `IRBResultBundle`, `SAResultBundle`
- Updated unit tests: removed `test_sa_calculator_stage()` and `test_irb_calculator_stage_empty()` (tested dead code); updated `test_crm_processor_stage()` to call renamed method
- Updated architecture documentation to reference renamed methods

## Testing
- Existing unit tests pass (removed tests for dead code; updated call sites for renamed methods)
- No calculation logic changed; refactoring is internal only

## Assumptions & Interpretations
The SA and IRB calculators are now invoked only through the `calculate_branch()` method within the unified single-pass flow. The removed private methods were legacy entry points no longer used by the production pipeline.

## Breaking Changes
None — all changes are to private methods and internal implementation. Public API unchanged.

## Related
Cleanup of stale terminology from earlier pipeline architecture iterations.

https://claude.ai/code/session_01QFXbCWiqJtJ5EpEyjECCHh