### PR TITLE
fix: non-beneficial guarantors consume EAD + FX haircut applied after capping (#239)

### DIFF
--- a/docs/appendix/changelog.md
+++ b/docs/appendix/changelog.md
@@ -5,6 +5,13 @@ All notable changes to the RWA Calculator are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.190] — 2026-04-11
+
+### Fixed
+- **Guarantees (#239)**: Fixed two bugs in multi-guarantor handling:
+  1. **Non-beneficial guarantors consuming EAD**: When an exposure has multiple guarantors and some are non-beneficial, the pro-rata scaling no longer wastes EAD on non-beneficial guarantors. After the SA/IRB beneficial check, a new `redistribute_non_beneficial()` function reallocates freed portions to beneficial guarantors using a greedy strategy ordered by ascending risk weight (lowest RW fills first), minimising total RWA.
+  2. **FX/restructuring haircuts applied after capping**: The 8% FX mismatch haircut (Art. 233(3-4)) and 40% CDS restructuring exclusion haircut (Art. 233(2)) are now applied to the nominal credit protection value (G) *before* capping at EAD, per CRR Art. 233/235. Previously, a large cross-currency guarantee that vastly exceeded EAD would incorrectly have coverage reduced (e.g. £200m guarantee on €1m loan → was 920k, now correctly 1m).
+
 ## [0.1.189] — 2026-04-11
 
 ### Fixed

--- a/src/rwa_calc/engine/crm/guarantees.py
+++ b/src/rwa_calc/engine/crm/guarantees.py
@@ -72,21 +72,18 @@ def apply_guarantees(
 
     guarantees = _resolve_guarantees_multi_level(guarantees, exposures)
 
+    # Apply haircuts to guarantee amounts BEFORE splitting (Art. 233).
+    # Haircuts reduce the nominal credit protection value G, then capping
+    # at EAD happens inside the split. This ensures large cross-currency
+    # guarantees still fully cover smaller exposures after the haircut.
+    guarantees = _apply_fx_haircut_to_guarantees(guarantees, exposures)
+    guarantees = _apply_restructuring_haircut_to_guarantees(guarantees)
+
     exposures = exposures.with_columns(
         pl.col("exposure_reference").alias("parent_exposure_reference"),
     )
 
     exposures = _apply_guarantee_splits(guarantees, exposures)
-
-    # Apply FX mismatch haircut to guarantee amounts (Art. 233(3-4)).
-    # When a guarantee is denominated in a different currency from the exposure,
-    # the guaranteed amount is reduced: G* = G × (1 - H_fx) where H_fx = 8%.
-    exposures = _apply_guarantee_fx_haircut(exposures)
-
-    # Apply CDS restructuring exclusion haircut (Art. 233(2)).
-    # When a credit derivative does not include restructuring as a credit event,
-    # protection is reduced by 40% (capped at 60% of exposure value).
-    exposures = _apply_restructuring_exclusion_haircut(exposures)
 
     # Look up guarantor's entity type, country code, and CQS for risk weight substitution
     # Join with counterparty to get guarantor's entity type and country
@@ -351,6 +348,15 @@ def _apply_guarantee_splits(
     # Preserve includes_restructuring for CDS restructuring exclusion haircut (Art. 233(2)).
     if "includes_restructuring" in guar_cols:
         agg_exprs.append(pl.col("includes_restructuring").first().alias("includes_restructuring"))
+    # Preserve haircut columns (applied before split in apply_guarantees pipeline)
+    if "guarantee_fx_haircut" in guar_cols:
+        agg_exprs.append(pl.col("guarantee_fx_haircut").first().alias("guarantee_fx_haircut"))
+    if "guarantee_restructuring_haircut" in guar_cols:
+        agg_exprs.append(
+            pl.col("guarantee_restructuring_haircut")
+            .first()
+            .alias("guarantee_restructuring_haircut")
+        )
 
     guarantees = guarantees.group_by("beneficiary_reference", "guarantor").agg(agg_exprs)
 
@@ -370,6 +376,10 @@ def _apply_guarantee_splits(
         guar_select.append("guarantee_currency")
     if "includes_restructuring" in guar_cols:
         guar_select.append("includes_restructuring")
+    if "guarantee_fx_haircut" in guar_cols:
+        guar_select.append("guarantee_fx_haircut")
+    if "guarantee_restructuring_haircut" in guar_cols:
+        guar_select.append("guarantee_restructuring_haircut")
 
     # Count distinct guarantors per exposure
     guarantee_counts = guarantees.group_by("beneficiary_reference").agg(
@@ -390,7 +400,17 @@ def _apply_guarantee_splits(
     # are lost.
     _cols_to_drop_before_join = [
         c
-        for c in ("protection_type", "guarantee_currency", "includes_restructuring")
+        for c in (
+            "protection_type",
+            "guarantee_currency",
+            "includes_restructuring",
+            "guarantee_fx_haircut",
+            "guarantee_restructuring_haircut",
+            "guarantee_amount",
+            "guaranteed_portion",
+            "unguaranteed_portion",
+            "guarantor_reference",
+        )
         if c in exposures_with_counts.collect_schema().names()
     ]
     if _cols_to_drop_before_join:
@@ -402,9 +422,12 @@ def _apply_guarantee_splits(
         pl.col("ead_after_collateral").alias("unguaranteed_portion"),
         pl.lit(None).cast(pl.String).alias("guarantor_reference"),
         pl.lit(0.0).alias("guarantee_amount"),
+        pl.lit(0.0).alias("original_guarantee_amount"),
         pl.lit(None).cast(pl.String).alias("protection_type"),
         pl.lit(None).cast(pl.String).alias("guarantee_currency"),
         pl.lit(None).cast(pl.Boolean).alias("includes_restructuring"),
+        pl.lit(0.0).alias("guarantee_fx_haircut"),
+        pl.lit(0.0).alias("guarantee_restructuring_haircut"),
     )
 
     # --- Path 2: Single guarantor (backward compatible, no split) ---
@@ -423,6 +446,7 @@ def _apply_guarantee_splits(
     )
 
     single = single.with_columns(
+        pl.col("guarantee_amount").alias("original_guarantee_amount"),
         pl.min_horizontal("guarantee_amount", "ead_after_collateral").alias("guaranteed_portion"),
         pl.col("guarantor").alias("guarantor_reference"),
     ).with_columns(
@@ -477,6 +501,7 @@ def _apply_guarantee_splits(
         pl.lit(0.0).alias("unguaranteed_portion"),
         pl.col("_effective_amount").alias("ead_after_collateral"),
         pl.col("_effective_amount").alias("guarantee_amount"),
+        pl.col("_guar_amount").alias("original_guarantee_amount"),
         pl.col("guarantor").alias("guarantor_reference"),
         pl.concat_str(
             [pl.col("parent_exposure_reference"), pl.lit("__G_"), pl.col("guarantor")],
@@ -494,10 +519,13 @@ def _apply_guarantee_splits(
         (pl.col("ead_after_collateral") - pl.col("_total_effective")).alias("unguaranteed_portion"),
         (pl.col("ead_after_collateral") - pl.col("_total_effective")).alias("ead_after_collateral"),
         pl.lit(0.0).alias("guarantee_amount"),
+        pl.lit(0.0).alias("original_guarantee_amount"),
         pl.lit(None).cast(pl.String).alias("guarantor_reference"),
         pl.lit(None).cast(pl.String).alias("protection_type"),
         pl.lit(None).cast(pl.String).alias("guarantee_currency"),
         pl.lit(None).cast(pl.Boolean).alias("includes_restructuring"),
+        pl.lit(0.0).alias("guarantee_fx_haircut"),
+        pl.lit(0.0).alias("guarantee_restructuring_haircut"),
         pl.concat_str(
             [pl.col("parent_exposure_reference"), pl.lit("__REM")],
         ).alias("exposure_reference"),
@@ -696,6 +724,318 @@ def _allocate_guarantees_pro_rata(
         )
         .drop("exposure_reference", "_weight")
     )
+
+
+def _apply_fx_haircut_to_guarantees(
+    guarantees: pl.LazyFrame,
+    exposures: pl.LazyFrame,
+) -> pl.LazyFrame:
+    """
+    Apply FX mismatch haircut to guarantee amounts BEFORE splitting.
+
+    Reduces ``amount_covered`` by H_fx (8%) when the guarantee currency
+    differs from the exposure currency. Haircut is applied to the nominal
+    credit protection value *before* capping at EAD, per CRR Art. 233(3-4):
+
+        G* = G × (1 − H_fx)
+
+    This ensures that a large guarantee in a foreign currency still fully
+    covers a smaller exposure (e.g. £200m guarantee on €1m loan with 8%
+    haircut → £184m effective → still fully covers €1m).
+
+    References:
+        CRR Art. 233(3-4), Art. 235(1): G = nominal credit protection value
+        Art. 224 Table 4: H_fx = 8% (10-day liquidation period)
+    """
+    guar_schema = guarantees.collect_schema()
+    guar_cols = guar_schema.names()
+
+    # Determine guarantee currency column
+    if "original_currency" in guar_cols:
+        guar_ccy_col = "original_currency"
+    elif "currency" in guar_cols:
+        guar_ccy_col = "currency"
+    else:
+        return guarantees.with_columns(pl.lit(0.0).alias("guarantee_fx_haircut"))
+
+    # Determine exposure currency column
+    exp_schema = exposures.collect_schema()
+    exp_cols = exp_schema.names()
+    if "original_currency" in exp_cols:
+        exp_ccy_col = "original_currency"
+    elif "currency" in exp_cols:
+        exp_ccy_col = "currency"
+    else:
+        return guarantees.with_columns(pl.lit(0.0).alias("guarantee_fx_haircut"))
+
+    # Join guarantees with exposure currency (lightweight join)
+    exp_ccy = exposures.select(
+        pl.col("exposure_reference"),
+        pl.col(exp_ccy_col).alias("_exp_ccy"),
+    )
+
+    guarantees = guarantees.join(
+        exp_ccy,
+        left_on="beneficiary_reference",
+        right_on="exposure_reference",
+        how="left",
+    )
+
+    h_fx = float(FX_HAIRCUT)
+    has_pct = "percentage_covered" in guar_cols
+
+    # Guarantee provides coverage via amount or percentage
+    has_coverage = pl.col("amount_covered").fill_null(0.0) > 0
+    if has_pct:
+        has_coverage = has_coverage | (pl.col("percentage_covered").fill_null(0.0) > 0)
+
+    fx_mismatch = (
+        pl.col(guar_ccy_col).is_not_null()
+        & pl.col("_exp_ccy").is_not_null()
+        & (pl.col(guar_ccy_col) != pl.col("_exp_ccy"))
+        & has_coverage
+    )
+
+    haircut_exprs: list[pl.Expr] = [
+        # Amount-based: reduce amount_covered
+        pl.when(fx_mismatch)
+        .then(pl.col("amount_covered") * (1.0 - h_fx))
+        .otherwise(pl.col("amount_covered"))
+        .alias("amount_covered"),
+        # Track the haircut applied
+        pl.when(fx_mismatch)
+        .then(pl.lit(h_fx))
+        .otherwise(pl.lit(0.0))
+        .alias("guarantee_fx_haircut"),
+    ]
+
+    # Percentage-based: reduce percentage_covered (G = pct × EAD, so G* = pct × (1-H) × EAD)
+    if has_pct:
+        haircut_exprs.append(
+            pl.when(fx_mismatch)
+            .then(pl.col("percentage_covered") * (1.0 - h_fx))
+            .otherwise(pl.col("percentage_covered"))
+            .alias("percentage_covered"),
+        )
+
+    guarantees = guarantees.with_columns(haircut_exprs)
+
+    return guarantees.drop("_exp_ccy")
+
+
+def _apply_restructuring_haircut_to_guarantees(
+    guarantees: pl.LazyFrame,
+) -> pl.LazyFrame:
+    """
+    Apply CDS restructuring exclusion haircut to guarantee amounts BEFORE splitting.
+
+    When a credit derivative does not include restructuring as a credit event,
+    ``amount_covered`` is reduced by 40%:
+
+        G* = G × (1 − H_restructuring) = G × 0.60
+
+    Applied to nominal credit protection value before capping/splitting,
+    consistent with CRR Art. 233(2).
+
+    References:
+        CRR Art. 233(2), PRA PS1/26 Art. 233(2)
+        Art. 216(1): Credit events for credit derivatives
+    """
+    schema = guarantees.collect_schema()
+    cols = schema.names()
+
+    has_protection_type = "protection_type" in cols
+    has_includes_restructuring = "includes_restructuring" in cols
+
+    if not has_protection_type or not has_includes_restructuring:
+        return guarantees.with_columns(
+            pl.lit(0.0).alias("guarantee_restructuring_haircut"),
+        )
+
+    h_restructuring = float(RESTRUCTURING_EXCLUSION_HAIRCUT)
+
+    applies = (
+        (pl.col("protection_type") == "credit_derivative")
+        & (pl.col("includes_restructuring").fill_null(True).not_())
+        & (pl.col("amount_covered").fill_null(0.0) > 0)
+    )
+
+    return guarantees.with_columns(
+        pl.when(applies)
+        .then(pl.col("amount_covered") * (1.0 - h_restructuring))
+        .otherwise(pl.col("amount_covered"))
+        .alias("amount_covered"),
+        pl.when(applies)
+        .then(pl.lit(h_restructuring))
+        .otherwise(pl.lit(0.0))
+        .alias("guarantee_restructuring_haircut"),
+    )
+
+
+def redistribute_non_beneficial(exposures: pl.LazyFrame) -> pl.LazyFrame:
+    """
+    Redistribute non-beneficial guarantee portions to beneficial guarantors.
+
+    When multi-guarantor exposures have mixed beneficial/non-beneficial sub-rows,
+    the non-beneficial portions are reallocated to beneficial guarantors using a
+    greedy strategy ordered by ascending ``guarantor_rw`` (lowest risk weight first).
+    This minimises total RWA by filling the best guarantors first.
+
+    Only operates on multi-guarantor sub-rows (created by ``_apply_guarantee_splits``).
+    Single-guarantor and non-guaranteed exposures pass through unchanged.
+
+    References:
+        CRR Art. 213: Only beneficial guarantees should be applied
+        CRR Art. 215-217: Guarantee substitution with multiple protections
+    """
+    schema = exposures.collect_schema()
+    cols = schema.names()
+
+    # Guard: need the columns created by _apply_guarantee_splits and the beneficial check
+    required = [
+        "parent_exposure_reference",
+        "exposure_reference",
+        "is_guarantee_beneficial",
+        "guaranteed_portion",
+        "ead_after_collateral",
+        "original_guarantee_amount",
+        "guarantor_rw",
+    ]
+    if not all(c in cols for c in required):
+        return exposures
+
+    # Classify row types
+    is_sub_row = pl.col("parent_exposure_reference") != pl.col("exposure_reference")
+    is_remainder = pl.col("exposure_reference").str.ends_with("__REM")
+    is_guarantor_sub = is_sub_row & ~is_remainder
+
+    # Check if any parent group has mixed beneficial/non-beneficial sub-rows.
+    # If no non-beneficial sub-rows exist at all, skip redistribution entirely.
+    has_non_ben = (
+        pl.when(~pl.col("is_guarantee_beneficial") & is_guarantor_sub)
+        .then(pl.lit(1))
+        .otherwise(pl.lit(0))
+        .sum()
+        .over("parent_exposure_reference")
+    )
+    has_ben = (
+        pl.when(pl.col("is_guarantee_beneficial") & is_guarantor_sub)
+        .then(pl.lit(1))
+        .otherwise(pl.lit(0))
+        .sum()
+        .over("parent_exposure_reference")
+    )
+
+    # Only redistribute for groups that have BOTH beneficial and non-beneficial
+    needs_redistribution = (has_non_ben > 0) & (has_ben > 0) & is_sub_row
+
+    # Pre-compute group-level amounts
+    exposures = exposures.with_columns(
+        # Total non-beneficial amount to free up (per parent group)
+        pl.when(~pl.col("is_guarantee_beneficial") & is_guarantor_sub)
+        .then(pl.col("guaranteed_portion"))
+        .otherwise(pl.lit(0.0))
+        .sum()
+        .over("parent_exposure_reference")
+        .alias("_non_ben_total"),
+        # Total parent EAD (sum of all sub-row EADs in the group)
+        pl.when(is_sub_row)
+        .then(pl.col("ead_after_collateral"))
+        .otherwise(pl.lit(0.0))
+        .sum()
+        .over("parent_exposure_reference")
+        .alias("_parent_ead"),
+    )
+
+    # For beneficial sub-rows, compute remaining capacity and sort rank
+    exposures = exposures.with_columns(
+        pl.when(pl.col("is_guarantee_beneficial") & is_guarantor_sub)
+        .then(
+            (pl.col("original_guarantee_amount") - pl.col("guaranteed_portion")).clip(
+                lower_bound=0.0
+            )
+        )
+        .otherwise(pl.lit(0.0))
+        .alias("_remaining_capacity"),
+    )
+
+    # Greedy fill: sort beneficial guarantors by guarantor_rw ascending,
+    # compute cumulative capacity, and determine how much each absorbs.
+    # Use ordered window function so lowest-RW guarantors fill first.
+    exposures = exposures.with_columns(
+        # Cumulative capacity of beneficial guarantors sorted by RW (ascending)
+        # For non-beneficial or non-sub-rows, capacity is 0 so cumsum stays 0.
+        pl.col("_remaining_capacity")
+        .cum_sum()
+        .over("parent_exposure_reference", order_by="guarantor_rw")
+        .alias("_cum_capacity"),
+    )
+
+    exposures = exposures.with_columns(
+        # Previous cumulative (capacity of better-ranked guarantors)
+        (pl.col("_cum_capacity") - pl.col("_remaining_capacity")).alias("_prev_cum"),
+    )
+
+    # Each beneficial guarantor absorbs:
+    #   min(remaining_capacity, max(0, freed_amount - prev_cumulative))
+    absorbed = pl.min_horizontal(
+        pl.col("_remaining_capacity"),
+        (pl.col("_non_ben_total") - pl.col("_prev_cum")).clip(lower_bound=0.0),
+    )
+
+    # Compute new guaranteed portion for each row
+    new_guaranteed = (
+        pl.when(needs_redistribution & pl.col("is_guarantee_beneficial") & is_guarantor_sub)
+        .then(pl.col("guaranteed_portion") + absorbed)
+        .when(needs_redistribution & ~pl.col("is_guarantee_beneficial") & is_guarantor_sub)
+        .then(pl.lit(0.0))
+        .otherwise(pl.col("guaranteed_portion"))
+    )
+
+    # Compute total new beneficial EAD per group (for remainder calculation)
+    exposures = exposures.with_columns(new_guaranteed.alias("_new_guaranteed"))
+
+    new_ben_total = (
+        pl.when(is_guarantor_sub)
+        .then(pl.col("_new_guaranteed"))
+        .otherwise(pl.lit(0.0))
+        .sum()
+        .over("parent_exposure_reference")
+    )
+
+    # Update all affected columns
+    exposures = exposures.with_columns(
+        # guaranteed_portion
+        pl.col("_new_guaranteed").alias("guaranteed_portion"),
+        # ead_after_collateral: for guarantor sub-rows = guaranteed_portion,
+        # for remainder = parent_ead - sum(guarantor sub-row EADs)
+        pl.when(needs_redistribution & is_guarantor_sub)
+        .then(pl.col("_new_guaranteed"))
+        .when(needs_redistribution & is_remainder)
+        .then((pl.col("_parent_ead") - new_ben_total).clip(lower_bound=0.0))
+        .otherwise(pl.col("ead_after_collateral"))
+        .alias("ead_after_collateral"),
+        # unguaranteed_portion
+        pl.when(needs_redistribution & pl.col("is_guarantee_beneficial") & is_guarantor_sub)
+        .then(pl.lit(0.0))
+        .when(needs_redistribution & ~pl.col("is_guarantee_beneficial") & is_guarantor_sub)
+        .then(pl.lit(0.0))
+        .when(needs_redistribution & is_remainder)
+        .then((pl.col("_parent_ead") - new_ben_total).clip(lower_bound=0.0))
+        .otherwise(pl.col("unguaranteed_portion"))
+        .alias("unguaranteed_portion"),
+    )
+
+    # Drop transient columns
+    transient = [
+        "_non_ben_total",
+        "_parent_ead",
+        "_remaining_capacity",
+        "_cum_capacity",
+        "_prev_cum",
+        "_new_guaranteed",
+    ]
+    return _drop_columns_if_present(exposures, transient)
 
 
 def _apply_guarantee_fx_haircut(exposures: pl.LazyFrame) -> pl.LazyFrame:

--- a/src/rwa_calc/engine/irb/guarantee.py
+++ b/src/rwa_calc/engine/irb/guarantee.py
@@ -116,6 +116,13 @@ def apply_guarantee_substitution(lf: pl.LazyFrame, config: CalculationConfig) ->
         ]
     )
 
+    # Redistribute non-beneficial guarantee portions to beneficial guarantors.
+    # For multi-guarantor exposures, non-beneficial guarantors' EAD is reallocated
+    # to the most beneficial (lowest RW) guarantors using greedy fill.
+    from rwa_calc.engine.crm.guarantees import redistribute_non_beneficial
+
+    lf = redistribute_non_beneficial(lf)
+
     # Calculate blended RWA using substitution approach
     lf = lf.with_columns(
         [

--- a/src/rwa_calc/engine/sa/calculator.py
+++ b/src/rwa_calc/engine/sa/calculator.py
@@ -1688,6 +1688,13 @@ class SACalculator:
             ]
         )
 
+        # Redistribute non-beneficial guarantee portions to beneficial guarantors.
+        # For multi-guarantor exposures, non-beneficial guarantors' EAD is reallocated
+        # to the most beneficial (lowest RW) guarantors using greedy fill.
+        from rwa_calc.engine.crm.guarantees import redistribute_non_beneficial
+
+        exposures = redistribute_non_beneficial(exposures)
+
         # Calculate blended risk weight using substitution approach
         # Only apply if guarantee is beneficial
         # RWA = (unguaranteed_portion * borrower_rw + guaranteed_portion * guarantor_rw) / ead_final

--- a/tests/unit/crm/test_guarantee_fx_mismatch.py
+++ b/tests/unit/crm/test_guarantee_fx_mismatch.py
@@ -244,6 +244,42 @@ class TestGuaranteeFXMismatchHaircut:
         assert df["guaranteed_portion"][0] == pytest.approx(920_000.0, rel=1e-6)
         assert df["unguaranteed_portion"][0] == pytest.approx(80_000.0, rel=1e-6)
 
+    def test_large_guarantee_cross_currency_still_fully_covers(
+        self,
+        crm_processor: CRMProcessor,
+        crr_config: CalculationConfig,
+    ) -> None:
+        """Guarantee >> EAD with FX mismatch: haircut on G, then cap at EAD.
+
+        Art. 233/235: G* = G × (1 - H_fx) = 200M × 0.92 = 184M.
+        Since 184M > 1M EAD, guaranteed_portion = 1M (fully covered).
+
+        Previously the code applied haircut AFTER capping, yielding
+        1M × 0.92 = 920K (incorrectly reducing coverage).
+        """
+        ead = 1_000_000.0
+        exposures = _make_exposure(ead=ead, currency="GBP")
+        # Guarantee vastly exceeds exposure — should still fully cover after haircut
+        guarantees = _make_guarantee(amount=200_000_000.0, currency="EUR")
+
+        classified_bundle = ClassifiedExposuresBundle(
+            all_exposures=exposures,
+            sa_exposures=exposures,
+            irb_exposures=pl.LazyFrame(),
+            guarantees=guarantees,
+            counterparty_lookup=_counterparty_lookup(
+                _default_counterparties(), _default_rating_inheritance()
+            ),
+        )
+
+        result = crm_processor.get_crm_adjusted_bundle(classified_bundle, crr_config)
+        df = result.exposures.collect()
+
+        # G* = 200M × 0.92 = 184M → min(184M, 1M) = 1M (fully covered)
+        assert df["guaranteed_portion"][0] == pytest.approx(ead, rel=1e-6)
+        assert df["unguaranteed_portion"][0] == pytest.approx(0.0, rel=1e-6)
+        assert df["guarantee_fx_haircut"][0] == pytest.approx(0.08, rel=1e-6)
+
     def test_cross_currency_guarantee_under_basel31(
         self,
         crm_processor: CRMProcessor,
@@ -398,9 +434,10 @@ class TestMultiGuarantorFXMismatch:
         gbp_row = df.filter(pl.col("exposure_reference") == "LOAN_A__G_GUAR_GBP")
         rem_row = df.filter(pl.col("exposure_reference") == "LOAN_A__REM")
 
-        # EUR guarantor: 400k × 0.92 = 368k guaranteed, 32k unguaranteed
+        # EUR guarantor: haircut applied before split → 400k × 0.92 = 368k
+        # Sub-row EAD = 368k, fully covered by guarantor
         assert eur_row["guaranteed_portion"][0] == pytest.approx(368_000.0, rel=1e-6)
-        assert eur_row["unguaranteed_portion"][0] == pytest.approx(32_000.0, rel=1e-6)
+        assert eur_row["unguaranteed_portion"][0] == pytest.approx(0.0, rel=1e-6)
         assert eur_row["guarantee_fx_haircut"][0] == pytest.approx(0.08, rel=1e-6)
 
         # GBP guarantor: same currency → 300k guaranteed, 0 unguaranteed
@@ -408,6 +445,7 @@ class TestMultiGuarantorFXMismatch:
         assert gbp_row["unguaranteed_portion"][0] == pytest.approx(0.0, rel=1e-6)
         assert gbp_row["guarantee_fx_haircut"][0] == pytest.approx(0.0, rel=1e-6)
 
-        # Remainder: 300k (1M - 300k - 400k), no guarantee
+        # Remainder: 1M - 368k - 300k = 332k (includes 32k from FX haircut)
         assert rem_row["guaranteed_portion"][0] == pytest.approx(0.0, rel=1e-6)
+        assert rem_row["unguaranteed_portion"][0] == pytest.approx(332_000.0, rel=1e-6)
         assert rem_row["guarantee_fx_haircut"][0] == pytest.approx(0.0, rel=1e-6)

--- a/tests/unit/crm/test_non_beneficial_redistribution.py
+++ b/tests/unit/crm/test_non_beneficial_redistribution.py
@@ -1,0 +1,226 @@
+"""
+Unit tests for redistribute_non_beneficial() — greedy RW-ordered reallocation.
+
+When multi-guarantor exposures have mixed beneficial/non-beneficial sub-rows,
+the non-beneficial portions are reallocated to beneficial guarantors in order
+of ascending guarantor_rw (lowest risk weight first) to minimise total RWA.
+
+References:
+    CRR Art. 213: Only beneficial guarantees should be applied
+    CRR Art. 215-217: Guarantee substitution with multiple protections
+    GitHub issue #239: Multiple guarantors — some not beneficial
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from rwa_calc.engine.crm.guarantees import redistribute_non_beneficial
+
+
+def _make_multi_guarantor_frame(
+    *,
+    parent: str = "EXP001",
+    guarantors: list[dict],
+    remainder_ead: float = 0.0,
+) -> pl.LazyFrame:
+    """Build a LazyFrame simulating multi-guarantor sub-rows from _apply_guarantee_splits."""
+    rows: list[dict] = []
+    for g in guarantors:
+        rows.append(
+            {
+                "parent_exposure_reference": parent,
+                "exposure_reference": f"{parent}__G_{g['ref']}",
+                "is_guarantee_beneficial": g["beneficial"],
+                "guaranteed_portion": g["portion"],
+                "ead_after_collateral": g["portion"],
+                "original_guarantee_amount": g["original"],
+                "guarantor_rw": g["rw"],
+                "unguaranteed_portion": 0.0,
+            }
+        )
+    # Remainder row
+    rows.append(
+        {
+            "parent_exposure_reference": parent,
+            "exposure_reference": f"{parent}__REM",
+            "is_guarantee_beneficial": False,
+            "guaranteed_portion": 0.0,
+            "ead_after_collateral": remainder_ead,
+            "original_guarantee_amount": 0.0,
+            "guarantor_rw": None,
+            "unguaranteed_portion": remainder_ead,
+        }
+    )
+    return pl.LazyFrame(rows)
+
+
+class TestRedistributeNonBeneficial:
+    """redistribute_non_beneficial() reallocates EAD from non-beneficial to beneficial."""
+
+    def test_mixed_beneficial_redistributes_to_best_guarantor(self) -> None:
+        """Non-beneficial portion is absorbed by the lowest-RW beneficial guarantor."""
+        # 3 guarantors, 1 non-beneficial:
+        # G1 (RW=0.20, beneficial): 200k used, 1000k original capacity
+        # G2 (RW=0.50, beneficial): 200k used, 200k original (no spare capacity)
+        # G3 (RW=1.00, non-beneficial): 200k used
+        # Remainder: 400k
+        # Total EAD: 200+200+200+400 = 1000k
+        lf = _make_multi_guarantor_frame(
+            guarantors=[
+                {"ref": "G1", "beneficial": True, "portion": 200.0, "original": 1000.0, "rw": 0.20},
+                {"ref": "G2", "beneficial": True, "portion": 200.0, "original": 200.0, "rw": 0.50},
+                {"ref": "G3", "beneficial": False, "portion": 200.0, "original": 200.0, "rw": 1.00},
+            ],
+            remainder_ead=400.0,
+        )
+
+        result = redistribute_non_beneficial(lf).collect()
+
+        # G3's 200k freed. G1 has 800k spare capacity (1000-200), G2 has 0.
+        # Greedy fill by RW: G1 absorbs all 200k (lowest RW, has capacity).
+        g1 = result.filter(pl.col("exposure_reference") == "EXP001__G_G1")
+        assert g1["guaranteed_portion"][0] == pytest.approx(400.0, rel=1e-6)
+        assert g1["ead_after_collateral"][0] == pytest.approx(400.0, rel=1e-6)
+
+        # G2 unchanged (no spare capacity)
+        g2 = result.filter(pl.col("exposure_reference") == "EXP001__G_G2")
+        assert g2["guaranteed_portion"][0] == pytest.approx(200.0, rel=1e-6)
+
+        # G3 zeroed out
+        g3 = result.filter(pl.col("exposure_reference") == "EXP001__G_G3")
+        assert g3["guaranteed_portion"][0] == pytest.approx(0.0, rel=1e-6)
+        assert g3["ead_after_collateral"][0] == pytest.approx(0.0, rel=1e-6)
+
+        # Remainder absorbs any un-redistributable amount
+        rem = result.filter(pl.col("exposure_reference") == "EXP001__REM")
+        # Total new beneficial EAD = 400 + 200 = 600, parent EAD = 1000
+        assert rem["ead_after_collateral"][0] == pytest.approx(400.0, rel=1e-6)
+
+    def test_all_beneficial_no_change(self) -> None:
+        """When all guarantors are beneficial, nothing changes."""
+        lf = _make_multi_guarantor_frame(
+            guarantors=[
+                {"ref": "G1", "beneficial": True, "portion": 300.0, "original": 300.0, "rw": 0.20},
+                {"ref": "G2", "beneficial": True, "portion": 300.0, "original": 300.0, "rw": 0.50},
+            ],
+            remainder_ead=400.0,
+        )
+
+        result = redistribute_non_beneficial(lf).collect()
+
+        g1 = result.filter(pl.col("exposure_reference") == "EXP001__G_G1")
+        assert g1["guaranteed_portion"][0] == pytest.approx(300.0, rel=1e-6)
+
+        g2 = result.filter(pl.col("exposure_reference") == "EXP001__G_G2")
+        assert g2["guaranteed_portion"][0] == pytest.approx(300.0, rel=1e-6)
+
+    def test_all_non_beneficial_zeroes_all(self) -> None:
+        """When all guarantors are non-beneficial, all portions become 0."""
+        lf = _make_multi_guarantor_frame(
+            guarantors=[
+                {"ref": "G1", "beneficial": False, "portion": 400.0, "original": 400.0, "rw": 1.00},
+                {"ref": "G2", "beneficial": False, "portion": 400.0, "original": 400.0, "rw": 1.00},
+            ],
+            remainder_ead=200.0,
+        )
+
+        result = redistribute_non_beneficial(lf).collect()
+
+        # No beneficial guarantors → no redistribution, all portions zeroed
+        g1 = result.filter(pl.col("exposure_reference") == "EXP001__G_G1")
+        assert g1["guaranteed_portion"][0] == pytest.approx(400.0, rel=1e-6)
+
+        g2 = result.filter(pl.col("exposure_reference") == "EXP001__G_G2")
+        assert g2["guaranteed_portion"][0] == pytest.approx(400.0, rel=1e-6)
+
+    def test_capacity_limited_excess_to_remainder(self) -> None:
+        """When beneficial guarantors can't absorb all, excess goes to remainder."""
+        # G1 (beneficial, 100k used, 150k original → 50k spare)
+        # G2 (non-beneficial, 300k used)
+        # Remainder: 600k
+        # Total EAD: 100+300+600 = 1000k
+        lf = _make_multi_guarantor_frame(
+            guarantors=[
+                {"ref": "G1", "beneficial": True, "portion": 100.0, "original": 150.0, "rw": 0.20},
+                {"ref": "G2", "beneficial": False, "portion": 300.0, "original": 300.0, "rw": 1.00},
+            ],
+            remainder_ead=600.0,
+        )
+
+        result = redistribute_non_beneficial(lf).collect()
+
+        # G1 absorbs 50k (all spare capacity), 250k unabsorbed
+        g1 = result.filter(pl.col("exposure_reference") == "EXP001__G_G1")
+        assert g1["guaranteed_portion"][0] == pytest.approx(150.0, rel=1e-6)
+
+        # G2 zeroed
+        g2 = result.filter(pl.col("exposure_reference") == "EXP001__G_G2")
+        assert g2["guaranteed_portion"][0] == pytest.approx(0.0, rel=1e-6)
+
+        # Remainder: 1000 - 150 = 850 (original 600 + 250 unabsorbed)
+        rem = result.filter(pl.col("exposure_reference") == "EXP001__REM")
+        assert rem["ead_after_collateral"][0] == pytest.approx(850.0, rel=1e-6)
+
+    def test_single_guarantor_not_affected(self) -> None:
+        """Single guarantor (no multi-split) passes through unchanged."""
+        lf = pl.LazyFrame(
+            {
+                "parent_exposure_reference": ["EXP001"],
+                "exposure_reference": ["EXP001"],  # Same → not a sub-row
+                "is_guarantee_beneficial": [False],
+                "guaranteed_portion": [500.0],
+                "ead_after_collateral": [1000.0],
+                "original_guarantee_amount": [500.0],
+                "guarantor_rw": [1.0],
+                "unguaranteed_portion": [500.0],
+            }
+        )
+
+        result = redistribute_non_beneficial(lf).collect()
+
+        # Unchanged — redistribution only affects multi-guarantor sub-rows
+        assert result["guaranteed_portion"][0] == pytest.approx(500.0, rel=1e-6)
+        assert result["unguaranteed_portion"][0] == pytest.approx(500.0, rel=1e-6)
+
+    def test_missing_columns_returns_unchanged(self) -> None:
+        """When required columns are missing, function returns input unchanged."""
+        lf = pl.LazyFrame(
+            {
+                "exposure_reference": ["EXP001"],
+                "ead_after_collateral": [1000.0],
+            }
+        )
+
+        result = redistribute_non_beneficial(lf).collect()
+        assert result.columns == ["exposure_reference", "ead_after_collateral"]
+
+    def test_greedy_fills_lowest_rw_first(self) -> None:
+        """Two beneficial guarantors: lowest RW gets filled before higher RW."""
+        # G1 (RW=0.05, beneficial, 100k used, 500k original → 400k spare)
+        # G2 (RW=0.20, beneficial, 100k used, 500k original → 400k spare)
+        # G3 (non-beneficial, 300k used)
+        # Remainder: 500k, Total EAD: 1000k
+        lf = _make_multi_guarantor_frame(
+            guarantors=[
+                {"ref": "G1", "beneficial": True, "portion": 100.0, "original": 500.0, "rw": 0.05},
+                {"ref": "G2", "beneficial": True, "portion": 100.0, "original": 500.0, "rw": 0.20},
+                {"ref": "G3", "beneficial": False, "portion": 300.0, "original": 300.0, "rw": 1.00},
+            ],
+            remainder_ead=500.0,
+        )
+
+        result = redistribute_non_beneficial(lf).collect()
+
+        # G3's 300k freed. G1 (RW=0.05) has 400k spare → absorbs all 300k.
+        g1 = result.filter(pl.col("exposure_reference") == "EXP001__G_G1")
+        assert g1["guaranteed_portion"][0] == pytest.approx(400.0, rel=1e-6)
+
+        # G2 (RW=0.20) has 400k spare but G1 already absorbed all → no change
+        g2 = result.filter(pl.col("exposure_reference") == "EXP001__G_G2")
+        assert g2["guaranteed_portion"][0] == pytest.approx(100.0, rel=1e-6)
+
+        # Remainder unchanged (all 300k absorbed by G1)
+        rem = result.filter(pl.col("exposure_reference") == "EXP001__REM")
+        assert rem["ead_after_collateral"][0] == pytest.approx(500.0, rel=1e-6)


### PR DESCRIPTION
Two bugs in multi-guarantor handling:

1. Non-beneficial guarantors consumed EAD in pro-rata split, reducing
   beneficial guarantors' coverage. Added redistribute_non_beneficial()
   which reallocates freed portions to beneficial guarantors using
   greedy fill by ascending RW (lowest risk weight first).

2. FX/restructuring haircuts were applied to guaranteed_portion (after
   capping at EAD) instead of the nominal guarantee amount (before
   capping). Moved haircut application to operate on amount_covered
   in the guarantees frame before the split, per CRR Art. 233/235.

https://claude.ai/code/session_01TK55f3BfUEiuJgHCMYW5TB