### PR TITLE
Add approach_reason and retail_reason audit columns to classification

### DIFF
--- a/src/rwa_calc/api/formatters.py
+++ b/src/rwa_calc/api/formatters.py
@@ -120,11 +120,17 @@ class ResultFormatter:
             "exposure_count": summary.exposure_count,
         }
 
+        # Collect classification audit separately (different plan root from results)
+        classification_audit_df: pl.DataFrame | None = None
+        if bundle.classification_audit is not None:
+            classification_audit_df = bundle.classification_audit.collect()
+
         # Write results + summaries to parquet via cache (no re-execution)
         cached = cache.sink_results(
             results=results_df,
             summary_by_class=summary_by_class_df,
             summary_by_approach=summary_by_approach_df,
+            classification_audit=classification_audit_df,
             metadata=metadata,
         )
 
@@ -143,6 +149,7 @@ class ResultFormatter:
             results_path=cached.results_path,
             summary_by_class_path=cached.summary_by_class_path,
             summary_by_approach_path=cached.summary_by_approach_path,
+            classification_audit_path=cached.classification_audit_path,
             errors=errors,
             performance=performance,
         )

--- a/src/rwa_calc/api/models.py
+++ b/src/rwa_calc/api/models.py
@@ -183,6 +183,7 @@ class CalculationResponse:
         results_path: Path to cached results parquet file
         summary_by_class_path: Path to class summary parquet (or None)
         summary_by_approach_path: Path to approach summary parquet (or None)
+        classification_audit_path: Path to classification audit parquet (or None)
         errors: List of errors/warnings encountered
         performance: Performance metrics for the run
     """
@@ -194,6 +195,7 @@ class CalculationResponse:
     results_path: Path
     summary_by_class_path: Path | None = None
     summary_by_approach_path: Path | None = None
+    classification_audit_path: Path | None = None
     errors: list[APIError] = field(default_factory=list)
     performance: PerformanceMetrics | None = None
 
@@ -216,6 +218,12 @@ class CalculationResponse:
         """Lazy-scan the approach summary parquet, or None if not available."""
         if self.summary_by_approach_path and self.summary_by_approach_path.exists():
             return pl.scan_parquet(self.summary_by_approach_path)
+        return None
+
+    def scan_classification_audit(self) -> pl.LazyFrame | None:
+        """Lazy-scan the classification audit parquet, or None if not available."""
+        if self.classification_audit_path and self.classification_audit_path.exists():
+            return pl.scan_parquet(self.classification_audit_path)
         return None
 
     def to_parquet(self, output_dir: Path) -> ExportResult:

--- a/src/rwa_calc/api/results_cache.py
+++ b/src/rwa_calc/api/results_cache.py
@@ -42,6 +42,7 @@ class CachedResults:
     results_path: Path
     summary_by_class_path: Path | None = None
     summary_by_approach_path: Path | None = None
+    classification_audit_path: Path | None = None
     metadata_path: Path | None = None
 
     def scan_results(self) -> pl.LazyFrame:
@@ -58,6 +59,12 @@ class CachedResults:
         """Lazy-scan the approach summary parquet, or None if not available."""
         if self.summary_by_approach_path and self.summary_by_approach_path.exists():
             return pl.scan_parquet(self.summary_by_approach_path)
+        return None
+
+    def scan_classification_audit(self) -> pl.LazyFrame | None:
+        """Lazy-scan the classification audit parquet, or None if not available."""
+        if self.classification_audit_path and self.classification_audit_path.exists():
+            return pl.scan_parquet(self.classification_audit_path)
         return None
 
 
@@ -100,6 +107,7 @@ class ResultsCache:
         results: pl.LazyFrame | pl.DataFrame,
         summary_by_class: pl.LazyFrame | pl.DataFrame | None = None,
         summary_by_approach: pl.LazyFrame | pl.DataFrame | None = None,
+        classification_audit: pl.LazyFrame | pl.DataFrame | None = None,
         metadata: dict | None = None,
     ) -> CachedResults:
         """
@@ -113,6 +121,7 @@ class ResultsCache:
             results: Main results (LazyFrame streamed, or DataFrame written directly)
             summary_by_class: Optional class summary
             summary_by_approach: Optional approach summary
+            classification_audit: Optional classification audit trail
             metadata: Optional metadata dict written as JSON
 
         Returns:
