### PR TITLE
refactor(crm): relocate supervisory regulatory values to data/tables/

### DIFF
--- a/src/rwa_calc/data/tables/crm_supervisory.py
+++ b/src/rwa_calc/data/tables/crm_supervisory.py
@@ -1,0 +1,80 @@
+"""
+CRM-shape supervisory values for F-IRB collateral processing.
+
+Pipeline position:
+    Data Tables -> CRM Processor (collateral.py, haircuts.py)
+
+Key responsibilities:
+- Hold the CRM-shape view of CRR Art. 161 / 230 / CRE32 supervisory data
+- Provide LGD, overcollateralisation ratio, and minimum threshold dicts
+  keyed by simple collateral category (financial, receivables, real_estate,
+  other_physical, covered_bond, life_insurance, unsecured) for use by
+  Polars expression builders in engine/crm/
+
+Sibling modules:
+- crr_firb_lgd.py / b31_firb_lgd.py hold the FIRB-shape view (split into
+  residential_re/commercial_re, FSE/non-FSE, senior/subordinated) used by
+  IRB-direct lookups. Both shapes encode the same regulatory data — this
+  module is the canonical CRM-side view.
+
+References:
+- CRR Art. 161: Supervisory LGD for F-IRB
+- CRR Art. 222(3), 227(3): Zero-haircut sovereign eligibility
+- CRR Art. 230 (Table 5): Overcollateralisation ratios and minimum thresholds
+- CRR Art. 232: Life insurance treatment (no overcollateralisation)
+- CRE22.52-53, CRE32.9-12: Basel 3.1 equivalents
+"""
+
+from __future__ import annotations
+
+from .crr_firb_lgd import (
+    FIRB_MIN_COLLATERALISATION_THRESHOLDS,
+    FIRB_OVERCOLLATERALISATION_RATIOS,
+)
+
+# ---------------------------------------------------------------------------
+# Zero-haircut sovereign eligibility (CRR Art. 227(3))
+# ---------------------------------------------------------------------------
+
+# Maximum CQS for sovereign bonds eligible for zero-haircut treatment in repos.
+# Only CQS 1 (0%-RW) sovereign debt qualifies.
+ZERO_HAIRCUT_MAX_SOVEREIGN_CQS: int = 1
+
+# ---------------------------------------------------------------------------
+# F-IRB supervisory LGD values by framework — CRM-shape view
+# CRR Art. 161 vs Basel 3.1 CRE32.9-12
+# ---------------------------------------------------------------------------
+
+CRR_SUPERVISORY_LGD: dict[str, float] = {
+    "financial": 0.0,
+    "receivables": 0.35,
+    "real_estate": 0.35,
+    "other_physical": 0.40,
+    "unsecured": 0.45,
+    "covered_bond": 0.1125,
+    "life_insurance": 0.40,  # Art. 232(2)(b): secured portion LGD = 40%
+    # CRR Art. 230 Table 5 subordinated LGDS (secured portion of subordinated claims)
+    "receivables_subordinated": 0.65,
+    "real_estate_subordinated": 0.65,
+    "other_physical_subordinated": 0.70,
+}
+
+BASEL31_SUPERVISORY_LGD: dict[str, float] = {
+    "financial": 0.0,
+    "receivables": 0.20,
+    "real_estate": 0.20,
+    "other_physical": 0.25,
+    "unsecured": 0.40,  # Art. 161(1)(aa): non-FSE corporates
+    "unsecured_fse": 0.45,  # Art. 161(1)(a): financial sector entities
+    "covered_bond": 0.1125,  # Art. 161(1)(d)
+    "life_insurance": 0.40,  # Art. 232(2)(b): secured portion LGD = 40%
+}
+
+# ---------------------------------------------------------------------------
+# Overcollateralisation ratios and minimum thresholds — same under both
+# frameworks (CRR Art. 230 / CRE32.9-12). Re-exported from crr_firb_lgd.py
+# under CRM-shape names; the underlying dicts are the single source of truth.
+# ---------------------------------------------------------------------------
+
+OVERCOLLATERALISATION_RATIOS: dict[str, float] = FIRB_OVERCOLLATERALISATION_RATIOS
+MIN_COLLATERALISATION_THRESHOLDS: dict[str, float] = FIRB_MIN_COLLATERALISATION_THRESHOLDS

