### PR TITLE
Move bundle validation from pipeline to loader stage

### DIFF
--- a/src/rwa_calc/contracts/bundles.py
+++ b/src/rwa_calc/contracts/bundles.py
@@ -57,6 +57,7 @@ class RawDataBundle:
         equity_exposures: Equity exposure details
         fx_rates: FX rates for currency conversion (optional)
         model_permissions: Per-model IRB permissions (optional, overrides org-wide IRBPermissions)
+        errors: Validation errors found during loading
     """
 
     facilities: pl.LazyFrame
@@ -75,6 +76,7 @@ class RawDataBundle:
     ciu_holdings: pl.LazyFrame | None = None
     fx_rates: pl.LazyFrame | None = None
     model_permissions: pl.LazyFrame | None = None
+    errors: list[CalculationError] = field(default_factory=list)
 
 
 @dataclass(frozen=True)

--- a/src/rwa_calc/contracts/protocols.py
+++ b/src/rwa_calc/contracts/protocols.py
@@ -44,8 +44,13 @@ class LoaderProtocol(Protocol):
     """
     Protocol for data loading components.
 
-    Responsible for loading raw data from source systems and
-    converting to LazyFrames with expected schemas.
+    Responsible for loading raw data from source systems,
+    converting to LazyFrames with expected schemas, and
+    validating categorical column values.
+
+    The returned RawDataBundle carries any validation errors
+    found during loading so downstream stages can trust the
+    data at the boundary.
 
     Implementations may load from:
     - Files (CSV, Parquet, JSON)
@@ -58,7 +63,8 @@ class LoaderProtocol(Protocol):
         Load all required data and return as a RawDataBundle.
 
         Returns:
-            RawDataBundle containing all input LazyFrames
+            RawDataBundle containing all input LazyFrames and any
+            validation errors discovered during loading
 
         Raises:
             DataLoadError: If required data cannot be loaded

--- a/src/rwa_calc/engine/loader.py
+++ b/src/rwa_calc/engine/loader.py
@@ -21,6 +21,7 @@ Usage:
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
@@ -30,6 +31,7 @@ import polars as pl
 
 from rwa_calc.config.data_sources import DataSourceRegistry
 from rwa_calc.contracts.bundles import RawDataBundle
