### PR TITLE
refactor: remove duplicated CRM constants, source from data/tables

### DIFF
--- a/src/rwa_calc/data/tables/__init__.py
+++ b/src/rwa_calc/data/tables/__init__.py
@@ -68,7 +68,10 @@ from .crr_equity_rw import (
 )
 from .crr_firb_lgd import (
     BASEL31_FIRB_SUPERVISORY_LGD,
+    FIRB_MIN_COLLATERALISATION_THRESHOLDS,
+    FIRB_OVERCOLLATERALISATION_RATIOS,
     FIRB_SUPERVISORY_LGD,
+    get_crm_supervisory_lgd,
     get_firb_lgd_table,
     get_firb_lgd_table_for_framework,
 )
@@ -146,6 +149,9 @@ __all__ = [
     # F-IRB LGD — CRR
     "FIRB_SUPERVISORY_LGD",
     "BASEL31_FIRB_SUPERVISORY_LGD",
+    "FIRB_OVERCOLLATERALISATION_RATIOS",
+    "FIRB_MIN_COLLATERALISATION_THRESHOLDS",
+    "get_crm_supervisory_lgd",
     "get_firb_lgd_table",
     "get_firb_lgd_table_for_framework",
     # F-IRB LGD — Basel 3.1

--- a/src/rwa_calc/data/tables/crr_firb_lgd.py
+++ b/src/rwa_calc/data/tables/crr_firb_lgd.py
@@ -4,9 +4,14 @@ CRR F-IRB Supervisory LGD values (CRR Art. 161).
 Provides supervisory LGD lookup tables for Foundation IRB approach
 as Polars DataFrames for efficient joins in the RWA calculation pipeline.
 
+This module is the single source of truth for supervisory LGD values,
+overcollateralisation ratios, and minimum collateralisation thresholds.
+The CRM engine imports derived dicts via ``get_crm_supervisory_lgd()``.
+
 Reference:
     CRR Art. 161: LGD for Foundation IRB approach
     CRR Art. 230: Overcollateralisation requirements for non-financial collateral
+    CRR Art. 232: Life insurance collateral LGD
     CRE32.9-12: Basel 3.1 overcollateralisation and minimum thresholds
 """
 
@@ -37,6 +42,8 @@ FIRB_SUPERVISORY_LGD: dict[str, Decimal] = {
     "commercial_re": Decimal("0.35"),  # 35% for commercial RE
     # Secured by other physical collateral — Art. 230 Table 5 (senior)
     "other_physical": Decimal("0.40"),  # 40% for other physical
+    # Life insurance — Art. 232(2)(b): secured portion LGD = 40%
+    "life_insurance": Decimal("0.40"),  # 40%
     # CRR Art. 230 Table 5 subordinated LGDS (secured portion of subordinated claims)
     "financial_collateral_subordinated": Decimal("0.00"),  # 0% (same as senior)
     "receivables_subordinated": Decimal("0.65"),  # 65% (senior: 35%)
@@ -66,6 +73,8 @@ BASEL31_FIRB_SUPERVISORY_LGD: dict[str, Decimal] = {
     "commercial_re": Decimal("0.20"),  # 20% (CRR: 35%)
     # Secured by other physical collateral
     "other_physical": Decimal("0.25"),  # 25% (CRR: 40%)
+    # Life insurance — Art. 232(2)(b): secured portion LGD = 40% (unchanged from CRR)
+    "life_insurance": Decimal("0.40"),  # 40%
 }
 
 
@@ -81,6 +90,44 @@ def get_firb_lgd_table_for_framework(is_basel_3_1: bool = False) -> dict[str, De
     return BASEL31_FIRB_SUPERVISORY_LGD if is_basel_3_1 else FIRB_SUPERVISORY_LGD
 
 
+def get_crm_supervisory_lgd(is_basel_3_1: bool = False) -> dict[str, float]:
+    """Return supervisory LGD dict with CRM-category keys for expression builders.
+
+    Maps the granular F-IRB table keys to the simplified category keys used by
+    the CRM waterfall (Art. 231) and collateral LGD expressions.
+
+    Keys always present: ``financial``, ``receivables``, ``real_estate``,
+    ``other_physical``, ``unsecured``, ``covered_bond``, ``life_insurance``.
+
+    CRR only: ``*_subordinated`` variants (Art. 230 Table 5).
+    Basel 3.1 only: ``unsecured_fse`` (Art. 161(1)(a)).
+
+    Args:
+        is_basel_3_1: True for Basel 3.1 values, False for CRR values
+
+    Returns:
+        Dictionary of CRM-category -> supervisory LGD as float
+    """
+    table = BASEL31_FIRB_SUPERVISORY_LGD if is_basel_3_1 else FIRB_SUPERVISORY_LGD
+    result: dict[str, float] = {
+        "financial": float(table["financial_collateral"]),
+        "receivables": float(table["receivables"]),
+        "real_estate": float(table["residential_re"]),
+        "other_physical": float(table["other_physical"]),
+        "unsecured": float(table["unsecured_senior"]),
+        "covered_bond": float(table["covered_bond"]),
+        "life_insurance": float(table["life_insurance"]),
+    }
+    if is_basel_3_1:
+        result["unsecured_fse"] = float(table["unsecured_senior_fse"])
+    else:
+        # CRR Art. 230 Table 5: subordinated LGDS for the secured portion
+        result["receivables_subordinated"] = float(table["receivables_subordinated"])
+        result["real_estate_subordinated"] = float(table["residential_re_subordinated"])
+        result["other_physical_subordinated"] = float(table["other_physical_subordinated"])
+    return result
+
+
 # =============================================================================
 # F-IRB OVERCOLLATERALISATION REQUIREMENTS (CRR Art. 230 / CRE32.9-12)
 # =============================================================================
@@ -92,6 +139,7 @@ FIRB_OVERCOLLATERALISATION_RATIOS: dict[str, float] = {
     "receivables": 1.25,  # 125% overcollateralisation
     "real_estate": 1.40,  # 140% overcollateralisation
     "other_physical": 1.40,  # 140% overcollateralisation
+    "life_insurance": 1.0,  # Art. 232: no overcollateralisation required
 }
 
 # Minimum collateralisation thresholds: if collateral value is below this
@@ -101,6 +149,7 @@ FIRB_MIN_COLLATERALISATION_THRESHOLDS: dict[str, float] = {
     "receivables": 0.0,  # No minimum threshold
     "real_estate": 0.30,  # 30% minimum threshold
     "other_physical": 0.30,  # 30% minimum threshold
+    "life_insurance": 0.0,  # Art. 232: no minimum threshold
 }
 
 # PD floor under CRR (single floor for all classes)

--- a/src/rwa_calc/engine/crm/constants.py
+++ b/src/rwa_calc/engine/crm/constants.py
@@ -1,18 +1,31 @@
 """
 Shared constants and expression builders for CRM processing.
 
-Centralises collateral type classifications, supervisory LGD values,
-overcollateralisation ratios, and beneficiary type definitions used
-across the CRM submodules (collateral, guarantees, provisions, haircuts).
+Centralises collateral type classifications, Polars expression builders,
+and beneficiary type definitions used across the CRM submodules
+(collateral, guarantees, provisions, haircuts).
+
+Regulatory parameter values (supervisory LGD, overcollateralisation ratios,
+minimum thresholds) are sourced from ``rwa_calc.data.tables.crr_firb_lgd``
+— the single source of truth for F-IRB parameters.
 
 References:
     CRR Art. 161, 224, 230: Supervisory LGD, haircuts, overcollateralisation
+    CRR Art. 232: Life insurance collateral LGD
     CRE22.52-53, CRE32.9-12: Basel 3.1 equivalents
 """
 
 from __future__ import annotations
 
 import polars as pl
+
+from rwa_calc.data.tables.crr_firb_lgd import (
+    FIRB_MIN_COLLATERALISATION_THRESHOLDS as MIN_COLLATERALISATION_THRESHOLDS,  # noqa: E501
+)
+from rwa_calc.data.tables.crr_firb_lgd import (
+    FIRB_OVERCOLLATERALISATION_RATIOS as OVERCOLLATERALISATION_RATIOS,  # noqa: E501
+)
+from rwa_calc.data.tables.crr_firb_lgd import get_crm_supervisory_lgd
 
 # ---------------------------------------------------------------------------
 # Collateral type classifications
@@ -85,59 +98,15 @@ NON_ELIGIBLE_RE_TYPES: list[str] = [
 DIRECT_BENEFICIARY_TYPES: list[str] = ["exposure", "loan", "contingent"]
 
 # ---------------------------------------------------------------------------
-# F-IRB supervisory LGD values by framework
+# F-IRB supervisory LGD values by framework — derived from data/tables
 # CRR Art. 161 vs Basel 3.1 CRE32.9-12
 # ---------------------------------------------------------------------------
 
-CRR_SUPERVISORY_LGD: dict[str, float] = {
-    "financial": 0.0,
-    "receivables": 0.35,
-    "real_estate": 0.35,
-    "other_physical": 0.40,
-    "unsecured": 0.45,
-    "covered_bond": 0.1125,
-    "life_insurance": 0.40,  # Art. 232(2)(b): secured portion LGD = 40%
-    # CRR Art. 230 Table 5 subordinated LGDS (secured portion of subordinated claims)
-    "receivables_subordinated": 0.65,
-    "real_estate_subordinated": 0.65,
-    "other_physical_subordinated": 0.70,
-}
+CRR_SUPERVISORY_LGD: dict[str, float] = get_crm_supervisory_lgd(is_basel_3_1=False)
+BASEL31_SUPERVISORY_LGD: dict[str, float] = get_crm_supervisory_lgd(is_basel_3_1=True)
 
-BASEL31_SUPERVISORY_LGD: dict[str, float] = {
-    "financial": 0.0,
-    "receivables": 0.20,
-    "real_estate": 0.20,
-    "other_physical": 0.25,
-    "unsecured": 0.40,  # Art. 161(1)(aa): non-FSE corporates
-    "unsecured_fse": 0.45,  # Art. 161(1)(a): financial sector entities
-    "covered_bond": 0.1125,  # Art. 161(1)(d)
-    "life_insurance": 0.40,  # Art. 232(2)(b): secured portion LGD = 40%
-}
-
-# ---------------------------------------------------------------------------
-# Overcollateralisation ratios — same under both frameworks
-# CRR Art. 230 / CRE32.9-12
-# ---------------------------------------------------------------------------
-
-OVERCOLLATERALISATION_RATIOS: dict[str, float] = {
-    "financial": 1.0,
-    "receivables": 1.25,
-    "real_estate": 1.40,
-    "other_physical": 1.40,
-    "life_insurance": 1.0,  # Art. 232: no overcollateralisation required
-}
-
-# ---------------------------------------------------------------------------
-# Minimum collateralisation thresholds — same under both frameworks
-# ---------------------------------------------------------------------------
-
-MIN_COLLATERALISATION_THRESHOLDS: dict[str, float] = {
-    "financial": 0.0,
-    "receivables": 0.0,
-    "real_estate": 0.30,
-    "other_physical": 0.30,
-    "life_insurance": 0.0,  # Art. 232: no minimum collateralisation threshold
-}
+# OVERCOLLATERALISATION_RATIOS and MIN_COLLATERALISATION_THRESHOLDS are
+# imported directly from data/tables/crr_firb_lgd.py (aliased above).
 
 
 # ---------------------------------------------------------------------------
@@ -152,7 +121,7 @@ def _coll_type_lower() -> pl.Expr:
 
 def supervisory_lgd_values(is_basel_3_1: bool) -> dict[str, float]:
     """Return the appropriate supervisory LGD dict for the framework."""
-    return BASEL31_SUPERVISORY_LGD if is_basel_3_1 else CRR_SUPERVISORY_LGD
+    return get_crm_supervisory_lgd(is_basel_3_1)
 
 
 def collateral_lgd_expr(is_basel_3_1: bool) -> pl.Expr:


### PR DESCRIPTION
CRM supervisory LGD values, overcollateralisation ratios, and minimum
collateralisation thresholds were duplicated between engine/crm/constants.py
and data/tables/crr_firb_lgd.py. This consolidates data/tables as the
single source of truth:

- Add life_insurance entries to FIRB LGD/OC/threshold dicts (Art. 232(2)(b))
- Add get_crm_supervisory_lgd() adapter mapping F-IRB keys to CRM-category keys
- Replace hardcoded dicts in constants.py with imports from data/tables
- Keep backward-compatible aliases (CRR_SUPERVISORY_LGD, BASEL31_SUPERVISORY_LGD)

All 635 CRM unit tests pass. No downstream consumer changes needed.

https://claude.ai/code/session_01PkiocFCFFCks5XqpApVavN