--- a/src/rwa_calc/data/tables/crr_firb_lgd.py
+++ b/src/rwa_calc/data/tables/crr_firb_lgd.py
@@ -92,6 +92,7 @@ FIRB_OVERCOLLATERALISATION_RATIOS: dict[str, float] = {
     "receivables": 1.25,  # 125% overcollateralisation
     "real_estate": 1.40,  # 140% overcollateralisation
     "other_physical": 1.40,  # 140% overcollateralisation
+    "life_insurance": 1.0,  # Art. 232: no overcollateralisation required
 }
 
 # Minimum collateralisation thresholds: if collateral value is below this
@@ -101,6 +102,7 @@ FIRB_MIN_COLLATERALISATION_THRESHOLDS: dict[str, float] = {
     "receivables": 0.0,  # No minimum threshold
     "real_estate": 0.30,  # 30% minimum threshold
     "other_physical": 0.30,  # 30% minimum threshold
+    "life_insurance": 0.0,  # Art. 232: no minimum collateralisation threshold
 }
 
 # PD floor under CRR (single floor for all classes)

--- a/src/rwa_calc/engine/crm/collateral.py
+++ b/src/rwa_calc/engine/crm/collateral.py
@@ -27,10 +27,10 @@ from typing import TYPE_CHECKING
 
 import polars as pl
 
