### PR TITLE
fix: correct CRR OC (Other Commitments) CCF from 0% to regulatory values

### DIFF
--- a/docs/appendix/changelog.md
+++ b/docs/appendix/changelog.md
@@ -5,6 +5,11 @@ All notable changes to the RWA Calculator are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.190] — 2026-04-11
+
+### Fixed
+- **CCF (P1.166)**: CRR OC (Other Commitments) CCF corrected from **0%** to maturity-dependent values. Under CRR, the OC category did not exist — commitments were classified by maturity: >1yr → MR (50% SA / 75% F-IRB), ≤1yr → MLR (20% SA / 75% F-IRB). The only 0% category was LR (unconditionally cancellable). Previously **understated capital** for all OC-tagged exposures under CRR. SA CRR: OC now receives 50% (>1yr) or 20% (≤1yr, based on maturity_date vs reporting_date); 50% conservative default when maturity_date absent. F-IRB CRR: OC moved from 0% to 75% (both MR and MLR are 75% under F-IRB). Basel 3.1 OC (40%) unchanged. Updated `sa_ccf_expression()`, `_firb_ccf_for_col()`, and `_compute_ccf()` with maturity-aware override. Spec F-IRB table corrected. 7 unit tests updated, 6 new tests added.
+
 ## [0.1.189] — 2026-04-11
 
 ### Fixed

--- a/docs/specifications/crr/credit-conversion-factors.md
+++ b/docs/specifications/crr/credit-conversion-factors.md
@@ -98,11 +98,11 @@ Under Basel 3.1, F-IRB CCFs are aligned to **SA CCFs** (Art. 166C). The separate
 | 2 | Full Risk — commitments (FRC) | 100% | **100%** | Commitments with certain drawdown: factoring, repos, forward purchases, partly-paid shares |
 | 3 | Other issued OBS items (MR) | 75% | **50%** | Other issued OBS items not of credit-substitute character |
 | 4 | NIFs/RUFs / UK resi mortgage (MR) | 75% | **50%** | (a) NIFs and RUFs; (b) UK residential mortgage commitments not subject to 10% or 100% CCF |
-| 5 | Other Commitments (OC) | 0% | **40%** | Any other commitment not subject to 10%, 50%, or 100% CCF |
+| 5 | Other Commitments (OC) | 75%* | **40%** | Any other commitment not subject to 10%, 50%, or 100% CCF |
 | 6 | Medium/Low Risk — issued items (MLR) | 75%/20%* | **20%** | Documentary credits, warranties, tender/performance bonds, guarantees (non-credit substitute), shipping guarantees |
 | 7 | Unconditionally Cancellable (LR) | 0% | **10%** | Undrawn commitments cancellable unconditionally at any time without notice |
 
-*\* Under CRR F-IRB, MLR was 75% for the general case (Art. 166(8)), with a 20% exception for short-term trade LCs arising from goods movement (Art. 166(9)). Basel 3.1 blanks Art. 166(9) and applies the SA Table A1 MLR value of 20% uniformly via Art. 166C.*
+*\* Under CRR, "Other Commitments" had no separate F-IRB category. These commitments were classified by maturity: >1yr → MR (75%), ≤1yr → MLR (75%). Both received 75% under F-IRB Art. 166(8). Under CRR F-IRB, MLR was 75% for the general case (Art. 166(8)), with a 20% exception for short-term trade LCs arising from goods movement (Art. 166(9)). Basel 3.1 blanks Art. 166(9) and applies the SA Table A1 MLR value of 20% uniformly via Art. 166C.*
 
 !!! warning "Critical Change — F-IRB CCFs Aligned to SA"
     Under Basel 3.1, Art. 166C states: *"the conversion factor for each type [of off-balance sheet item] shall be the same as the value set out in Article 111(1)"* (i.e., SA Table A1). F-IRB no longer has its own distinct CCF schedule. The CRR F-IRB 75% rate for MR and MLR commitments is eliminated. All six rows above match the SA Table A1 values exactly.
@@ -208,6 +208,8 @@ This ensures that provisions reduce the nominal amount before the CCF multiplier
 | CRR-D.CCF2 | Medium Risk (MR) — undrawn commitment >1yr | 50% | 75% | Art. 111, Art. 166(8) |
 | CRR-D.CCF3 | Medium-Low Risk (MLR) — trade LC for goods movement | 20% | 20% | Art. 111, Art. 166(9) |
 | CRR-D.CCF4 | Low Risk (LR) — unconditionally cancellable | 0% | 0% | Art. 111, Art. 166(8) |