@@ -122,6 +131,7 @@ class ResultsCache:
         metadata_path = self._cache_dir / "last_results_meta.json"
         class_path = self._cache_dir / "last_summary_by_class.parquet"
         approach_path = self._cache_dir / "last_summary_by_approach.parquet"
+        audit_path = self._cache_dir / "last_classification_audit.parquet"
 
         # Write main results to parquet
         if isinstance(results, pl.DataFrame):
@@ -156,6 +166,19 @@ class ResultsCache:
             except Exception:
                 logger.warning("Failed to write summary_by_approach parquet")
 
+        audit_out = None
+        if classification_audit is not None:
+            try:
+                df = (
+                    classification_audit
+                    if isinstance(classification_audit, pl.DataFrame)
+                    else classification_audit.collect()
+                )
+                df.write_parquet(audit_path)
+                audit_out = audit_path
+            except Exception:
+                logger.warning("Failed to write classification_audit parquet")
+
         # Write metadata JSON
         if metadata is not None:
             metadata_path.write_text(json.dumps(metadata, indent=2))
@@ -164,6 +187,7 @@ class ResultsCache:
             results_path=results_path,
             summary_by_class_path=class_out,
             summary_by_approach_path=approach_out,
+            classification_audit_path=audit_out,
             metadata_path=metadata_path if metadata is not None else None,
         )
 
@@ -181,11 +205,13 @@ class ResultsCache:
         metadata_path = self._cache_dir / "last_results_meta.json"
         class_path = self._cache_dir / "last_summary_by_class.parquet"
         approach_path = self._cache_dir / "last_summary_by_approach.parquet"
+        audit_path = self._cache_dir / "last_classification_audit.parquet"
 
         return CachedResults(
             results_path=results_path,
             summary_by_class_path=class_path if class_path.exists() else None,
             summary_by_approach_path=approach_path if approach_path.exists() else None,
+            classification_audit_path=audit_path if audit_path.exists() else None,
             metadata_path=metadata_path if metadata_path.exists() else None,
         )
 

--- a/src/rwa_calc/contracts/bundles.py
+++ b/src/rwa_calc/contracts/bundles.py
@@ -425,6 +425,7 @@ class AggregatedResultBundle:
         post_crm_detailed: Post-CRM detailed view (split rows for guarantees)
         post_crm_summary: Post-CRM summary (net view by effective class)
         el_summary: Portfolio-level EL summary with T2 credit cap (IRB only)
