### PR TITLE
fix: replace float equality checks with tolerance-based comparisons

### DIFF
--- a/src/rwa_calc/data/tables/crr_haircuts.py
+++ b/src/rwa_calc/data/tables/crr_haircuts.py
@@ -160,7 +160,7 @@ def scale_haircut_for_liquidation_period(
     Returns:
         Scaled haircut for the target liquidation period
     """
-    if liquidation_period_days == 10 or base_haircut_10day == 0.0:
+    if liquidation_period_days == 10 or math.isclose(base_haircut_10day, 0.0, abs_tol=1e-10):
         return base_haircut_10day
     return base_haircut_10day * math.sqrt(liquidation_period_days / 10.0)
 

--- a/src/rwa_calc/engine/crm/simple_method.py
+++ b/src/rwa_calc/engine/crm/simple_method.py
@@ -148,7 +148,7 @@ def _is_zero_rw_exception_expr() -> pl.Expr:
 
     # (b) 0%-RW sovereign bond in same currency (CQS 1 sovereign → 0% RW)
     is_zero_rw_sovereign = (
-        (pl.col("_fcsm_item_rw") == 0.0)
+        (pl.col("_fcsm_item_rw").abs() < 1e-10)
         & is_same_currency
         & ~ctype.is_in(["cash", "deposit", "gold", "equity", "equity_main_index", "equity_other"])
     )
@@ -290,7 +290,7 @@ def compute_fcsm_columns(
         .fill_null("")
         .str.to_lowercase()
         .is_in(["sovereign", "central_government", "central_bank"])
-        & (pl.col("_fcsm_item_rw") == 0.0)
+        & (pl.col("_fcsm_item_rw").abs() < 1e-10)
         & ~pl.col("collateral_type").str.to_lowercase().is_in(["cash", "deposit", "gold"])
     )
     coll_with_exp = coll_with_exp.with_columns(

--- a/src/rwa_calc/reporting/pillar3/generator.py
+++ b/src/rwa_calc/reporting/pillar3/generator.py
@@ -31,6 +31,7 @@ References:
 from __future__ import annotations
 
 import logging
+import math
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -418,7 +419,7 @@ class Pillar3Generator:
         rows_out: list[dict[str, object]] = []
 
         for lower, upper, row_ref, label in CR6_PD_RANGES:
-            if upper == float("inf"):
+            if math.isinf(upper):
                 bucket = class_data.filter(pl.col(alloc_pd_col) >= lower)
             else:
                 bucket = class_data.filter(
@@ -795,7 +796,7 @@ class Pillar3Generator:
         rows_out: list[dict[str, object]] = []
 
         for lower, upper, row_ref, label in CR6_PD_RANGES:
-            if upper == float("inf"):
+            if math.isinf(upper):
                 bucket = class_data.filter(pl.col(alloc_pd_col) >= lower)
             else:
                 bucket = class_data.filter(

--- a/tests/acceptance/basel31/test_scenario_b31_b_firb.py
+++ b/tests/acceptance/basel31/test_scenario_b31_b_firb.py
@@ -439,7 +439,7 @@ class TestB31GroupB_ParameterizedValidation:
         """Verify all B31-B scenarios have SF=1.0 (disabled under Basel 3.1)."""
         for scenario in b31_b_scenarios:
             sf = scenario["supporting_factor"]
-            assert sf == 1.0, (
+            assert sf == pytest.approx(1.0, abs=1e-10), (
                 f"Scenario {scenario['scenario_id']}: SF should be 1.0 "
                 f"(disabled under Basel 3.1), got {sf}"
             )

--- a/tests/acceptance/basel31/test_scenario_b31_c_airb.py
+++ b/tests/acceptance/basel31/test_scenario_b31_c_airb.py
@@ -323,7 +323,7 @@ class TestB31GroupC_ParameterizedValidation:
         """Verify all B31-C scenarios have SF=1.0 (disabled under Basel 3.1)."""
         for scenario in b31_c_scenarios:
             sf = scenario["supporting_factor"]
-            assert sf == 1.0, (
+            assert sf == pytest.approx(1.0, abs=1e-10), (
                 f"Scenario {scenario['scenario_id']}: SF should be 1.0 "
                 f"(disabled under Basel 3.1), got {sf}"
             )

--- a/tests/acceptance/basel31/test_scenario_b31_g_provisions.py
+++ b/tests/acceptance/basel31/test_scenario_b31_g_provisions.py
@@ -480,7 +480,9 @@ class TestB31GroupG_ParameterizedValidation:
         """Verify all B31-G scenarios have SF=1.0 (disabled under Basel 3.1)."""
         for scenario in b31_g_scenarios:
             sf = scenario["supporting_factor"]
-            assert sf == 1.0, f"Scenario {scenario['scenario_id']}: SF should be 1.0, got {sf}"
+            assert sf == pytest.approx(1.0, abs=1e-10), (
+                f"Scenario {scenario['scenario_id']}: SF should be 1.0, got {sf}"
+            )
             assert scenario["rwa_before_sf"] == pytest.approx(
                 scenario["rwa_after_sf"], rel=0.001
             ), (

--- a/tests/acceptance/basel31/test_scenario_b31_h_complex.py
+++ b/tests/acceptance/basel31/test_scenario_b31_h_complex.py
@@ -246,7 +246,9 @@ class TestB31GroupH_ParameterizedValidation:
         """Verify all B31-H scenarios have SF=1.0 (disabled under Basel 3.1)."""
         for scenario in b31_h_scenarios:
             sf = scenario["supporting_factor"]
-            assert sf == 1.0, f"Scenario {scenario['scenario_id']}: SF should be 1.0, got {sf}"
+            assert sf == pytest.approx(1.0, abs=1e-10), (
+                f"Scenario {scenario['scenario_id']}: SF should be 1.0, got {sf}"
+            )
             assert scenario["rwa_before_sf"] == pytest.approx(
                 scenario["rwa_after_sf"], rel=0.001
             ), (

--- a/tests/fixtures/guarantee/guarantee.py
+++ b/tests/fixtures/guarantee/guarantee.py
@@ -401,8 +401,8 @@ def print_summary(output_path: Path) -> None:
         print(f"  {row['guarantee_type']}: GBP {row['total_covered']:,.0f}")
 
     print("\nCoverage distribution:")
-    full_coverage = df.filter(pl.col("percentage_covered") == 1.0).height
-    partial_coverage = df.filter(pl.col("percentage_covered") < 1.0).height
+    full_coverage = df.filter((pl.col("percentage_covered") - 1.0).abs() < 1e-10).height
+    partial_coverage = df.filter(pl.col("percentage_covered") < 1.0 - 1e-10).height
     print(f"  Full coverage (100%): {full_coverage}")
     print(f"  Partial coverage: {partial_coverage}")
 

--- a/tests/unit/api/test_models.py
+++ b/tests/unit/api/test_models.py
@@ -210,7 +210,7 @@ class TestPerformanceMetrics:
             duration_seconds=0.0,
             exposure_count=1000,
         )
-        assert metrics.exposures_per_second == 0.0
+        assert metrics.exposures_per_second == pytest.approx(0.0, abs=1e-10)
 
 
 # =============================================================================

--- a/tests/unit/crm/test_collateral_allocation_bundle.py
+++ b/tests/unit/crm/test_collateral_allocation_bundle.py
@@ -14,6 +14,7 @@ IMPLEMENTATION_PLAN.md P6.20.
 
 from __future__ import annotations
 
+import math
 from datetime import date
 
 import polars as pl
@@ -118,7 +119,7 @@ def _sa_exposure(
         "drawn_amount": drawn,
         "interest": 0.0,
         "nominal_amount": nominal,
-        "risk_type": "FR" if nominal == 0.0 else "MR",
+        "risk_type": "FR" if math.isclose(nominal, 0.0, abs_tol=1e-10) else "MR",
         "lgd": 0.45,
         "seniority": "senior",
         "parent_facility_reference": "FAC_DEFAULT",

--- a/tests/unit/crm/test_liquidation_period_haircuts.py
+++ b/tests/unit/crm/test_liquidation_period_haircuts.py
@@ -19,6 +19,7 @@ import math
 from decimal import Decimal
 
 import polars as pl
+import pytest
 
 from rwa_calc.data.tables.crr_haircuts import (
     BASEL31_COLLATERAL_HAIRCUTS,
@@ -91,7 +92,7 @@ class TestScalingFormula:
 
     def test_10_day_no_scaling(self) -> None:
         """10-day period returns base value unchanged."""
-        assert scale_haircut_for_liquidation_period(0.20, 10) == 0.20
+        assert scale_haircut_for_liquidation_period(0.20, 10) == pytest.approx(0.20, abs=1e-10)
 
     def test_5_day_repo_scaling(self) -> None:
         """5-day (repo) scales down by sqrt(0.5)."""
@@ -107,7 +108,7 @@ class TestScalingFormula:
 
     def test_zero_haircut_not_scaled(self) -> None:
         """Zero haircut (cash) stays zero regardless of period."""
-        assert scale_haircut_for_liquidation_period(0.0, 20) == 0.0
+        assert scale_haircut_for_liquidation_period(0.0, 20) == pytest.approx(0.0, abs=1e-10)
 
     def test_gold_b31_5day(self) -> None:
         """B31 gold 5-day: 20% × sqrt(0.5) ≈ 14.142%."""

--- a/tests/unit/crm/test_multi_level_sa_collateral.py
+++ b/tests/unit/crm/test_multi_level_sa_collateral.py
@@ -19,6 +19,7 @@ Covers:
 
 from __future__ import annotations
 
+import math
 from datetime import date
 
 import polars as pl
@@ -120,7 +121,7 @@ def _sa_exposure(
         "drawn_amount": drawn,
         "interest": 0.0,
         "nominal_amount": nominal,
-        "risk_type": "FR" if nominal == 0.0 else "MR",
+        "risk_type": "FR" if math.isclose(nominal, 0.0, abs_tol=1e-10) else "MR",
         "lgd": 0.45,
         "seniority": "senior",
         "parent_facility_reference": facility_ref,
@@ -145,7 +146,7 @@ def _irb_exposure(
         "drawn_amount": drawn,
         "interest": 0.0,
         "nominal_amount": nominal,
-        "risk_type": "FR" if nominal == 0.0 else "MR",
+        "risk_type": "FR" if math.isclose(nominal, 0.0, abs_tol=1e-10) else "MR",
         "lgd": 0.45,
         "seniority": "senior",
         "parent_facility_reference": facility_ref,

--- a/tests/unit/crm/test_simple_method.py
+++ b/tests/unit/crm/test_simple_method.py
@@ -205,64 +205,76 @@ class TestCollateralRWDerivation:
         return result["rw"][0]
 
     def test_cash_zero_rw(self):
-        assert self._compute_rw("cash") == 0.0
+        assert self._compute_rw("cash") == pytest.approx(0.0, abs=1e-10)
 
     def test_deposit_zero_rw(self):
-        assert self._compute_rw("deposit") == 0.0
+        assert self._compute_rw("deposit") == pytest.approx(0.0, abs=1e-10)
 
     def test_gold_zero_rw(self):
-        assert self._compute_rw("gold") == 0.0
+        assert self._compute_rw("gold") == pytest.approx(0.0, abs=1e-10)
 
     def test_sovereign_cqs1_zero_rw(self):
-        assert self._compute_rw("government_bond", "sovereign", 1) == 0.0
+        assert self._compute_rw("government_bond", "sovereign", 1) == pytest.approx(0.0, abs=1e-10)
 
     def test_sovereign_cqs2_twenty_pct(self):
-        assert self._compute_rw("government_bond", "sovereign", 2) == 0.20
+        assert self._compute_rw("government_bond", "sovereign", 2) == pytest.approx(0.20, abs=1e-10)
 
     def test_sovereign_cqs3_fifty_pct(self):
-        assert self._compute_rw("government_bond", "sovereign", 3) == 0.50
+        assert self._compute_rw("government_bond", "sovereign", 3) == pytest.approx(0.50, abs=1e-10)
 
     def test_sovereign_cqs4_hundred_pct(self):
-        assert self._compute_rw("government_bond", "sovereign", 4) == 1.00
+        assert self._compute_rw("government_bond", "sovereign", 4) == pytest.approx(1.00, abs=1e-10)
 
     def test_sovereign_cqs6_one_fifty_pct(self):
-        assert self._compute_rw("government_bond", "sovereign", 6) == 1.50
+        assert self._compute_rw("government_bond", "sovereign", 6) == pytest.approx(1.50, abs=1e-10)
 
     def test_institution_cqs1_twenty_pct(self):
-        assert self._compute_rw("corporate_bond", "institution", 1) == 0.20
+        assert self._compute_rw("corporate_bond", "institution", 1) == pytest.approx(
+            0.20, abs=1e-10
+        )
 
     def test_institution_cqs2_fifty_pct(self):
-        assert self._compute_rw("corporate_bond", "institution", 2) == 0.50
+        assert self._compute_rw("corporate_bond", "institution", 2) == pytest.approx(
+            0.50, abs=1e-10
+        )
 
     def test_institution_unrated_hundred_pct(self):
-        assert self._compute_rw("corporate_bond", "institution", None) == 1.00
+        assert self._compute_rw("corporate_bond", "institution", None) == pytest.approx(
+            1.00, abs=1e-10
+        )
 
     def test_corporate_cqs1_twenty_pct(self):
-        assert self._compute_rw("corporate_bond", "corporate", 1) == 0.20
+        assert self._compute_rw("corporate_bond", "corporate", 1) == pytest.approx(0.20, abs=1e-10)
 
     def test_corporate_cqs2_fifty_pct(self):
-        assert self._compute_rw("corporate_bond", "corporate", 2) == 0.50
+        assert self._compute_rw("corporate_bond", "corporate", 2) == pytest.approx(0.50, abs=1e-10)
 
     def test_corporate_cqs3_hundred_pct(self):
-        assert self._compute_rw("corporate_bond", "corporate", 3) == 1.00
+        assert self._compute_rw("corporate_bond", "corporate", 3) == pytest.approx(1.00, abs=1e-10)
 
     def test_corporate_cqs5_crr_hundred_pct(self):
         """CRR Art. 122 Table 5: CQS 5 = 100%."""
-        assert self._compute_rw("corporate_bond", "corporate", 5, is_basel_3_1=False) == 1.00
+        assert self._compute_rw(
+            "corporate_bond", "corporate", 5, is_basel_3_1=False
+        ) == pytest.approx(1.00, abs=1e-10)
 
     def test_corporate_cqs5_b31_one_fifty_pct(self):
         """B31 Art. 122(2) Table 6: CQS 5 = 150%."""
-        assert self._compute_rw("corporate_bond", "corporate", 5, is_basel_3_1=True) == 1.50
+        assert self._compute_rw(
+            "corporate_bond", "corporate", 5, is_basel_3_1=True
+        ) == pytest.approx(1.50, abs=1e-10)
 
     def test_equity_hundred_pct(self):
-        assert self._compute_rw("equity") == 1.00
+        assert self._compute_rw("equity") == pytest.approx(1.00, abs=1e-10)
 
     def test_equity_main_index_hundred_pct(self):
-        assert self._compute_rw("equity_main_index") == 1.00
+        assert self._compute_rw("equity_main_index") == pytest.approx(1.00, abs=1e-10)
 
     def test_unknown_type_defaults_to_corporate(self):
         """Unknown collateral type treated as corporate bond (conservative)."""
-        assert self._compute_rw("other_instrument", "corporate", 1) == 0.20
+        assert self._compute_rw("other_instrument", "corporate", 1) == pytest.approx(
+            0.20, abs=1e-10
+        )
 
 
 # =============================================================================
@@ -319,7 +331,7 @@ class TestComputeFCSMColumns:
         result = _add_default_fcsm_columns(exposures).collect()
         assert "fcsm_collateral_value" in result.columns
         assert "fcsm_collateral_rw" in result.columns
-        assert result["fcsm_collateral_value"][0] == 0.0
+        assert result["fcsm_collateral_value"][0] == pytest.approx(0.0, abs=1e-10)
 
 
 # =============================================================================

--- a/tests/unit/crr/test_crr_irb.py
+++ b/tests/unit/crr/test_crr_irb.py
@@ -190,7 +190,7 @@ class TestCapitalRequirementK:
     def test_k_zero_for_zero_pd(self) -> None:
         """K should be zero when PD is zero."""
         k = calculate_k(pd=0.0, lgd=0.45, correlation=0.15)
-        assert k == 0.0
+        assert k == pytest.approx(0.0, abs=1e-10)
 
     def test_k_equals_lgd_for_defaulted(self) -> None:
         """K should equal LGD for defaulted exposure (PD=100%)."""

--- a/tests/unit/irb/test_irb_formulas.py
+++ b/tests/unit/irb/test_irb_formulas.py
@@ -684,38 +684,38 @@ class TestCorrelationParams:
 
     def test_corporate_params(self) -> None:
         p = get_correlation_params("CORPORATE")
-        assert p.r_min == 0.12
-        assert p.r_max == 0.24
+        assert p.r_min == pytest.approx(0.12, abs=1e-10)
+        assert p.r_max == pytest.approx(0.24, abs=1e-10)
         assert p.decay_factor == 50.0
 
     def test_retail_mortgage_fixed(self) -> None:
         p = get_correlation_params("RETAIL_MORTGAGE")
         assert p.correlation_type == "fixed"
-        assert p.fixed == 0.15
+        assert p.fixed == pytest.approx(0.15, abs=1e-10)
 
     def test_qrre_fixed(self) -> None:
         p = get_correlation_params("RETAIL_QRRE")
         assert p.correlation_type == "fixed"
-        assert p.fixed == 0.04
+        assert p.fixed == pytest.approx(0.04, abs=1e-10)
 
     def test_retail_other_params(self) -> None:
         p = get_correlation_params("RETAIL_OTHER")
-        assert p.r_min == 0.03
-        assert p.r_max == 0.16
+        assert p.r_min == pytest.approx(0.03, abs=1e-10)
+        assert p.r_max == pytest.approx(0.16, abs=1e-10)
         assert p.decay_factor == 35.0
 
     def test_substring_matching_mortgage(self) -> None:
         p = get_correlation_params("residential_mortgage")
-        assert p.fixed == 0.15
+        assert p.fixed == pytest.approx(0.15, abs=1e-10)
 
     def test_substring_matching_government(self) -> None:
         p = get_correlation_params("GOVERNMENT_BOND")
-        assert p.r_min == 0.12  # Corporate params
+        assert p.r_min == pytest.approx(0.12, abs=1e-10)  # Corporate params
 
     def test_unknown_defaults_to_corporate(self) -> None:
         p = get_correlation_params("SOME_UNKNOWN")
-        assert p.r_min == 0.12
-        assert p.r_max == 0.24
+        assert p.r_min == pytest.approx(0.12, abs=1e-10)
+        assert p.r_max == pytest.approx(0.24, abs=1e-10)
 
 
 # =============================================================================
@@ -734,7 +734,7 @@ class TestCapitalK:
     def test_k_zero_for_pd_zero(self) -> None:
         """K = 0 when PD = 0 (scalar wrapper short-circuit)."""
         k = calculate_k(0.0, 0.45, 0.20)
-        assert k == 0.0
+        assert k == pytest.approx(0.0, abs=1e-10)
 
     def test_k_equals_lgd_for_pd_one(self) -> None:
         """K = LGD when PD = 1.0 (certain default, scalar wrapper)."""
@@ -992,8 +992,8 @@ class TestCalculateIRBRWA:
             lgd_floor=None,
         )
         assert result["rwa"] > 0
-        assert result["pd_floored"] == 0.01  # Above floor
-        assert result["scaling_factor"] == 1.06
+        assert result["pd_floored"] == pytest.approx(0.01, abs=1e-10)  # Above floor
+        assert result["scaling_factor"] == pytest.approx(1.06, abs=1e-10)
 
     def test_crr_scaling_factor(self) -> None:
         """CRR applies 1.06 scaling factor."""
@@ -1008,7 +1008,7 @@ class TestCalculateIRBRWA:
             pd_floor=0.0003,
             lgd_floor=None,
         )
-        assert result["scaling_factor"] == 1.06
+        assert result["scaling_factor"] == pytest.approx(1.06, abs=1e-10)
 
     def test_b31_no_scaling_factor(self) -> None:
         """Basel 3.1 uses scaling factor = 1.0."""
@@ -1023,7 +1023,7 @@ class TestCalculateIRBRWA:
             pd_floor=0.0005,
             lgd_floor=None,
         )
-        assert result["scaling_factor"] == 1.0
+        assert result["scaling_factor"] == pytest.approx(1.0, abs=1e-10)
 
     def test_pd_floor_applied(self) -> None:
         """PD below floor is raised to floor value."""
@@ -1038,7 +1038,7 @@ class TestCalculateIRBRWA:
             pd_floor=0.0005,
             lgd_floor=None,
         )
-        assert result["pd_floored"] == 0.0005
+        assert result["pd_floored"] == pytest.approx(0.0005, abs=1e-10)
 
     def test_lgd_floor_applied(self) -> None:
         """LGD below floor is raised to floor value."""
@@ -1053,7 +1053,7 @@ class TestCalculateIRBRWA:
             pd_floor=0.0003,
             lgd_floor=0.25,
         )
-        assert result["lgd_floored"] == 0.25
+        assert result["lgd_floored"] == pytest.approx(0.25, abs=1e-10)
 
     def test_no_maturity_adjustment(self) -> None:
         """Without maturity adjustment, MA forced to 1.0."""
@@ -1068,7 +1068,7 @@ class TestCalculateIRBRWA:
             pd_floor=0.0003,
             lgd_floor=None,
         )
-        assert result["maturity_adjustment"] == 1.0
+        assert result["maturity_adjustment"] == pytest.approx(1.0, abs=1e-10)
 
     def test_risk_weight_formula(self) -> None:
         """risk_weight = K × 12.5 × scaling × MA."""

--- a/tests/unit/test_b31_firb_lgd.py
+++ b/tests/unit/test_b31_firb_lgd.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from decimal import Decimal
 
 import polars as pl
+import pytest
 
 from rwa_calc.data.tables.b31_firb_lgd import (
     B31_FIRB_LGD_COMMERCIAL_RE,
@@ -191,7 +192,7 @@ class TestB31FIRBLGDDataFrame:
             & (pl.col("is_fse") == False)  # noqa: E712
         )
         assert len(non_fse) == 1
-        assert non_fse["lgd"][0] == 0.40
+        assert non_fse["lgd"][0] == pytest.approx(0.40, abs=1e-10)
 
     def test_dataframe_fse_senior_unsecured_value(self) -> None:
         """FSE senior unsecured row has LGD = 0.45."""
@@ -202,49 +203,49 @@ class TestB31FIRBLGDDataFrame:
             & (pl.col("is_fse") == True)  # noqa: E712
         )
         assert len(fse) == 1
-        assert fse["lgd"][0] == 0.45
+        assert fse["lgd"][0] == pytest.approx(0.45, abs=1e-10)
 
     def test_dataframe_subordinated_value(self) -> None:
         """Subordinated row has LGD = 0.75."""
         df = get_b31_firb_lgd_table()
         sub = df.filter(pl.col("seniority") == "subordinated")
         assert len(sub) == 1
-        assert sub["lgd"][0] == 0.75
+        assert sub["lgd"][0] == pytest.approx(0.75, abs=1e-10)
 
     def test_dataframe_covered_bond_value(self) -> None:
         """Covered bond row has LGD = 0.1125."""
         df = get_b31_firb_lgd_table()
         cb = df.filter(pl.col("collateral_type") == "covered_bond")
         assert len(cb) == 1
-        assert cb["lgd"][0] == 0.1125
+        assert cb["lgd"][0] == pytest.approx(0.1125, abs=1e-10)
 
     def test_dataframe_receivables_value(self) -> None:
         """Receivables row has LGD = 0.20 (CRR: 0.35)."""
         df = get_b31_firb_lgd_table()
         recv = df.filter(pl.col("collateral_type") == "receivables")
         assert len(recv) == 1
-        assert recv["lgd"][0] == 0.20
+        assert recv["lgd"][0] == pytest.approx(0.20, abs=1e-10)
 
     def test_dataframe_residential_re_value(self) -> None:
         """Residential RE row has LGD = 0.20 (CRR: 0.35)."""
         df = get_b31_firb_lgd_table()
         rre = df.filter(pl.col("collateral_type") == "residential_re")
         assert len(rre) == 1
-        assert rre["lgd"][0] == 0.20
+        assert rre["lgd"][0] == pytest.approx(0.20, abs=1e-10)
 
     def test_dataframe_commercial_re_value(self) -> None:
         """Commercial RE row has LGD = 0.20 (CRR: 0.35)."""
         df = get_b31_firb_lgd_table()
         cre = df.filter(pl.col("collateral_type") == "commercial_re")
         assert len(cre) == 1
-        assert cre["lgd"][0] == 0.20
+        assert cre["lgd"][0] == pytest.approx(0.20, abs=1e-10)
 
     def test_dataframe_other_physical_value(self) -> None:
         """Other physical row has LGD = 0.25 (CRR: 0.40)."""
         df = get_b31_firb_lgd_table()
         op = df.filter(pl.col("collateral_type") == "other_physical")
         assert len(op) == 1
-        assert op["lgd"][0] == 0.25
+        assert op["lgd"][0] == pytest.approx(0.25, abs=1e-10)
 
     def test_dataframe_re_overcoll_ratio_one_forty(self) -> None:
         """Real estate rows have 140% overcollateralisation ratio."""
@@ -252,13 +253,16 @@ class TestB31FIRBLGDDataFrame:
         re_rows = df.filter(
             pl.col("collateral_type").is_in(["residential_re", "commercial_re", "real_estate"])
         )
-        assert all(r == 1.40 for r in re_rows["overcollateralisation_ratio"].to_list())
+        assert all(
+            r == pytest.approx(1.40, abs=1e-10)
+            for r in re_rows["overcollateralisation_ratio"].to_list()
+        )
 
     def test_dataframe_receivables_overcoll_ratio_one_twenty_five(self) -> None:
         """Receivables have 125% overcollateralisation ratio."""
         df = get_b31_firb_lgd_table()
         recv = df.filter(pl.col("collateral_type") == "receivables")
-        assert recv["overcollateralisation_ratio"][0] == 1.25
+        assert recv["overcollateralisation_ratio"][0] == pytest.approx(1.25, abs=1e-10)
 
     def test_dataframe_re_min_threshold_thirty_percent(self) -> None:
         """Real estate and other physical have 30% minimum threshold."""
@@ -268,14 +272,16 @@ class TestB31FIRBLGDDataFrame:
                 ["residential_re", "commercial_re", "real_estate", "other_physical"]
             )
         )
-        assert all(t == 0.30 for t in rows["min_threshold"].to_list())
+        assert all(t == pytest.approx(0.30, abs=1e-10) for t in rows["min_threshold"].to_list())
 
     def test_dataframe_financial_no_overcoll(self) -> None:
         """Financial collateral has no overcollateralisation requirement."""
         df = get_b31_firb_lgd_table()
         fin = df.filter(pl.col("collateral_type").is_in(["financial_collateral", "cash"]))
-        assert all(r == 1.0 for r in fin["overcollateralisation_ratio"].to_list())
-        assert all(t == 0.0 for t in fin["min_threshold"].to_list())
+        assert all(
+            r == pytest.approx(1.0, abs=1e-10) for r in fin["overcollateralisation_ratio"].to_list()
+        )
+        assert all(t == pytest.approx(0.0, abs=1e-10) for t in fin["min_threshold"].to_list())
 
 
 # =============================================================================
@@ -477,8 +483,10 @@ class TestB31VsCRRComparisonTable:
         df = get_b31_vs_crr_lgd_comparison()
         fse = df.filter(pl.col("collateral_type") == "unsecured_senior_fse")
         assert len(fse) == 1
-        assert fse["crr_lgd"][0] == 0.45  # CRR has no FSE split — uses senior unsecured
-        assert fse["b31_lgd"][0] == 0.45
+        assert fse["crr_lgd"][0] == pytest.approx(
+            0.45, abs=1e-10
+        )  # CRR has no FSE split — uses senior unsecured
+        assert fse["b31_lgd"][0] == pytest.approx(0.45, abs=1e-10)
 
 
 # =============================================================================
@@ -497,7 +505,7 @@ class TestB31FIRBLGDConsistency:
             & (pl.col("seniority") == "senior")
             & (pl.col("is_fse") == False)  # noqa: E712
         )
-        assert row["lgd"][0] == float(B31_FIRB_LGD_UNSECURED_SENIOR)
+        assert row["lgd"][0] == pytest.approx(float(B31_FIRB_LGD_UNSECURED_SENIOR), abs=1e-10)
 
     def test_dataframe_matches_constants_fse_senior(self) -> None:
         """DataFrame FSE senior LGD matches named constant."""
@@ -507,19 +515,19 @@ class TestB31FIRBLGDConsistency:
             & (pl.col("seniority") == "senior")
             & (pl.col("is_fse") == True)  # noqa: E712
         )
-        assert row["lgd"][0] == float(B31_FIRB_LGD_UNSECURED_SENIOR_FSE)
+        assert row["lgd"][0] == pytest.approx(float(B31_FIRB_LGD_UNSECURED_SENIOR_FSE), abs=1e-10)
 
     def test_dataframe_matches_constants_receivables(self) -> None:
         """DataFrame receivables LGD matches named constant."""
         df = get_b31_firb_lgd_table()
         row = df.filter(pl.col("collateral_type") == "receivables")
-        assert row["lgd"][0] == float(B31_FIRB_LGD_RECEIVABLES)
+        assert row["lgd"][0] == pytest.approx(float(B31_FIRB_LGD_RECEIVABLES), abs=1e-10)
 
     def test_dataframe_matches_constants_other_physical(self) -> None:
         """DataFrame other physical LGD matches named constant."""
         df = get_b31_firb_lgd_table()
         row = df.filter(pl.col("collateral_type") == "other_physical")
-        assert row["lgd"][0] == float(B31_FIRB_LGD_OTHER_PHYSICAL)
+        assert row["lgd"][0] == pytest.approx(float(B31_FIRB_LGD_OTHER_PHYSICAL), abs=1e-10)
 
     def test_lookup_matches_constants_all_types(self) -> None:
         """Scalar lookup returns values consistent with named constants."""

--- a/tests/unit/test_corep.py
+++ b/tests/unit/test_corep.py
@@ -17,6 +17,7 @@ aggregation path with hand-calculated expected values.
 from __future__ import annotations
 
 import importlib.util
+import math
 import sys
 from pathlib import Path
 
@@ -434,8 +435,8 @@ class TestTemplateDefinitions:
 
     def test_pd_bands_cover_full_range(self) -> None:
         """PD bands must cover 0% to 100%+ without gaps."""
-        assert PD_BANDS[0][0] == 0.0
-        assert PD_BANDS[-1][1] == float("inf")
+        assert PD_BANDS[0][0] == pytest.approx(0.0, abs=1e-10)
+        assert math.isinf(PD_BANDS[-1][1])
 
         for i in range(len(PD_BANDS) - 1):
             assert PD_BANDS[i][1] == PD_BANDS[i + 1][0], f"Gap between bands {i} and {i + 1}"
@@ -4414,9 +4415,9 @@ class TestC0803TemplateDefinitions:
         from rwa_calc.reporting.corep.templates import C08_03_PD_RANGES
 
         # First range starts at 0
-        assert C08_03_PD_RANGES[0][0] == 0.0
+        assert C08_03_PD_RANGES[0][0] == pytest.approx(0.0, abs=1e-10)
         # Last range upper bound is infinity (captures 100% default)
-        assert C08_03_PD_RANGES[-1][1] == float("inf")
+        assert math.isinf(C08_03_PD_RANGES[-1][1])
         # Ranges are contiguous (upper of i == lower of i+1)
         for i in range(len(C08_03_PD_RANGES) - 1):
             assert C08_03_PD_RANGES[i][1] == C08_03_PD_RANGES[i + 1][0]

--- a/tests/unit/test_corep_reporting_basis.py
+++ b/tests/unit/test_corep_reporting_basis.py
@@ -277,7 +277,7 @@ class TestOF0200FloorIndicatorRows:
         )
         row = _get_c02_row(bundle, "0034")
         assert row is not None
-        assert row["0010"] == 0.0
+        assert row["0010"] == pytest.approx(0.0, abs=1e-10)
 
     def test_exempt_entity_multiplier_zero(self) -> None:
         """Exempt entity: row 0035 (multiplier) = 0.0."""
@@ -289,7 +289,7 @@ class TestOF0200FloorIndicatorRows:
         )
         row = _get_c02_row(bundle, "0035")
         assert row is not None
-        assert row["0010"] == 0.0
+        assert row["0010"] == pytest.approx(0.0, abs=1e-10)
 
     def test_exempt_entity_of_adj_zero(self) -> None:
         """Exempt entity: row 0036 (OF-ADJ) = 0.0."""
@@ -301,7 +301,7 @@ class TestOF0200FloorIndicatorRows:
         )
         row = _get_c02_row(bundle, "0036")
         assert row is not None
-        assert row["0010"] == 0.0
+        assert row["0010"] == pytest.approx(0.0, abs=1e-10)
 
     def test_applicable_entity_floor_activated(self) -> None:
         """Applicable entity with binding floor: row 0034 = 1.0."""
@@ -314,7 +314,7 @@ class TestOF0200FloorIndicatorRows:
         row = _get_c02_row(bundle, "0034")
         assert row is not None
         # rwa_final (60k) > rwa_pre_floor (50k) → floor activated
-        assert row["0010"] == 1.0
+        assert row["0010"] == pytest.approx(1.0, abs=1e-10)
 
     def test_no_config_backward_compat(self) -> None:
         """No config → floor is assumed applicable (backward compat)."""
@@ -326,7 +326,7 @@ class TestOF0200FloorIndicatorRows:
         row = _get_c02_row(bundle, "0034")
         assert row is not None
         # rwa_final (60k) > rwa_pre_floor (50k) → floor activated
-        assert row["0010"] == 1.0
+        assert row["0010"] == pytest.approx(1.0, abs=1e-10)
 
     def test_crr_no_floor_indicator_rows(self) -> None:
         """CRR: rows 0034-0036 not present in C 02.00."""
@@ -354,7 +354,9 @@ class TestOF0200FloorIndicatorRows:
         for ref in ("0034", "0035", "0036"):
             row = _get_c02_row(bundle, ref)
             assert row is not None
-            assert row["0010"] == 0.0, f"Row {ref} should be 0.0 for exempt entity"
+            assert row["0010"] == pytest.approx(0.0, abs=1e-10), (
+                f"Row {ref} should be 0.0 for exempt entity"
+            )
 
 
 # =============================================================================
@@ -541,9 +543,9 @@ class TestEntityTypeCombinations:
         assert row is not None
         if expect_applicable:
             # Floor binds: rwa_final (60k) > rwa_pre_floor (50k)
-            assert row["0010"] == 1.0
+            assert row["0010"] == pytest.approx(1.0, abs=1e-10)
         else:
-            assert row["0010"] == 0.0
+            assert row["0010"] == pytest.approx(0.0, abs=1e-10)
 
 
 # =============================================================================

--- a/tests/unit/test_corporate_to_retail_reclassification.py
+++ b/tests/unit/test_corporate_to_retail_reclassification.py
@@ -891,7 +891,7 @@ class TestLGDHandlingByApproach:
 
         # Under full_irb, AIRB is available for corporate — LGD is NOT cleared
         assert df["approach"][0] == ApproachType.AIRB.value
-        assert df["lgd"][0] == 0.20
+        assert df["lgd"][0] == pytest.approx(0.20, abs=1e-10)
 
     def test_airb_sme_corporate_keeps_lgd(
         self,
@@ -932,7 +932,7 @@ class TestLGDHandlingByApproach:
         # Under full_irb, AIRB is available — stays CORPORATE_SME with LGD preserved
         assert df["approach"][0] == ApproachType.AIRB.value
         assert df["reclassified_to_retail"][0] is False
-        assert df["lgd"][0] == 0.20
+        assert df["lgd"][0] == pytest.approx(0.20, abs=1e-10)
 
     def test_individual_exceeding_threshold_gets_airb_lgd_preserved(
         self,
@@ -983,4 +983,4 @@ class TestLGDHandlingByApproach:
         ]
         # Under full_irb, AIRB available for corporate — LGD preserved
         assert df["approach"][0] == ApproachType.AIRB.value
-        assert df["lgd"][0] == 0.25
+        assert df["lgd"][0] == pytest.approx(0.25, abs=1e-10)

--- a/tests/unit/test_hierarchy.py
+++ b/tests/unit/test_hierarchy.py
@@ -843,7 +843,7 @@ class TestLendingGroupAggregation:
 
         # Standalone loan should have 0 lending group total
         standalone = df.filter(pl.col("exposure_reference") == "STANDALONE_LOAN")
-        assert standalone["lending_group_total_exposure"][0] == 0.0
+        assert standalone["lending_group_total_exposure"][0] == pytest.approx(0.0, abs=1e-10)
 
 
 # =============================================================================

--- a/tests/unit/test_lgd_floor_blended.py
+++ b/tests/unit/test_lgd_floor_blended.py
@@ -88,7 +88,7 @@ class TestBlendedExpressionDirect:
         """CRR has no LGD floors — blended expression returns 0."""
         lf = _make_df(crm_alloc_other_physical=60_000.0)
         result = lf.with_columns(_lgd_floor_blended_expression(CRR).alias("floor")).collect()
-        assert result["floor"][0] == 0.0
+        assert result["floor"][0] == pytest.approx(0.0, abs=1e-10)
 
     def test_fully_unsecured_retail_other_returns_null(self):
         """Fully unsecured retail_other: blended returns null (defers to fallback)."""

--- a/tests/unit/test_of_adj.py
+++ b/tests/unit/test_of_adj.py
@@ -417,16 +417,16 @@ class TestOfAdjConfig:
     def test_default_values_zero(self) -> None:
         """OF-ADJ config fields default to zero."""
         config = OutputFloorConfig.basel_3_1()
-        assert config.gcra_amount == 0.0
-        assert config.sa_t2_credit == 0.0
-        assert config.art_40_deductions == 0.0
+        assert config.gcra_amount == pytest.approx(0.0, abs=1e-10)
+        assert config.sa_t2_credit == pytest.approx(0.0, abs=1e-10)
+        assert config.art_40_deductions == pytest.approx(0.0, abs=1e-10)
 
     def test_crr_config_has_defaults(self) -> None:
         """CRR config has OF-ADJ fields at zero (floor disabled anyway)."""
         config = OutputFloorConfig.crr()
-        assert config.gcra_amount == 0.0
-        assert config.sa_t2_credit == 0.0
-        assert config.art_40_deductions == 0.0
+        assert config.gcra_amount == pytest.approx(0.0, abs=1e-10)
+        assert config.sa_t2_credit == pytest.approx(0.0, abs=1e-10)
+        assert config.art_40_deductions == pytest.approx(0.0, abs=1e-10)
 
     def test_calculation_config_propagates_of_adj_inputs(self) -> None:
         """CalculationConfig.basel_3_1() propagates OF-ADJ inputs."""

--- a/tests/unit/test_pillar3.py
+++ b/tests/unit/test_pillar3.py
@@ -23,6 +23,7 @@ the fixed-format disclosure templates for both CRR and Basel 3.1.
 
 from __future__ import annotations
 
+import math
 from pathlib import Path
 
 import polars as pl
@@ -253,8 +254,8 @@ class TestTemplateDefinitions:
 
     def test_cr6_pd_ranges_cover_full_range(self):
         """PD ranges should cover 0% to 100% default."""
-        assert CR6_PD_RANGES[0][0] == 0.0
-        assert CR6_PD_RANGES[-1][1] == float("inf")
+        assert CR6_PD_RANGES[0][0] == pytest.approx(0.0, abs=1e-10)
+        assert math.isinf(CR6_PD_RANGES[-1][1])
 
     def test_cr6a_columns_count(self):
         assert len(CR6A_COLUMNS) == 5
@@ -1288,8 +1289,8 @@ class TestCR9TemplateDefinitions:
     def test_cr9_uses_same_pd_ranges_as_cr6(self):
         """CR9 uses the same 17 fixed PD range buckets as CR6."""
         assert len(CR6_PD_RANGES) == 17
-        assert CR6_PD_RANGES[0][0] == 0.0
-        assert CR6_PD_RANGES[-1][1] == float("inf")
+        assert CR6_PD_RANGES[0][0] == pytest.approx(0.0, abs=1e-10)
+        assert math.isinf(CR6_PD_RANGES[-1][1])
 
 
 class TestCR9Generation:

--- a/tests/unit/test_transitional_schedule.py
+++ b/tests/unit/test_transitional_schedule.py
@@ -152,7 +152,7 @@ class TestExtractFloorMetrics:
             0.50,
         )
         assert metrics["year"] == 2027
-        assert metrics["floor_percentage"] == 0.50
+        assert metrics["floor_percentage"] == pytest.approx(0.50, abs=1e-10)
         assert metrics["floor_binding_count"] == 1  # Only EXP001 binds
         assert metrics["total_floor_impact"] == pytest.approx(50_000.0)
         assert metrics["total_rwa_pre_floor"] == pytest.approx(1_250_000.0)
@@ -176,7 +176,7 @@ class TestExtractFloorMetrics:
             0.65,
         )
         assert metrics["floor_binding_count"] == 0
-        assert metrics["total_floor_impact"] == 0.0
+        assert metrics["total_floor_impact"] == pytest.approx(0.0, abs=1e-10)
         assert metrics["total_irb_exposure_count"] == 0
 
     def test_sa_rwa_back_calculated(self, mock_result_with_floor):


### PR DESCRIPTION
Resolves SonarCloud python:S1244 — floating point values should not be
tested for equality. Production code uses .abs() < 1e-10 for Polars
expressions, math.isclose() for Python floats, and math.isinf() for
infinity checks. Test code uses pytest.approx() consistently.

https://claude.ai/code/session_01VMGCMyqNGaPMPAFhJKFwp6