+| CRR-D.CCF5 | Other Commitments (OC) >1yr | 50% | 75% | Art. 111, Art. 166(8); maturity-dependent |
+| CRR-D.CCF6 | Other Commitments (OC) <=1yr | 20% | 75% | Art. 111, Art. 166(8); maturity-dependent |
 
 ### Basel 3.1 Scenarios
 

--- a/src/rwa_calc/engine/ccf.py
+++ b/src/rwa_calc/engine/ccf.py
@@ -85,7 +85,7 @@ def sa_ccf_expression(
     - FRC / full_risk_commitment: 100% (Row 2 — repos, factoring, forward deposits)
     - MR / medium_risk: 50%
     - MLR / medium_low_risk: 20%
-    - OC / other_commit: 0% (no separate category under CRR)
+    - OC / other_commit: 50% conservative default (CRR: 50% if >1yr, 20% if <=1yr)
     - LR / low_risk: 0%
 
     Basel 3.1 (PRA Art. 111 Table A1):
@@ -103,9 +103,10 @@ def sa_ccf_expression(
     normalized = pl.col(risk_type_col).fill_null("").str.to_lowercase()
     # Basel 3.1: SA UCC/LR gets 10% instead of 0% (PRA Art. 111 Table A1 Row 6)
     lr_ccf = 0.10 if is_basel_3_1 else 0.0
-    # Basel 3.1: "Other commitments" gets 40% (Table A1 Row 5); CRR has no
-    # separate category — these were 0% (lumped with LR/UCC).
-    oc_ccf = 0.40 if is_basel_3_1 else 0.0
+    # Basel 3.1: "Other commitments" gets 40% (Table A1 Row 5); CRR: 50%
+    # conservative default (maturity-dependent override to 20% in _compute_ccf
+    # for <=1yr). Under CRR, OC mapped to MR (50%) or MLR (20%) by maturity.
+    oc_ccf = 0.40 if is_basel_3_1 else 0.50
     return (
         pl.when(normalized.is_in(["fr", "full_risk", "frc", "full_risk_commitment"]))
         .then(pl.lit(1.0))
@@ -126,7 +127,8 @@ def _firb_ccf_for_col(risk_type_col: str = "risk_type") -> pl.Expr:
 
     CRR Art. 166(8): 75% for commitments, with exceptions:
     - FR/FRC = 100%
-    - LR/OC = 0%
+    - LR = 0%
+    - OC = 75% (CRR: no separate category; maps to MR/MLR, both 75%)
     - MLR with is_short_term_trade_lc = 20% (Art. 166(9))
     - MR/MLR otherwise = 75%
 
@@ -137,8 +139,10 @@ def _firb_ccf_for_col(risk_type_col: str = "risk_type") -> pl.Expr:
     return (
         pl.when(normalized.is_in(["fr", "full_risk", "frc", "full_risk_commitment"]))
         .then(pl.lit(1.0))
-        .when(normalized.is_in(["lr", "low_risk", "oc", "other_commit"]))
+        .when(normalized.is_in(["lr", "low_risk"]))
         .then(pl.lit(0.0))
+        .when(normalized.is_in(["oc", "other_commit"]))
+        .then(pl.lit(0.75))
         .when(
             normalized.is_in(["mlr", "medium_low_risk"])
             & pl.col("is_short_term_trade_lc").fill_null(False)
@@ -291,6 +295,27 @@ class CCFCalculator:
                 "_nominal_is_zero"
             ),
         )
+
+        # CRR maturity-dependent OC override: under CRR, "other commitments" mapped
+        # to MR (50%, >1yr) or MLR (20%, <=1yr). The sa_ccf_expression gives OC 50%
+        # as the conservative default; override to 20% when remaining maturity <= 1yr.
+        if not is_b31:
+            normalized_rt = pl.col("risk_type").fill_null("").str.to_lowercase()
+            is_oc = normalized_rt.is_in(["oc", "other_commit"])
+            schema_names = exposures.collect_schema().names()
+            if "maturity_date" in schema_names:
+                is_short_maturity = pl.col("maturity_date").is_not_null() & (
+                    (
+                        pl.col("maturity_date").cast(pl.Date) - pl.lit(config.reporting_date)
+                    ).dt.total_days()
+                    <= 365
+                )
+                exposures = exposures.with_columns(
+                    pl.when(is_oc & is_short_maturity)
+                    .then(pl.lit(0.2))
+                    .otherwise(pl.col("_sa_ccf_from_risk_type"))
+                    .alias("_sa_ccf_from_risk_type"),
+                )
 
         # Art. 111(1)(c): commitment-to-issue lower-of rule.
         # When underlying_risk_type is specified, cap CCFs at the underlying item's CCF.

--- a/tests/unit/test_ccf.py
+++ b/tests/unit/test_ccf.py
@@ -1103,7 +1103,7 @@ class TestSACCFExpression:
                 ]
             }
         ).select(sa_ccf_expression().alias("ccf"))