+from rwa_calc.data.tables.crm_supervisory import MIN_COLLATERALISATION_THRESHOLDS
 from rwa_calc.domain.enums import AIRBCollateralMethod, ApproachType
 from rwa_calc.engine.crm.constants import (
     CRM_ALLOC_COLUMNS,
-    MIN_COLLATERALISATION_THRESHOLDS,
     NON_ELIGIBLE_RE_TYPES,
     WATERFALL_ORDER,
     beneficiary_level_expr,

--- a/src/rwa_calc/engine/crm/constants.py
+++ b/src/rwa_calc/engine/crm/constants.py
@@ -1,9 +1,11 @@
 """
-Shared constants and expression builders for CRM processing.
+Shared collateral type classifications and Polars expression builders for CRM.
 
-Centralises collateral type classifications, supervisory LGD values,
-overcollateralisation ratios, and beneficiary type definitions used
-across the CRM submodules (collateral, guarantees, provisions, haircuts).
+Holds input-domain string lists for collateral classification and the
+expression builders that consume them. Regulatory values (supervisory
+LGD, overcollateralisation ratios, minimum thresholds, zero-haircut
+sovereign CQS cap) live in data/tables/crm_supervisory.py and are
+imported here for use by the expression builders below.
 
 References:
     CRR Art. 161, 224, 230: Supervisory LGD, haircuts, overcollateralisation
@@ -13,6 +15,13 @@ References:
 from __future__ import annotations
 
 import polars as pl
+
+from rwa_calc.data.tables.crm_supervisory import (
+    BASEL31_SUPERVISORY_LGD,
+    CRR_SUPERVISORY_LGD,
+    MIN_COLLATERALISATION_THRESHOLDS,
+    OVERCOLLATERALISATION_RATIOS,
+)
 
 # ---------------------------------------------------------------------------
 # Collateral type classifications
@@ -63,10 +72,6 @@ ZERO_HAIRCUT_ELIGIBLE_TYPES: list[str] = [
     "gilt",
 ]
 
-# Art. 227(3): maximum CQS for sovereign bonds eligible for zero-haircut treatment.
-# Only CQS 1 (0%-RW) sovereign debt qualifies.
-ZERO_HAIRCUT_MAX_SOVEREIGN_CQS: int = 1
-
 # Subset of real estate types that are NOT eligible financial collateral
 # (used for SA EAD reduction eligibility check)
 NON_ELIGIBLE_RE_TYPES: list[str] = [
@@ -83,62 +88,6 @@ NON_ELIGIBLE_RE_TYPES: list[str] = [
 # ---------------------------------------------------------------------------
 
 DIRECT_BENEFICIARY_TYPES: list[str] = ["exposure", "loan", "contingent"]
-
-# ---------------------------------------------------------------------------
-# F-IRB supervisory LGD values by framework
-# CRR Art. 161 vs Basel 3.1 CRE32.9-12
-# ---------------------------------------------------------------------------
-
-CRR_SUPERVISORY_LGD: dict[str, float] = {
-    "financial": 0.0,
-    "receivables": 0.35,
-    "real_estate": 0.35,
-    "other_physical": 0.40,
-    "unsecured": 0.45,
-    "covered_bond": 0.1125,
-    "life_insurance": 0.40,  # Art. 232(2)(b): secured portion LGD = 40%
-    # CRR Art. 230 Table 5 subordinated LGDS (secured portion of subordinated claims)
-    "receivables_subordinated": 0.65,
-    "real_estate_subordinated": 0.65,
-    "other_physical_subordinated": 0.70,
-}
-
-BASEL31_SUPERVISORY_LGD: dict[str, float] = {
-    "financial": 0.0,
-    "receivables": 0.20,
-    "real_estate": 0.20,
-    "other_physical": 0.25,
-    "unsecured": 0.40,  # Art. 161(1)(aa): non-FSE corporates
-    "unsecured_fse": 0.45,  # Art. 161(1)(a): financial sector entities
-    "covered_bond": 0.1125,  # Art. 161(1)(d)
-    "life_insurance": 0.40,  # Art. 232(2)(b): secured portion LGD = 40%
-}
-
-# ---------------------------------------------------------------------------
-# Overcollateralisation ratios — same under both frameworks
-# CRR Art. 230 / CRE32.9-12
-# ---------------------------------------------------------------------------
-
-OVERCOLLATERALISATION_RATIOS: dict[str, float] = {
-    "financial": 1.0,
-    "receivables": 1.25,
-    "real_estate": 1.40,
-    "other_physical": 1.40,
-    "life_insurance": 1.0,  # Art. 232: no overcollateralisation required
-}
-
-# ---------------------------------------------------------------------------
-# Minimum collateralisation thresholds — same under both frameworks
-# ---------------------------------------------------------------------------
-
-MIN_COLLATERALISATION_THRESHOLDS: dict[str, float] = {
-    "financial": 0.0,
-    "receivables": 0.0,
-    "real_estate": 0.30,
-    "other_physical": 0.30,
-    "life_insurance": 0.0,  # Art. 232: no minimum collateralisation threshold
-}
-
 
 # ---------------------------------------------------------------------------
 # Polars expression builders

--- a/src/rwa_calc/engine/crm/haircuts.py
+++ b/src/rwa_calc/engine/crm/haircuts.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING
 
 import polars as pl
 
+from rwa_calc.data.tables.crm_supervisory import ZERO_HAIRCUT_MAX_SOVEREIGN_CQS
 from rwa_calc.data.tables.crr_haircuts import (
     FX_HAIRCUT,
     calculate_adjusted_collateral_value,
@@ -39,7 +40,6 @@ from rwa_calc.data.tables.crr_haircuts import (
 from rwa_calc.engine.crm.constants import (
     REAL_ESTATE_TYPES,
     RECEIVABLE_TYPES,
-    ZERO_HAIRCUT_MAX_SOVEREIGN_CQS,
 )
 
 if TYPE_CHECKING:

--- a/tests/unit/crm/test_art227_zero_haircut.py
+++ b/tests/unit/crm/test_art227_zero_haircut.py
@@ -37,10 +37,8 @@ from decimal import Decimal
 import polars as pl
 import pytest
 
-from rwa_calc.engine.crm.constants import (
-    ZERO_HAIRCUT_ELIGIBLE_TYPES,
-    ZERO_HAIRCUT_MAX_SOVEREIGN_CQS,
-)
+from rwa_calc.data.tables.crm_supervisory import ZERO_HAIRCUT_MAX_SOVEREIGN_CQS
+from rwa_calc.engine.crm.constants import ZERO_HAIRCUT_ELIGIBLE_TYPES
 from rwa_calc.engine.crm.haircuts import HaircutCalculator
 
 # =============================================================================

--- a/tests/unit/crm/test_life_insurance.py
+++ b/tests/unit/crm/test_life_insurance.py
@@ -16,9 +16,11 @@ from decimal import Decimal
 import polars as pl
 import pytest
 
-from rwa_calc.engine.crm.constants import (
+from rwa_calc.data.tables.crm_supervisory import (
     BASEL31_SUPERVISORY_LGD,
     CRR_SUPERVISORY_LGD,
+)
+from rwa_calc.engine.crm.constants import (
     WATERFALL_ORDER,
     collateral_category_expr,
     collateral_lgd_expr,


### PR DESCRIPTION
## Summary

- Move CRM-side supervisory LGD, overcollateralisation ratios, minimum collateralisation thresholds, and the Art. 227(3) sovereign zero-haircut CQS cap out of `engine/crm/constants.py` into a new `data/tables/crm_supervisory.py` module — aligning with the established pattern where regulatory values live under `data/tables/`.
- Deduplicate the overcollateralisation ratio and minimum threshold dicts: add `life_insurance` keys (Art. 232: ratio 1.0, threshold 0.0) to the existing FIRB dicts in `crr_firb_lgd.py` and re-alias them from `crm_supervisory.py`, giving a single source of truth.
- Keep the CRM-shape LGD view (single `real_estate` key, simple `unsecured` key) distinct from the FIRB-shape view in `crr_firb_lgd.py` (`residential_re`/`commercial_re` split, FSE/non-FSE, subordinated variants); both encode the same Art. 161 / 230 / CRE32 data through different join shapes for different consumers, now explicitly documented.
- `engine/crm/constants.py` is now scoped to type-set string lists and the Polars expression builders that consume the relocated regulatory values.

This is **Step 1 of 3** in a sequenced architectural refactor (see plan: `cosmic-sleeping-avalanche.md`). Steps 2 (collateral type sets → `data/schemas.py`) and 3 (scattered regulatory scalars: `FCSM_RW_FLOOR`, `GCRA_CAP_RATE`, `_CRR_SCALING_FACTOR`, etc.) follow as separate PRs.

## Files changed

- **New**: `src/rwa_calc/data/tables/crm_supervisory.py`
- **Edited**: `src/rwa_calc/data/tables/crr_firb_lgd.py` — added `life_insurance` keys to the two ratio dicts
- **Edited**: `src/rwa_calc/engine/crm/constants.py` — deleted moved values; updated docstring; imports from new module
- **Edited**: `src/rwa_calc/engine/crm/collateral.py`, `src/rwa_calc/engine/crm/haircuts.py` — import from new location
- **Edited**: `tests/unit/crm/test_life_insurance.py`, `tests/unit/crm/test_art227_zero_haircut.py` — import paths updated

## Test plan

- [x] `uv run pytest tests/` — 5246 passed, 11 deselected
- [x] `uv run ruff check` clean on all touched files
- [x] No regulatory value changes — pure relocation; acceptance tests against golden files in `tests/expected_outputs/{crr,basel31}/` confirm no numeric drift
- [x] `life_insurance` keys added to FIRB ratio dicts are regulatorily correct (Art. 232: no overcollateralisation, no minimum threshold) and unused by existing FIRB consumers, so additive-only