+from rwa_calc.contracts.errors import CalculationError
 from rwa_calc.data.schemas import (
     CIU_HOLDINGS_SCHEMA,
     COLLATERAL_SCHEMA,
@@ -49,6 +51,8 @@ from rwa_calc.data.schemas import (
     SPECIALISED_LENDING_SCHEMA,
 )
 from rwa_calc.engine.utils import has_rows
+
+logger = logging.getLogger(__name__)
 
 type ScanFn = Callable[[Path], pl.LazyFrame]
 
@@ -220,6 +224,21 @@ def _load_file_optional(
         return None
 
 
+def _run_bundle_validation(bundle: RawDataBundle) -> list[CalculationError]:
+    """Validate categorical column values in a loaded bundle.
+
+    Wraps ``validate_bundle_values`` with exception handling so that
+    validation failures never prevent the bundle from being returned.
+    """
+    try:
+        from rwa_calc.contracts.validation import validate_bundle_values
+
+        return validate_bundle_values(bundle)
+    except Exception as e:
+        logger.warning("Bundle value validation failed: %s", e)
+        return []
+
+
 def _build_bundle(
     load: Callable[[str | Path | None, dict[str, pl.DataType] | None], pl.LazyFrame],
     load_optional: Callable[
@@ -228,7 +247,7 @@ def _build_bundle(
     config: DataSourceConfig,
 ) -> RawDataBundle:
     """Build a RawDataBundle — single implementation shared by all loaders."""
-    return RawDataBundle(
+    bundle = RawDataBundle(
         facilities=load(config.facilities_file, FACILITY_SCHEMA),
         loans=load(config.loans_file, LOAN_SCHEMA),
         counterparties=load(config.counterparties_file, COUNTERPARTY_SCHEMA),
@@ -247,6 +266,29 @@ def _build_bundle(
         ),
         fx_rates=load_optional(config.fx_rates_file, FX_RATES_SCHEMA),
         model_permissions=load_optional(config.model_permissions_file, MODEL_PERMISSIONS_SCHEMA),
+    )
+    errors = _run_bundle_validation(bundle)
+    if not errors:
+        return bundle
+    # Frozen dataclass — reconstruct with errors attached
+    return RawDataBundle(
+        facilities=bundle.facilities,
+        loans=bundle.loans,
+        counterparties=bundle.counterparties,
+        facility_mappings=bundle.facility_mappings,
+        lending_mappings=bundle.lending_mappings,
+        org_mappings=bundle.org_mappings,
+        contingents=bundle.contingents,
+        collateral=bundle.collateral,
+        guarantees=bundle.guarantees,
+        provisions=bundle.provisions,
+        ratings=bundle.ratings,
+        specialised_lending=bundle.specialised_lending,
+        equity_exposures=bundle.equity_exposures,
+        ciu_holdings=bundle.ciu_holdings,
+        fx_rates=bundle.fx_rates,
+        model_permissions=bundle.model_permissions,
+        errors=errors,
     )
 
 

--- a/src/rwa_calc/engine/pipeline.py
+++ b/src/rwa_calc/engine/pipeline.py
@@ -224,9 +224,6 @@ class PipelineOrchestrator:
             # Ensure components are initialized (config needed for framework-specific CRM)
             self._ensure_components_initialized(config)
 
-            # Validate input data values
-            self._validate_input_data(data)
-
             # IRB mode without model_permissions → all exposures fall back to SA.
             # The classifier forces all permission expressions to False when
             # has_model_permissions=False in IRB mode. We surface a pipeline-level
@@ -268,11 +265,12 @@ class PipelineOrchestrator:
             # Stages 5-8: Calculation and aggregation
             result = self._run_calculators(crm_adjusted, config)
 
-            # Add pipeline errors to result
-            if self._errors:
-                all_errors = list(result.errors) + [
-                    self._convert_pipeline_error(e) for e in self._errors
-                ]
+            # Add loader validation errors and pipeline errors to result
+            loader_errors = list(data.errors) if data.errors else []
+            pipeline_errors = [self._convert_pipeline_error(e) for e in self._errors]
+            extra_errors = loader_errors + pipeline_errors
+            if extra_errors:
+                all_errors = list(result.errors) + extra_errors
                 result = AggregatedResultBundle(
                     results=result.results,
                     sa_results=result.sa_results,
@@ -336,29 +334,6 @@ class PipelineOrchestrator:
     # =========================================================================
     # Private Methods - Stage Execution
     # =========================================================================
-
-    def _validate_input_data(self, data: RawDataBundle) -> None:
-        """Validate input data values against column constraints."""
-        try:
-            from rwa_calc.contracts.validation import validate_bundle_values
-
-            validation_errors = validate_bundle_values(data)
-            for error in validation_errors:
-                self._errors.append(
-                    PipelineError(
-                        stage="input_validation",
-                        error_type="invalid_value",
-                        message=error.message,
-                    )
-                )
-        except Exception as e:
-            self._errors.append(
-                PipelineError(
-                    stage="input_validation",
-                    error_type="validation_error",
-                    message=f"Value validation failed: {e}",
-                )
-            )
 
     def _run_hierarchy_resolver(
         self,

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -1063,3 +1063,65 @@ class TestEdgeCases:
 
         empty_schema_lf = pl.LazyFrame(schema={})
         assert has_rows(empty_schema_lf) is False
+
+
+# =============================================================================
+# Bundle Validation Tests
+# =============================================================================
+
+
+class TestBundleValidation:
+    """Tests that the loader validates bundle values and attaches errors."""
+
+    def test_loader_attaches_errors_to_bundle(self, temp_parquet_dir: Path) -> None:
+        """Loader should attach validation errors to the bundle."""
+        loader = ParquetLoader(temp_parquet_dir)
+        bundle = loader.load()
+
+        assert isinstance(bundle.errors, list)
+        # temp_parquet_dir has collateral_type='PROPERTY' which is invalid,
+        # so we expect at least one validation error
+        assert len(bundle.errors) >= 1
+        assert any("collateral_type" in e.field_name for e in bundle.errors if e.field_name)
+
+    def test_invalid_categorical_values_produce_errors(self) -> None:
+        """Loader validation should catch invalid categorical column values."""
+        from rwa_calc.engine.loader import _run_bundle_validation
+
+        bundle = RawDataBundle(
+            facilities=pl.LazyFrame(),
+            loans=pl.LazyFrame(),
+            counterparties=pl.LazyFrame({"entity_type": ["sovereign", "INVALID_TYPE"]}),
+            facility_mappings=pl.LazyFrame(),
+            lending_mappings=pl.LazyFrame(),
+        )
+
+        errors = _run_bundle_validation(bundle)
+        assert len(errors) >= 1
+        assert any("INVALID_TYPE" in e.message for e in errors)
+
+    def test_run_bundle_validation_returns_empty_for_valid_data(self) -> None:
+        """_run_bundle_validation returns empty list when all values are valid."""
+        from rwa_calc.engine.loader import _run_bundle_validation
+
+        bundle = RawDataBundle(
+            facilities=pl.LazyFrame(),
+            loans=pl.LazyFrame(),
+            counterparties=pl.LazyFrame({"entity_type": ["sovereign", "corporate"]}),
+            facility_mappings=pl.LazyFrame(),
+            lending_mappings=pl.LazyFrame(),
+        )
+
+        errors = _run_bundle_validation(bundle)
+        assert errors == []
+
+    def test_errors_field_default_is_empty_list(self) -> None:
+        """RawDataBundle.errors defaults to an empty list."""
+        bundle = RawDataBundle(
+            facilities=pl.LazyFrame(),
+            loans=pl.LazyFrame(),
+            counterparties=pl.LazyFrame(),
+            facility_mappings=pl.LazyFrame(),
+            lending_mappings=pl.LazyFrame(),
+        )
+        assert bundle.errors == []

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -596,6 +596,55 @@ class TestPipelineErrorHandling:
         assert len(result.errors) > 0
 
 
+class TestPipelineBundleErrorPropagation:
+    """Tests that RawDataBundle.errors are propagated to the final result."""
+
+    def test_bundle_errors_propagated_to_result(self, mock_raw_data, crr_config):
+        """Validation errors on RawDataBundle should appear in the final result."""
+        from rwa_calc.contracts.errors import CalculationError
+        from rwa_calc.domain.enums import ErrorCategory, ErrorSeverity
+
+        validation_error = CalculationError(
+            code="DQ002",
+            message="[counterparties] column 'entity_type': invalid values: INVALID_TYPE (1 row)",
+            severity=ErrorSeverity.WARNING,
+            category=ErrorCategory.DATA_QUALITY,
+            field_name="entity_type",
+        )
+
+        # Reconstruct mock_raw_data with a validation error
+        data_with_errors = RawDataBundle(
+            facilities=mock_raw_data.facilities,
+            loans=mock_raw_data.loans,
+            contingents=mock_raw_data.contingents,
+            counterparties=mock_raw_data.counterparties,
+            collateral=mock_raw_data.collateral,
+            guarantees=mock_raw_data.guarantees,
+            provisions=mock_raw_data.provisions,
+            ratings=mock_raw_data.ratings,
+            facility_mappings=mock_raw_data.facility_mappings,
+            org_mappings=mock_raw_data.org_mappings,
+            lending_mappings=mock_raw_data.lending_mappings,
+            errors=[validation_error],
+        )
+
+        pipeline = PipelineOrchestrator()
+        result = pipeline.run_with_data(data_with_errors, crr_config)
+
+        assert isinstance(result, AggregatedResultBundle)
+        # The validation error should be present in the final result errors
+        assert any("INVALID_TYPE" in e.message for e in result.errors)
+
+    def test_empty_bundle_errors_not_added(self, mock_raw_data, crr_config):
+        """Empty bundle errors should not bloat the final result."""
+        pipeline = PipelineOrchestrator()
+        result = pipeline.run_with_data(mock_raw_data, crr_config)
+
+        assert isinstance(result, AggregatedResultBundle)
+        # No spurious errors from empty data.errors
+        assert not any("entity_type" in e.message for e in result.errors)
+
+
 class TestPipelineUtilities:
     """Tests for utility methods."""
 

--- a/tests/unit/test_pipeline_validation.py
+++ b/tests/unit/test_pipeline_validation.py
@@ -1,17 +1,24 @@
 """Tests for input value validation in the pipeline.
 
-Verifies that the pipeline detects invalid column values, reports them
-as errors, and continues execution (non-blocking validation).
+Verifies that:
+- The loader validates bundle values and attaches errors to RawDataBundle
+- The pipeline propagates RawDataBundle.errors to the final result
+- The pipeline continues execution despite validation errors (non-blocking)
 """
 
 import polars as pl
 
 from rwa_calc.contracts.bundles import RawDataBundle
+from rwa_calc.engine.loader import _run_bundle_validation
 from rwa_calc.engine.pipeline import PipelineOrchestrator
 
 
 def _make_minimal_bundle(**overrides) -> RawDataBundle:
-    """Create a minimal RawDataBundle suitable for pipeline validation testing."""
+    """Create a minimal RawDataBundle suitable for pipeline validation testing.
+
+    Runs loader-level validation and attaches any errors to the bundle,
+    matching the behaviour of a real loader.
+    """
     from datetime import date
 
     facilities = pl.LazyFrame(
@@ -90,7 +97,12 @@ def _make_minimal_bundle(**overrides) -> RawDataBundle:
         "lending_mappings": lending_mappings,
     }
     defaults.update(overrides)
-    return RawDataBundle(**defaults)
+    bundle = RawDataBundle(**defaults)
+    # Run loader-level validation to match real loader behaviour
+    errors = _run_bundle_validation(bundle)
+    if errors:
+        return RawDataBundle(**{**defaults, "errors": errors})
+    return bundle
 
 
 def _make_config():
@@ -103,7 +115,7 @@ def _make_config():
 
 
 class TestPipelineInputValidation:
-    """Tests that pipeline detects and reports invalid input values."""
+    """Tests that loader validation errors propagate through the pipeline."""
 
     def test_valid_data_no_validation_errors(self):
         """Valid input data should produce no validation errors."""
@@ -114,9 +126,7 @@ class TestPipelineInputValidation:
         result = pipeline.run_with_data(bundle, config)
 
         validation_errors = [
-            e
-            for e in result.errors
-            if hasattr(e, "message") and "input_validation" in str(e.message)
+            e for e in result.errors if hasattr(e, "field_name") and e.field_name is not None
         ]
         assert validation_errors == []
 


### PR DESCRIPTION
## Summary
Shift data validation responsibility from the pipeline to the loader stage. Loaders now validate categorical column values and attach errors to `RawDataBundle`, allowing downstream stages to trust data at the boundary and simplifying error propagation.

## Changes

### Data Model
- Added `errors: list[CalculationError]` field to `RawDataBundle` with default empty list
- Updated `LoaderProtocol` docstring to document that loaders validate data and return errors in the bundle

### Calculation Logic
None

### Other
**Loader (`src/rwa_calc/engine/loader.py`)**
- Added `_run_bundle_validation()` function that wraps `validate_bundle_values()` with exception handling
- Modified `_build_bundle()` to call validation and reconstruct the frozen dataclass with errors attached
- Validation failures are logged as warnings but never prevent bundle return (non-blocking)

**Pipeline (`src/rwa_calc/engine/pipeline.py`)**
- Removed `_validate_input_data()` method that previously ran validation in the pipeline
- Updated `run_with_data()` to extract and propagate `data.errors` from the loaded bundle to the final result
- Validation errors now flow through the same error aggregation path as pipeline errors

**Tests**
- Added `TestBundleValidation` class in `test_loader.py` with 4 tests covering:
  - Loader attaches validation errors to bundle
  - Invalid categorical values produce errors
  - Valid data returns empty error list
  - Default empty errors field
- Added `TestPipelineBundleErrorPropagation` class in `test_pipeline.py` with 2 tests covering:
  - Bundle validation errors propagate to final result
  - Empty bundle errors don't bloat result
- Updated `test_pipeline_validation.py` to use loader-level validation in test fixtures and verify error propagation through pipeline

## Testing
- Added 6 new unit tests covering loader validation and error propagation
- Existing pipeline tests continue to pass with validation moved to loader stage
- Error propagation verified end-to-end from loader through pipeline to final result

## Assumptions & Interpretations
- Validation errors are non-blocking: invalid data is loaded and errors are reported, allowing downstream stages to handle or filter as needed
- Validation failures in the loader (exceptions) are logged but don't prevent bundle return, ensuring robustness
- The frozen `RawDataBundle` dataclass requires full reconstruction to attach errors; this is acceptable as it occurs once per load

## Breaking Changes
- `RawDataBundle` now has an `errors` field (defaults to empty list, so existing code creating bundles without errors continues to work)
- Pipeline no longer performs input validation; validation is now the loader's responsibility
- Validation errors now appear in `AggregatedResultBundle.errors` with their original `CalculationError` structure rather than converted `PipelineError` objects

## Related
Improves data quality assurance by validating at the data boundary (loader) rather than in the orchestration layer (pipeline), following separation of concerns principles.

https://claude.ai/code/session_014Rpz8zDN2TnUwv2kvV8jsb