-        assert df["ccf"].to_list() == pytest.approx([1.0, 1.0, 0.5, 0.0, 0.2, 0.0])
+        assert df["ccf"].to_list() == pytest.approx([1.0, 1.0, 0.5, 0.5, 0.2, 0.0])
 
     def test_case_insensitive(self) -> None:
         """Risk type matching should be case insensitive."""
@@ -1130,11 +1130,11 @@ class TestSACCFExpression:
         assert df["ccf"].to_list() == pytest.approx([1.0, 0.0])
 
     def test_all_risk_types_batch(self) -> None:
-        """Verify all SA CCFs in a single batch (CRR — OC maps to 0%)."""
+        """Verify all SA CCFs in a single batch (CRR — OC maps to 50%)."""
         df = pl.DataFrame({"risk_type": ["FR", "FRC", "MR", "OC", "MLR", "LR"]}).select(
             sa_ccf_expression().alias("ccf")
         )
-        expected = [1.0, 1.0, 0.5, 0.0, 0.2, 0.0]
+        expected = [1.0, 1.0, 0.5, 0.5, 0.2, 0.0]
         assert df["ccf"].to_list() == pytest.approx(expected)
 
 
@@ -1144,11 +1144,12 @@ class TestSACCFExpression:
 
 
 class TestOtherCommitCCF:
-    """Tests for the Basel 3.1 'other commitments' 40% CCF category.
+    """Tests for the 'other commitments' CCF category.
 
     PRA PS1/26 Art. 111 Table A1 Row 5 introduces a new 40% CCF for
     'all other commitments not in other categories'. Under CRR, this
-    category did not exist (0%).
+    category did not exist — commitments were classified by maturity
+    into MR (50% SA / 75% F-IRB) or MLR (20% SA / 75% F-IRB).
 
     References:
         PRA PS1/26 Art. 111 Table A1
@@ -1182,12 +1183,12 @@ class TestOtherCommitCCF:
         )
         assert df["ccf"].to_list() == pytest.approx([0.4, 0.4, 0.4, 0.4])
 
-    def test_oc_returns_0_percent_crr(self) -> None:
-        """OC should return 0% under CRR (no separate category)."""
+    def test_oc_returns_50_percent_crr(self) -> None:
+        """OC should return 50% conservative default under CRR (>1yr MR equivalent)."""
         df = pl.DataFrame({"risk_type": ["OC"]}).select(
             sa_ccf_expression(is_basel_3_1=False).alias("ccf")
         )
-        assert df["ccf"][0] == pytest.approx(0.0)
+        assert df["ccf"][0] == pytest.approx(0.5)
 
     def test_all_risk_types_b31_batch(self) -> None:
         """Verify all SA CCFs including OC and FRC in a single Basel 3.1 batch."""
@@ -1202,7 +1203,7 @@ class TestOtherCommitCCF:
         df = pl.DataFrame({"risk_type": ["FR", "FRC", "MR", "OC", "MLR", "LR"]}).select(
             sa_ccf_expression(is_basel_3_1=False).alias("ccf")
         )
-        expected = [1.0, 1.0, 0.5, 0.0, 0.2, 0.0]
+        expected = [1.0, 1.0, 0.5, 0.5, 0.2, 0.0]
         assert df["ccf"].to_list() == pytest.approx(expected)
 
     # --- Pipeline-level SA tests ---
@@ -1228,12 +1229,12 @@ class TestOtherCommitCCF:
         assert result["ccf"][0] == pytest.approx(0.4)
         assert result["ead_from_ccf"][0] == pytest.approx(40000.0)
 
