### PR TITLE
docs: fix remaining OC 0% CCF references across documentation

### DIFF
--- a/.claude/skills/basel31/references/credit-conversion-factors.md
+++ b/.claude/skills/basel31/references/credit-conversion-factors.md
@@ -8,26 +8,32 @@ CCF comparison tables with deltas from CRR.
 
 ## SA CCFs (Art. 111, Table A1)
 
-| CCF Category | CRR | Basel 3.1 | Description |
-|-------------|-----|-----------|-------------|
+| CCF Category | CRR SA | Basel 3.1 SA | Description |
+|-------------|--------|-------------|-------------|
 | Full Risk (FR) | 100% | 100% | Direct credit substitutes, guarantees |
+| Full Risk Commitment (FRC) | 100% | 100% | Certain-drawdown: repos, factoring, forward deposits |
 | Medium Risk (MR) | 50% | 50% | NIFs, RUFs, UK resi mortgage commitments |
+| Other Commitments (OC) | 50%/20%* | **40%** | All other commitments not in other categories |
 | Medium-Low Risk (MLR) | 20% | 20% | Trade-related LCs, performance bonds |
-| Other commitments | 0% | **40%** | All other commitments not in other categories |
 | Low Risk (LR) | 0% | **10%** | Unconditionally cancellable commitments |
+
+*\* Under CRR, OC had no separate category. These commitments were classified by maturity: >1yr → MR (50%), ≤1yr → MLR (20%). Basel 3.1 replaces this with a flat 40%.*
 
 Key change: UCC goes from 0% to 10%; "other commitments" unified at 40%.
 
 ## F-IRB CCFs (Art. 166C)
 
-| CCF Category | CRR | Basel 3.1 | Notes |
-|-------------|-----|-----------|-------|
-| Full Risk (FR) | 100% | 100% | Unchanged |
-| Medium Risk (MR) | 75% | 75% | Unchanged |
-| MLR (trade LCs) | 20% | 20% | Art. 166C exception |
-| Low Risk (LR) | 0% | **40%** | Major increase |
+| CCF Category | CRR F-IRB | Basel 3.1 F-IRB | Notes |
+|-------------|-----------|-----------------|-------|
+| Full Risk (FR/FRC) | 100% | 100% | Unchanged |
+| Medium Risk (MR) | 75% | **50%** | Down from 75% (Art. 166C = SA) |
+| Other Commitments (OC) | 75%* | **40%** | New Table A1 Row 5 category |
+| Medium-Low Risk (MLR) | 75%/20%* | **20%** | Down from 75% (Art. 166C = SA) |
+| Low Risk (LR) | 0% | **10%** | Up from 0% (Art. 166C = SA) |
 
-Key change: LR goes from 0% to 40% under F-IRB.
+*\* Under CRR, OC had no separate F-IRB category (mapped to MR/MLR at 75%). MLR was 75% general with 20% for trade LCs (Art. 166(9)). Basel 3.1 aligns all F-IRB CCFs to SA Table A1 via Art. 166C.*
+
+Key change: F-IRB no longer has distinct CCF schedule; all aligned to SA Table A1.
 
 ## A-IRB CCFs (Art. 166D)
 

--- a/docs/framework-comparison/key-differences.md
+++ b/docs/framework-comparison/key-differences.md
@@ -891,8 +891,10 @@ values above.
 | FR / FRC | 100% | 100% | Unchanged |
 | MR | 75% | **50%** | Down from 75% |
 | MLR | 75% | **20%** | Down from 75% |
-| OC | 0% | **40%** | New Table A1 Row 5 category |
+| OC | 75%* | **40%** | New Table A1 Row 5 category |
 | LR (UCC) | 0% | **10%** | Up from 0% |
+
+*\* Under CRR, "Other Commitments" had no separate F-IRB category. These commitments were classified by maturity: >1yr → MR (75%), ≤1yr → MLR (75%). Both received 75% under F-IRB Art. 166(8).*
 
 !!! info "Art. 166(9) Trade LC Exception Removed"
     CRR Art. 166(9) is **blanked by PRA PS1/26**. The 20% short-term trade LC carve-out

--- a/docs/user-guide/methodology/irb-approach.md
+++ b/docs/user-guide/methodology/irb-approach.md
@@ -106,8 +106,10 @@ for details.
     | FR / FRC | 100% | 100% | Unchanged |
     | MR | 75% | **50%** | Down from 75% |
     | MLR | 75% | **20%** | Down from 75% |
-    | OC | 0% | **40%** | Up from 0% (new Table A1 Row 5) |
+    | OC | 75%* | **40%** | New Table A1 Row 5 category |
     | LR (UCC) | 0% | **10%** | Up from 0% |
+
+    *\* Under CRR, OC had no separate category. These commitments were classified by maturity into MR/MLR, both 75% under F-IRB Art. 166(8).*
 
     !!! warning "Art. 166(9) Trade LC Exception Removed"
         CRR Art. 166(9) is **blanked by PRA PS1/26**. The 20% short-term trade LC


### PR DESCRIPTION
Update F-IRB CCF comparison tables in key-differences.md and irb-approach.md to show OC at 75% under CRR (not 0%), with footnotes explaining OC had no separate CRR category. Also fix the Basel 3.1 skill reference which had an incomplete/incorrect F-IRB table.