+        classification_audit: Classification decision audit trail with explanations
         errors: All errors accumulated throughout pipeline
     """
 
@@ -442,6 +443,7 @@ class AggregatedResultBundle:
     post_crm_detailed: pl.LazyFrame | None = None
     post_crm_summary: pl.LazyFrame | None = None
     el_summary: ELPortfolioSummary | None = None
+    classification_audit: pl.LazyFrame | None = None
     errors: list[CalculationError] = field(default_factory=list)
 
 

--- a/src/rwa_calc/engine/classifier.py
+++ b/src/rwa_calc/engine/classifier.py
@@ -1009,6 +1009,11 @@ class ExposureClassifier:
         # CCP exposures must always use SA (CRR Art. 300-311, CRE54)
         is_ccp = pl.col("cp_entity_type") == "ccp"
 
+        # SL conditions reused by both approach and reason expressions
+        _is_sl = pl.col("exposure_class") == ExposureClass.SPECIALISED_LENDING.value
+        _sl_airb_eligible = _is_sl & sl_airb & has_internal_rating
+        _sl_slotting_eligible = _is_sl & sl_slotting
+
         approach_expr = (
             pl.when(managed_as_retail_without_lgd)
             .then(pl.lit(ApproachType.SA.value))
@@ -1022,16 +1027,10 @@ class ExposureClassifier:
             .when(_b31_ipre_hvcre_forced_slotting)
             .then(pl.lit(ApproachType.SLOTTING.value))
             # SL A-IRB takes precedence over slotting (non-IPRE/HVCRE under B31)
-            .when(
-                (pl.col("exposure_class") == ExposureClass.SPECIALISED_LENDING.value)
-                & sl_airb
-                & has_internal_rating
-            )
+            .when(_sl_airb_eligible)
             .then(pl.lit(ApproachType.AIRB.value))
             # SL slotting fallback (slotting does not require internal rating)
-            .when(
-                (pl.col("exposure_class") == ExposureClass.SPECIALISED_LENDING.value) & sl_slotting
-            )
+            .when(_sl_slotting_eligible)
             .then(pl.lit(ApproachType.SLOTTING.value))
             # A-IRB (model or org-wide, with B31 FSE/large-corp restriction applied)
             .when(airb_permitted_expr)
@@ -1045,6 +1044,143 @@ class ExposureClassifier:
             .then(pl.lit(ApproachType.EQUITY.value))
             .otherwise(pl.lit(ApproachType.SA.value))
             .alias("approach")
+        )
+
+        # --- Approach reason expression ---
+        # Mirrors the approach waterfall above with human-readable explanations.
+        approach_reason_expr = (
+            pl.when(managed_as_retail_without_lgd)
+            .then(pl.lit("SA: Retail exposure without modelled LGD"))
+            .when(_is_eu_domestic_sovereign)
+            .then(
+                pl.lit(
+                    "SA: EU domestic sovereign in domestic currency"
+                    " — forced to SA per Art. 114(4) for 0% RW"
+                )
+            )
+            .when(is_ccp)
+            .then(pl.lit("SA: CCP trade exposure (CRR Art. 300-311)"))
+            .when(_b31_ipre_hvcre_forced_slotting)
+            .then(
+                pl.lit(
+                    "Slotting: IPRE/HVCRE specialised lending"
+                    " — slotting required per Art. 147A(1)(c)"
+                )
+            )
+            .when(_sl_airb_eligible)
+            .then(pl.lit("AIRB: Specialised lending with AIRB permission and internal rating"))
+            .when(_sl_slotting_eligible)
+            .then(pl.lit("Slotting: Specialised lending with slotting permission"))
+            .when(airb_permitted_expr)
+            .then(pl.lit("AIRB: Internal rating and modelled LGD present; AIRB permission granted"))
+        )
+        # B31 FIRB sub-reasons: explain WHY AIRB was blocked
+        if config.is_basel_3_1:
+            approach_reason_expr = (
+                approach_reason_expr.when(firb_permitted_expr & _b31_institution_no_airb)
+                .then(pl.lit("FIRB: Institution exposure — AIRB not permitted per Art. 147A(1)(b)"))
+                .when(firb_permitted_expr & _is_fse)
+                .then(
+                    pl.lit("FIRB: Financial Sector Entity — AIRB not permitted per Art. 147A(1)(d)")
+                )
+                .when(firb_permitted_expr & _is_large_corp)
+                .then(
+                    pl.lit(
+                        "FIRB: Large corporate (revenue > threshold)"
+                        " — AIRB not permitted per Art. 147A(1)(e)"
+                    )
+                )
+            )
+        approach_reason_expr = (
+            approach_reason_expr.when(firb_permitted_expr)
+            .then(
+                pl.lit(
+                    "FIRB: Internal rating present; FIRB permission granted;"
+                    " AIRB not permitted or no modelled LGD"
+                )
+            )
+            .when(pl.col("exposure_class") == ExposureClass.EQUITY.value)
+            .then(pl.lit("Equity: Equity exposure class"))
+            .otherwise(
+                pl.lit(
+                    "SA: No IRB permission or no internal rating — default to Standardised Approach"
+                )
+            )
+            .alias("approach_reason")
+        )
+
+        # --- Retail reason expression ---
+        # Explains why the exposure was or was not reclassified to retail.
+        max_retail_exposure = float(config.thresholds.retail_max_exposure)
+        sme_threshold = float(config.thresholds.sme_turnover_threshold)
+        _is_corporate_class = pl.col("exposure_class").is_in(
+            [
+                ExposureClass.CORPORATE.value,
+                ExposureClass.CORPORATE_SME.value,
+            ]
+        ) | pl.col("exposure_class_irb").is_in(
+            [
+                ExposureClass.CORPORATE.value,
+                ExposureClass.CORPORATE_SME.value,
+            ]
+        )
+        retail_reason_expr = (
+            pl.when(pl.col("reclassified_to_retail"))
+            .then(
+                pl.lit(
+                    "Retail: Reclassified from corporate — meets threshold, SME, and pool criteria"
+                )
+            )
+            .when(~_is_corporate_class)
+            .then(
+                pl.lit(
+                    "Not applicable: Exposure class not eligible"
+                    " for corporate-to-retail reclassification"
+                )
+            )
+            .when(pl.col("lending_group_adjusted_exposure") > max_retail_exposure)
+            .then(
+                pl.concat_str(
+                    [
+                        pl.lit("Not retail: Lending group exposure ("),
+                        pl.col("lending_group_adjusted_exposure").round(0).cast(pl.String),
+                        pl.lit(f") exceeds threshold ({max_retail_exposure:,.0f})"),
+                        pl.lit(" — Art. 123"),
+                    ]
+                )
+            )
+            .when(pl.col("qualifies_as_retail") == False)  # noqa: E712
+            .then(
+                pl.lit(
+                    "Not retail: Does not meet retail qualification criteria (Art. 123 / Art. 123A)"
+                )
+            )
+            .when(pl.col("lgd").is_null())
+            .then(
+                pl.lit("Not retail: No modelled LGD — reclassification requires bank-estimated LGD")
+            )
+            .when(
+                (pl.col("cp_annual_revenue").fill_null(0.0) <= 0)
+                | (pl.col("cp_annual_revenue") >= sme_threshold)
+            )
+            .then(
+                pl.concat_str(
+                    [
+                        pl.lit("Not retail: Counterparty not SME (revenue "),
+                        pl.col("cp_annual_revenue").fill_null(0.0).round(0).cast(pl.String),
+                        pl.lit(f", threshold {sme_threshold:,.0f})"),
+                    ]
+                )
+            )
+            .when(~pl.col("cp_is_managed_as_retail").fill_null(True))
+            .then(
+                pl.lit(
+                    "Not retail: Counterparty not managed as retail pool"
+                    " — Art. 123A(1)(b)(iii) not met"
+                )
+            )
+            .otherwise(pl.lit("Not retail: Reclassification conditions not met"))
+            .alias("retail_reason")
         )
 
         # --- FIRB LGD clearing ---
@@ -1061,6 +1197,8 @@ class ExposureClassifier:
             [
                 approach_expr,
                 lgd_expr,
+                approach_reason_expr,
+                retail_reason_expr,
             ]
         )
 
@@ -1230,6 +1368,8 @@ class ExposureClassifier:
                 pl.col("residential_collateral_value"),
                 pl.col("lending_group_adjusted_exposure"),
                 pl.col("reclassified_to_retail"),
+                pl.col("approach_reason"),
+                pl.col("retail_reason"),
                 pl.concat_str(
                     [
                         pl.lit("entity_type="),

--- a/src/rwa_calc/engine/pipeline.py
+++ b/src/rwa_calc/engine/pipeline.py
@@ -265,6 +265,12 @@ class PipelineOrchestrator:
             # Stages 5-8: Calculation and aggregation
             result = self._run_calculators(crm_adjusted, config)
 
+            # Thread classification audit to final result (bypasses CRM/calculators)
+            if classified.classification_audit is not None:
+                result = replace(
+                    result, classification_audit=classified.classification_audit,
+                )
+
             # Add loader validation errors and pipeline errors to result
             loader_errors = list(data.errors) if data.errors else []
             pipeline_errors = [self._convert_pipeline_error(e) for e in self._errors]

--- a/tests/unit/test_classifier.py
+++ b/tests/unit/test_classifier.py
@@ -1548,6 +1548,275 @@ class TestClassificationAudit:
         assert "approach" in audit_df.columns
         assert "classification_reason" in audit_df.columns
 
+    def test_audit_trail_has_approach_reason(
+        self,
+        classifier: ExposureClassifier,
+        simple_exposures: pl.LazyFrame,
+        corporate_counterparties: pl.LazyFrame,
+        crr_config: CalculationConfig,
+    ) -> None:
+        """Audit trail should include approach_reason column."""
+        bundle = create_resolved_bundle(simple_exposures, corporate_counterparties)
+        result = classifier.classify(bundle, crr_config)
+
+        audit_df = result.classification_audit.collect()
+
+        assert "approach_reason" in audit_df.columns
+        # All SA under default CRR config (no IRB permissions)
+        for reason in audit_df["approach_reason"]:
+            assert reason is not None
+            assert reason.startswith("SA:")
+
+    def test_audit_trail_has_retail_reason(
+        self,
+        classifier: ExposureClassifier,
+        simple_exposures: pl.LazyFrame,
+        corporate_counterparties: pl.LazyFrame,
+        crr_config: CalculationConfig,
+    ) -> None:
+        """Audit trail should include retail_reason column."""
+        bundle = create_resolved_bundle(simple_exposures, corporate_counterparties)
+        result = classifier.classify(bundle, crr_config)
+
+        audit_df = result.classification_audit.collect()
+
+        assert "retail_reason" in audit_df.columns
+        for reason in audit_df["retail_reason"]:
+            assert reason is not None
+
+    def test_approach_reason_sa_no_irb_permission(
+        self,
+        classifier: ExposureClassifier,
+        simple_exposures: pl.LazyFrame,
+        corporate_counterparties: pl.LazyFrame,
+        crr_config: CalculationConfig,
+    ) -> None:
+        """SA exposures should have approach_reason explaining no IRB permission."""
+        bundle = create_resolved_bundle(simple_exposures, corporate_counterparties)
+        result = classifier.classify(bundle, crr_config)
+
+        audit_df = result.classification_audit.collect()
+        sa_reasons = audit_df.filter(pl.col("approach") == ApproachType.SA.value)["approach_reason"]
+
+        for reason in sa_reasons:
+            assert "SA:" in reason
+
+    def test_approach_reason_firb_with_model_permissions(
+        self,
+        classifier: ExposureClassifier,
+        crr_config_with_irb: CalculationConfig,
+    ) -> None:
+        """FIRB exposures should have approach_reason explaining FIRB selection."""
+        # Create exposure with internal rating but no modelled LGD (→ FIRB)
+        exposures = pl.DataFrame(
+            {
+                "exposure_reference": ["EXP_FIRB"],
+                "exposure_type": ["loan"],
+                "product_type": ["TERM_LOAN"],
+                "book_code": ["CORP"],
+                "counterparty_reference": ["CORP_FIRB"],
+                "value_date": [date(2023, 1, 1)],
+                "maturity_date": [date(2028, 1, 1)],
+                "currency": ["GBP"],
+                "drawn_amount": [5000000.0],
+                "undrawn_amount": [0.0],
+                "nominal_amount": [0.0],
+                "lgd": [None],  # No modelled LGD → FIRB not AIRB
+                "seniority": ["senior"],
+                "exposure_has_parent": [False],
+                "root_facility_reference": [None],
+                "facility_hierarchy_depth": [1],
+                "counterparty_has_parent": [False],
+                "parent_counterparty_reference": [None],
+                "ultimate_parent_reference": [None],
+                "counterparty_hierarchy_depth": [1],
+                "lending_group_reference": [None],
+                "lending_group_total_exposure": [0.0],
+            }
+        ).lazy()
+
+        counterparties = pl.DataFrame(
+            {
+                "counterparty_reference": ["CORP_FIRB"],
+                "counterparty_name": ["FIRB Corp"],
+                "entity_type": ["corporate"],
+                "country_code": ["GB"],
+                "annual_revenue": [50000000.0],
+                "total_assets": [250000000.0],
+                "default_status": [False],
+                "sector_code": ["MANU"],
+                "apply_fi_scalar": [False],
+                "is_managed_as_retail": [False],
+            }
+        ).lazy()
+
+        # Model permissions granting both FIRB and AIRB for corporate
+        model_perms = pl.DataFrame(
+            {
+                "model_id": ["CORP_PD"],
+                "exposure_class": [ExposureClass.CORPORATE.value],
+                "approach": [ApproachType.FIRB.value],
+            }
+        ).lazy()
+
+        bundle = create_resolved_bundle(
+            exposures,
+            counterparties,
+            model_permissions=model_perms,
+        )
+        # Add internal_pd via ratings (normally done by hierarchy resolver)
+        bundle = ResolvedHierarchyBundle(
+            exposures=bundle.exposures.with_columns(
+                pl.lit(0.02).alias("internal_pd"),
+                pl.lit("CORP_PD").alias("model_id"),
+            ),
+            counterparty_lookup=bundle.counterparty_lookup,
+            lending_group_totals=bundle.lending_group_totals,
+            model_permissions=model_perms,
+        )
+
+        result = classifier.classify(bundle, crr_config_with_irb)
+        audit_df = result.classification_audit.collect()
+
+        assert len(audit_df) == 1
+        assert audit_df["approach"][0] == ApproachType.FIRB.value
+        assert "FIRB:" in audit_df["approach_reason"][0]
+
+    def test_retail_reason_threshold_exceeded(
+        self,
+        classifier: ExposureClassifier,
+        crr_config: CalculationConfig,
+    ) -> None:
+        """Corporate exposure exceeding retail threshold should explain why."""
+        exposures = pl.DataFrame(
+            {
+                "exposure_reference": ["EXP_LARGE_CORP"],
+                "exposure_type": ["loan"],
+                "product_type": ["TERM_LOAN"],
+                "book_code": ["CORP"],
+                "counterparty_reference": ["CORP_BIG"],
+                "value_date": [date(2023, 1, 1)],
+                "maturity_date": [date(2028, 1, 1)],
+                "currency": ["GBP"],
+                "drawn_amount": [5000000.0],
+                "undrawn_amount": [0.0],
+                "nominal_amount": [0.0],
+                "lgd": [0.45],
+                "seniority": ["senior"],
+                "exposure_has_parent": [False],
+                "root_facility_reference": [None],
+                "facility_hierarchy_depth": [1],
+                "counterparty_has_parent": [False],
+                "parent_counterparty_reference": [None],
+                "ultimate_parent_reference": [None],
+                "counterparty_hierarchy_depth": [1],
+                "lending_group_reference": [None],
+                "lending_group_total_exposure": [0.0],
+            }
+        ).lazy()
+
+        counterparties = pl.DataFrame(
+            {
+                "counterparty_reference": ["CORP_BIG"],
+                "counterparty_name": ["Big Corp"],
+                "entity_type": ["corporate"],
+                "country_code": ["GB"],
+                "annual_revenue": [100000000.0],
+                "total_assets": [500000000.0],
+                "default_status": [False],
+                "sector_code": ["MANU"],
+                "apply_fi_scalar": [False],
+                "is_managed_as_retail": [False],
+            }
+        ).lazy()
+
+        bundle = create_resolved_bundle(exposures, counterparties)
+        result = classifier.classify(bundle, crr_config)
+
+        audit_df = result.classification_audit.collect()
+
+        # Corporate with large exposure should not qualify as retail
+        reason = audit_df["retail_reason"][0]
+        assert "Not retail" in reason or "Not applicable" in reason
+
+    def test_approach_reason_b31_institution_firb(
+        self,
+        classifier: ExposureClassifier,
+    ) -> None:
+        """B31 institution should get FIRB with Art. 147A(1)(b) reason."""
+        b31_config = CalculationConfig.basel_3_1(
+            reporting_date=date(2027, 1, 1),
+            permission_mode=PermissionMode.IRB,
+        )
+
+        exposures = pl.DataFrame(
+            {
+                "exposure_reference": ["EXP_INST"],
+                "exposure_type": ["loan"],
+                "product_type": ["INTERBANK_DEPOSIT"],
+                "book_code": ["FI"],
+                "counterparty_reference": ["INST_01"],
+                "value_date": [date(2027, 1, 1)],
+                "maturity_date": [date(2028, 1, 1)],
+                "currency": ["GBP"],
+                "drawn_amount": [10000000.0],
+                "undrawn_amount": [0.0],
+                "nominal_amount": [0.0],
+                "lgd": [0.45],
+                "seniority": ["senior"],
+                "exposure_has_parent": [False],
+                "root_facility_reference": [None],
+                "facility_hierarchy_depth": [1],
+                "counterparty_has_parent": [False],
+                "parent_counterparty_reference": [None],
+                "ultimate_parent_reference": [None],
+                "counterparty_hierarchy_depth": [1],
+                "lending_group_reference": [None],
+                "lending_group_total_exposure": [0.0],
+            }
+        ).lazy()
+
+        counterparties = pl.DataFrame(
+            {
+                "counterparty_reference": ["INST_01"],
+                "counterparty_name": ["Bank ABC"],
+                "entity_type": ["bank"],
+                "country_code": ["GB"],
+                "annual_revenue": [5000000000.0],
+                "total_assets": [100000000000.0],
+                "default_status": [False],
+                "sector_code": ["BANK"],
+                "apply_fi_scalar": [False],
+                "is_managed_as_retail": [False],
+            }
+        ).lazy()
+
+        model_perms = _full_model_permissions()
+
+        bundle = create_resolved_bundle(
+            exposures,
+            counterparties,
+            model_permissions=model_perms,
+        )
+        bundle = ResolvedHierarchyBundle(
+            exposures=bundle.exposures.with_columns(
+                pl.lit(0.005).alias("internal_pd"),
+                pl.lit(_TEST_MODEL_ID).alias("model_id"),
+            ),
+            counterparty_lookup=bundle.counterparty_lookup,
+            lending_group_totals=bundle.lending_group_totals,
+            model_permissions=model_perms,
+        )
+
+        result = classifier.classify(bundle, b31_config)
+        audit_df = result.classification_audit.collect()
+
+        assert len(audit_df) == 1
+        assert audit_df["approach"][0] == ApproachType.FIRB.value
+        reason = audit_df["approach_reason"][0]
+        assert "Institution" in reason
+        assert "147A(1)(b)" in reason
+
 
 # =============================================================================
 # Factory Function Tests


### PR DESCRIPTION
## Summary
Add detailed explanatory columns (`approach_reason` and `retail_reason`) to the classification audit trail, providing human-readable justifications for why each exposure was assigned its regulatory approach (SA/FIRB/AIRB/Slotting) and retail reclassification status.

## Regulatory Context
Supports audit trail requirements by documenting the regulatory logic applied to each exposure classification decision. Mirrors the approach assignment waterfall (CRR Art. 114(4), 123, 123A, 147A, 300-311) with explicit reasoning tied to specific regulatory articles and thresholds.

## Changes

### Calculation Logic
- **Approach reason expression**: Mirrors the approach assignment waterfall with explanations for each decision path:
  - SA forced cases (retail without LGD, EU domestic sovereign, CCP)
  - Slotting (IPRE/HVCRE, general SL)
  - AIRB (with modelled LGD and permission)
  - FIRB (with internal rating, explaining B31 restrictions: institutions, FSE, large corporates)
  - Equity class
  - Default SA fallback
  
- **Retail reason expression**: Explains corporate-to-retail reclassification decisions:
  - Successful reclassification (meets all criteria)
  - Ineligible exposure classes
  - Lending group exposure threshold exceeded
  - Fails retail qualification criteria
  - Missing modelled LGD
  - Counterparty not SME (revenue threshold)
  - Counterparty not managed as retail pool
  - Generic fallback

### Data Model
- Added `approach_reason` column to classification audit (LazyFrame)
- Added `retail_reason` column to classification audit (LazyFrame)
- Updated `CachedResults` to include `classification_audit_path` field
- Updated `CalculationResponse` to include `classification_audit_path` field
- Updated `sink_results()` to accept and persist `classification_audit` parameter
- Updated `AggregatedResultBundle` to thread `classification_audit` through pipeline

### Other
- Refactored SL condition expressions (`_is_sl`, `_sl_airb_eligible`, `_sl_slotting_eligible`) to avoid duplication between approach and reason logic
- Updated `_build_audit_trail()` to include new reason columns in output
- Updated `format_response()` to collect and persist classification audit separately
- Updated pipeline to thread classification audit to final result

## Testing
- Added 5 new unit tests covering:
  - Presence of `approach_reason` and `retail_reason` columns
  - SA approach reasons (no IRB permission)
  - FIRB approach reasons (with model permissions)
  - Retail threshold exceeded scenarios
  - B31 institution FIRB with Art. 147A(1)(b) reasoning
- All tests verify both column presence and content validity

## Assumptions & Interpretations
- Approach reason logic follows the exact waterfall order implemented in `_assign_approach()` to ensure consistency
- B31-specific FIRB sub-reasons (institutions, FSE, large corporates) are only generated when `config.is_basel_3_1` is true
- Retail reason thresholds and criteria match those used in actual reclassification logic (max exposure, SME turnover, managed-as-retail flag)
- Reason strings are human-readable but not localized (English only)

## Breaking Changes
None. New columns are additive to the audit trail; existing columns and calculation logic unchanged.

## Related
Enhances audit trail transparency for regulatory reporting and internal validation of classification decisions.

https://claude.ai/code/session_014FZLFUMS7XfzTi1E9Jz7CE