-    def test_sa_pipeline_oc_0_percent_crr(
+    def test_sa_pipeline_oc_50_percent_crr_no_maturity(
         self,
         ccf_calculator: CCFCalculator,
         crr_config: CalculationConfig,
     ) -> None:
-        """SA pipeline should apply 0% CCF for OC risk_type under CRR."""
+        """SA pipeline: OC without maturity_date gets conservative 50% under CRR."""
         exposures = pl.DataFrame(
             {
                 "exposure_reference": ["OC_CRR"],
@@ -1246,8 +1247,8 @@ class TestOtherCommitCCF:
 
         result = ccf_calculator.apply_ccf(exposures, crr_config).collect()
 
-        assert result["ccf"][0] == pytest.approx(0.0)
-        assert result["ead_from_ccf"][0] == pytest.approx(0.0)
+        assert result["ccf"][0] == pytest.approx(0.5)
+        assert result["ead_from_ccf"][0] == pytest.approx(50000.0)
 
     # --- F-IRB pipeline tests ---
 
@@ -1272,12 +1273,12 @@ class TestOtherCommitCCF:
         assert result["ccf"][0] == pytest.approx(0.4)
         assert result["ead_from_ccf"][0] == pytest.approx(80000.0)
 
-    def test_firb_oc_0_percent_crr(
+    def test_firb_oc_75_percent_crr(
         self,
         ccf_calculator: CCFCalculator,
         crr_config: CalculationConfig,
     ) -> None:
-        """CRR F-IRB OC should get 0% (no separate CRR category)."""
+        """CRR F-IRB OC should get 75% (maps to MR/MLR, both 75% under F-IRB)."""
         exposures = pl.DataFrame(
             {
                 "exposure_reference": ["FIRB_OC_CRR"],
@@ -1290,7 +1291,140 @@ class TestOtherCommitCCF:
 
         result = ccf_calculator.apply_ccf(exposures, crr_config).collect()
 
-        assert result["ccf"][0] == pytest.approx(0.0)
+        assert result["ccf"][0] == pytest.approx(0.75)
+
+    # --- CRR maturity-dependent OC tests ---
+
+    def test_sa_pipeline_oc_20_percent_crr_short_maturity(
+        self,
+        ccf_calculator: CCFCalculator,
+        crr_config: CalculationConfig,
+    ) -> None:
+        """CRR SA: OC with maturity <=1yr from reporting_date -> 20% CCF."""
+        exposures = pl.DataFrame(
+            {
+                "exposure_reference": ["OC_SHORT"],
+                "drawn_amount": [0.0],
+                "nominal_amount": [100000.0],
+                "risk_type": ["OC"],
+                "approach": ["standardised"],
+                "maturity_date": [date(2025, 6, 30)],  # ~6 months from 2024-12-31
+            }
+        ).lazy()
+
+        result = ccf_calculator.apply_ccf(exposures, crr_config).collect()
+
+        assert result["ccf"][0] == pytest.approx(0.2)
+        assert result["ead_from_ccf"][0] == pytest.approx(20000.0)
+
+    def test_sa_pipeline_oc_50_percent_crr_long_maturity(
+        self,
+        ccf_calculator: CCFCalculator,
+        crr_config: CalculationConfig,
+    ) -> None:
+        """CRR SA: OC with maturity >1yr from reporting_date -> 50% CCF."""
+        exposures = pl.DataFrame(
+            {
+                "exposure_reference": ["OC_LONG"],
+                "drawn_amount": [0.0],
+                "nominal_amount": [100000.0],
+                "risk_type": ["OC"],
+                "approach": ["standardised"],
+                "maturity_date": [date(2026, 6, 30)],  # ~18 months from 2024-12-31
+            }
+        ).lazy()
+
+        result = ccf_calculator.apply_ccf(exposures, crr_config).collect()
+
+        assert result["ccf"][0] == pytest.approx(0.5)
+        assert result["ead_from_ccf"][0] == pytest.approx(50000.0)
+
+    def test_sa_pipeline_oc_boundary_exactly_1yr(
+        self,
+        ccf_calculator: CCFCalculator,
+        crr_config: CalculationConfig,
+    ) -> None:
+        """CRR SA: OC with maturity exactly 365 days from reporting_date -> 20% (<=1yr)."""
+        exposures = pl.DataFrame(
+            {
+                "exposure_reference": ["OC_BOUNDARY"],
+                "drawn_amount": [0.0],
+                "nominal_amount": [100000.0],
+                "risk_type": ["OC"],
+                "approach": ["standardised"],
+                "maturity_date": [date(2025, 12, 31)],  # exactly 365 days from 2024-12-31
+            }
+        ).lazy()
+
+        result = ccf_calculator.apply_ccf(exposures, crr_config).collect()
+
+        assert result["ccf"][0] == pytest.approx(0.2)
+
+    def test_sa_pipeline_oc_null_maturity_conservative_50(
+        self,
+        ccf_calculator: CCFCalculator,
+        crr_config: CalculationConfig,
+    ) -> None:
+        """CRR SA: OC with null maturity_date -> conservative 50%."""
+        exposures = pl.DataFrame(
+            {
+                "exposure_reference": ["OC_NULL_MAT"],
+                "drawn_amount": [0.0],
+                "nominal_amount": [100000.0],
+                "risk_type": ["OC"],
+                "approach": ["standardised"],
+                "maturity_date": [None],
+            },
+            schema_overrides={"maturity_date": pl.Date},
+        ).lazy()
+
+        result = ccf_calculator.apply_ccf(exposures, crr_config).collect()
+
+        assert result["ccf"][0] == pytest.approx(0.5)
+
+    def test_firb_oc_75_percent_crr_independent_of_maturity(
+        self,
+        ccf_calculator: CCFCalculator,
+        crr_config: CalculationConfig,
+    ) -> None:
+        """CRR F-IRB: OC -> 75% regardless of maturity (MR=MLR=75% under F-IRB)."""
+        exposures = pl.DataFrame(
+            {
+                "exposure_reference": ["FIRB_OC_SHORT", "FIRB_OC_LONG"],
+                "drawn_amount": [0.0, 0.0],
+                "nominal_amount": [200000.0, 200000.0],
+                "risk_type": ["OC", "OC"],
+                "approach": ["foundation_irb", "foundation_irb"],
+                "maturity_date": [date(2025, 6, 30), date(2026, 6, 30)],
+            }
+        ).lazy()
+
+        result = ccf_calculator.apply_ccf(exposures, crr_config).collect()
+
+        assert result["ccf"][0] == pytest.approx(0.75)
+        assert result["ccf"][1] == pytest.approx(0.75)
+
+    def test_b31_oc_40_percent_ignores_maturity(
+        self,
+        ccf_calculator: CCFCalculator,
+        b31_config: CalculationConfig,
+    ) -> None:
+        """B31 SA: OC -> 40% regardless of maturity (maturity distinction removed)."""
+        exposures = pl.DataFrame(
+            {
+                "exposure_reference": ["OC_B31_SHORT", "OC_B31_LONG"],
+                "drawn_amount": [0.0, 0.0],
+                "nominal_amount": [100000.0, 100000.0],
+                "risk_type": ["OC", "OC"],
+                "approach": ["standardised", "standardised"],
+                "maturity_date": [date(2028, 6, 30), date(2030, 1, 1)],
+            }
+        ).lazy()
+
+        result = ccf_calculator.apply_ccf(exposures, b31_config).collect()
+
+        assert result["ccf"][0] == pytest.approx(0.4)
+        assert result["ccf"][1] == pytest.approx(0.4)
 
     # --- A-IRB pipeline tests ---
 
@@ -3005,10 +3139,10 @@ class TestCommitmentToIssueLowerOf:
         result = ccf_calculator.apply_ccf(exposures, crr_config).collect()
         assert result["ccf"][0] == pytest.approx(0.0)
 
-    def test_crr_sa_commitment_oc_to_issue_fr_oc_is_zero(
+    def test_crr_sa_commitment_oc_to_issue_fr_uses_oc_ccf(
         self, ccf_calculator: CCFCalculator, crr_config: CalculationConfig
     ) -> None:
-        """CRR: OC commitment (0%) to issue FR guarantee (100%) → min(0%,100%) = 0%."""
+        """CRR: OC commitment (50%) to issue FR guarantee (100%) → min(50%,100%) = 50%."""
         exposures = pl.DataFrame(
             {
                 "exposure_reference": ["CRR_OC_FR"],
@@ -3020,7 +3154,7 @@ class TestCommitmentToIssueLowerOf:
         ).lazy()
 
         result = ccf_calculator.apply_ccf(exposures, crr_config).collect()
-        assert result["ccf"][0] == pytest.approx(0.0)
+        assert result["ccf"][0] == pytest.approx(0.5)
 
     # --- F-IRB tests ---
 


### PR DESCRIPTION
Under CRR, the "Other Commitments" category did not exist — commitments
were classified by maturity into MR (>1yr) or MLR (<=1yr). The only 0%
category was LR (unconditionally cancellable). This understated capital
for all OC-tagged exposures under CRR.

- F-IRB CRR: OC moved from 0% to 75% (both MR and MLR are 75%)
- SA CRR: OC changed from 0% to maturity-dependent (50% if >1yr,
  20% if <=1yr based on maturity_date vs reporting_date)
- SA CRR conservative default: 50% when maturity_date absent
- Basel 3.1 OC (40%) unchanged

https://claude.ai/code/session_01NXeVdJ1g5UZkwnc2op4jrs