### PR TITLE
refactor(crm): relocate collateral type-set lists to data/schemas.py

### DIFF
--- a/src/rwa_calc/data/schemas.py
+++ b/src/rwa_calc/data/schemas.py
@@ -502,6 +502,98 @@ VALID_COLLATERAL_TYPES = {
     "credit_linked_note",
 }
 
+# =============================================================================
+# Engine-side collateral classification (CRM)
+# =============================================================================
+# These lists capture every collateral_type string the CRM engine recognises,
+# grouped by the regulatory category it maps to. They are broader than
+# VALID_COLLATERAL_TYPES because the engine accepts synonyms (e.g. "rre" /
+# "residential_property" for residential real estate, "govt_bond" / "gilt" for
+# sovereign debt). VALID_COLLATERAL_TYPES is the canonical input set used by
+# validate_bundle_values; these engine lists drive Polars expression builders
+# in engine/crm/constants.py for category-based dispatch.
+#
+# References: CRR Art. 161 / 230, CRE22.40-78
+
+FINANCIAL_COLLATERAL_TYPES: list[str] = [
+    "cash",
+    "deposit",
+    "gold",
+    "financial_collateral",
+    "government_bond",
+    "corporate_bond",
+    "equity",
+    "credit_linked_note",
+]
+
+RECEIVABLE_COLLATERAL_TYPES: list[str] = ["receivables", "trade_receivables"]
+
+REAL_ESTATE_COLLATERAL_TYPES: list[str] = [
+    "real_estate",
+    "property",
+    "rre",
+    "cre",
+    "residential_re",
+    "commercial_re",
+    "residential",
+    "commercial",
+    "residential_property",
+    "commercial_property",
+]
+
+OTHER_PHYSICAL_COLLATERAL_TYPES: list[str] = [
+    "other_physical",
+    "equipment",
+    "inventory",
+    "other",
+]
+
+COVERED_BOND_COLLATERAL_TYPES: list[str] = ["covered_bond", "covered_bonds"]
+
+LIFE_INSURANCE_COLLATERAL_TYPES: list[str] = ["life_insurance"]
+
+CREDIT_LINKED_NOTE_COLLATERAL_TYPES: list[str] = ["credit_linked_note"]
+
+# Art. 227(2)(a): collateral types eligible for zero-haircut treatment in repos.
+# Both the exposure and collateral must be cash or 0%-RW sovereign debt securities.
+ZERO_HAIRCUT_ELIGIBLE_TYPES: list[str] = [
+    "cash",
+    "deposit",
+    "govt_bond",
+    "sovereign_bond",
+    "government_bond",
+    "gilt",
+]
+
+# Subset of real estate types that are NOT eligible financial collateral
+# (used for SA EAD reduction eligibility check).
+NON_ELIGIBLE_RE_TYPES: list[str] = [
+    "real_estate",
+    "property",
+    "rre",
+    "cre",
+    "residential_property",
+    "commercial_property",
+]
+
+# Beneficiary types treated as direct attachment to a single exposure
+# (vs. facility-level or counterparty-level pro-rata allocation).
+DIRECT_BENEFICIARY_TYPES: list[str] = ["exposure", "loan", "contingent"]
+
+# Canonical mapping from accepted collateral_type string to its CRM category.
+# Single source of truth for engine-side categorisation. Engine code can use
+# either the per-category lists above (is_in checks) or this mapping
+# (category-resolution joins).
+COLLATERAL_TYPE_CATEGORY: dict[str, str] = {
+    **dict.fromkeys(FINANCIAL_COLLATERAL_TYPES, "financial"),
+    **dict.fromkeys(RECEIVABLE_COLLATERAL_TYPES, "receivables"),
+    **dict.fromkeys(REAL_ESTATE_COLLATERAL_TYPES, "real_estate"),
+    **dict.fromkeys(OTHER_PHYSICAL_COLLATERAL_TYPES, "other_physical"),
+    **dict.fromkeys(COVERED_BOND_COLLATERAL_TYPES, "covered_bond"),
+    **dict.fromkeys(LIFE_INSURANCE_COLLATERAL_TYPES, "life_insurance"),
+}
+
+
 VALID_PROPERTY_TYPES = {"residential", "commercial", "adc"}
 
 VALID_ISSUER_TYPES = {"sovereign", "pse", "corporate", "securitisation"}

--- a/src/rwa_calc/engine/crm/collateral.py
+++ b/src/rwa_calc/engine/crm/collateral.py
@@ -27,11 +27,11 @@ from typing import TYPE_CHECKING
 
 import polars as pl
 
+from rwa_calc.data.schemas import NON_ELIGIBLE_RE_TYPES
 from rwa_calc.data.tables.crm_supervisory import MIN_COLLATERALISATION_THRESHOLDS
 from rwa_calc.domain.enums import AIRBCollateralMethod, ApproachType
 from rwa_calc.engine.crm.constants import (
     CRM_ALLOC_COLUMNS,
-    NON_ELIGIBLE_RE_TYPES,
     WATERFALL_ORDER,
     beneficiary_level_expr,
     collateral_category_expr,

--- a/src/rwa_calc/engine/crm/constants.py
+++ b/src/rwa_calc/engine/crm/constants.py
@@ -1,11 +1,13 @@
 """
-Shared collateral type classifications and Polars expression builders for CRM.
+Polars expression builders for CRM collateral and beneficiary classification.
 
-Holds input-domain string lists for collateral classification and the
-expression builders that consume them. Regulatory values (supervisory
-LGD, overcollateralisation ratios, minimum thresholds, zero-haircut
-sovereign CQS cap) live in data/tables/crm_supervisory.py and are
-imported here for use by the expression builders below.
+Input-domain collateral type-set lists (FINANCIAL, RECEIVABLE, REAL_ESTATE,
+OTHER_PHYSICAL, COVERED_BOND, LIFE_INSURANCE) and the canonical
+collateral_type -> category mapping live in data/schemas.py alongside
+VALID_COLLATERAL_TYPES. Regulatory values (supervisory LGD,
+overcollateralisation ratios, minimum thresholds, zero-haircut sovereign
+CQS cap) live in data/tables/crm_supervisory.py. Both are imported here
+for use by the expression builders below.
 
 References:
     CRR Art. 161, 224, 230: Supervisory LGD, haircuts, overcollateralisation
@@ -16,78 +18,21 @@ from __future__ import annotations
 
 import polars as pl
 
+from rwa_calc.data.schemas import (
+    COVERED_BOND_COLLATERAL_TYPES,
+    DIRECT_BENEFICIARY_TYPES,
+    FINANCIAL_COLLATERAL_TYPES,
+    LIFE_INSURANCE_COLLATERAL_TYPES,
+    OTHER_PHYSICAL_COLLATERAL_TYPES,
+    REAL_ESTATE_COLLATERAL_TYPES,
+    RECEIVABLE_COLLATERAL_TYPES,
+)
 from rwa_calc.data.tables.crm_supervisory import (
     BASEL31_SUPERVISORY_LGD,
     CRR_SUPERVISORY_LGD,
     MIN_COLLATERALISATION_THRESHOLDS,
     OVERCOLLATERALISATION_RATIOS,
 )
-
-# ---------------------------------------------------------------------------
-# Collateral type classifications
-# ---------------------------------------------------------------------------
-
-FINANCIAL_TYPES: list[str] = [
-    "cash",
-    "deposit",
-    "gold",
-    "financial_collateral",
-    "government_bond",
-    "corporate_bond",
-    "equity",
-    "credit_linked_note",
-]
-
-RECEIVABLE_TYPES: list[str] = ["receivables", "trade_receivables"]
-
-REAL_ESTATE_TYPES: list[str] = [
-    "real_estate",
-    "property",
-    "rre",
-    "cre",
-    "residential_re",
-    "commercial_re",
-    "residential",
-    "commercial",
-    "residential_property",
-    "commercial_property",
-]
-
-OTHER_PHYSICAL_TYPES: list[str] = ["other_physical", "equipment", "inventory", "other"]
-
-COVERED_BOND_TYPES: list[str] = ["covered_bond", "covered_bonds"]
-
-LIFE_INSURANCE_TYPES: list[str] = ["life_insurance"]
-
-CREDIT_LINKED_NOTE_TYPES: list[str] = ["credit_linked_note"]
-
-# Art. 227(2)(a): collateral types eligible for zero-haircut treatment in repos.
-# Both the exposure and collateral must be cash or 0%-RW sovereign debt securities.
-ZERO_HAIRCUT_ELIGIBLE_TYPES: list[str] = [
-    "cash",
-    "deposit",
-    "govt_bond",
-    "sovereign_bond",
-    "government_bond",
-    "gilt",
-]
-
-# Subset of real estate types that are NOT eligible financial collateral
-# (used for SA EAD reduction eligibility check)
-NON_ELIGIBLE_RE_TYPES: list[str] = [
-    "real_estate",
-    "property",
-    "rre",
-    "cre",
-    "residential_property",
-    "commercial_property",
-]
-
-# ---------------------------------------------------------------------------
-# Beneficiary type classifications
-# ---------------------------------------------------------------------------
-
-DIRECT_BENEFICIARY_TYPES: list[str] = ["exposure", "loan", "contingent"]
 
 # ---------------------------------------------------------------------------
 # Polars expression builders
@@ -114,17 +59,17 @@ def collateral_lgd_expr(is_basel_3_1: bool) -> pl.Expr:
     lgd = supervisory_lgd_values(is_basel_3_1)
     ct = _coll_type_lower()
     return (
-        pl.when(ct.is_in(LIFE_INSURANCE_TYPES))
+        pl.when(ct.is_in(LIFE_INSURANCE_COLLATERAL_TYPES))
         .then(pl.lit(lgd["life_insurance"]))
-        .when(ct.is_in(FINANCIAL_TYPES))
+        .when(ct.is_in(FINANCIAL_COLLATERAL_TYPES))
         .then(pl.lit(lgd["financial"]))
-        .when(ct.is_in(COVERED_BOND_TYPES))
+        .when(ct.is_in(COVERED_BOND_COLLATERAL_TYPES))
         .then(pl.lit(lgd["covered_bond"]))
-        .when(ct.is_in(RECEIVABLE_TYPES))
+        .when(ct.is_in(RECEIVABLE_COLLATERAL_TYPES))
         .then(pl.lit(lgd["receivables"]))
-        .when(ct.is_in(REAL_ESTATE_TYPES))
+        .when(ct.is_in(REAL_ESTATE_COLLATERAL_TYPES))
         .then(pl.lit(lgd["real_estate"]))
-        .when(ct.is_in(OTHER_PHYSICAL_TYPES))
+        .when(ct.is_in(OTHER_PHYSICAL_COLLATERAL_TYPES))
         .then(pl.lit(lgd["other_physical"]))
         .otherwise(pl.lit(lgd["unsecured"]))
     )
@@ -134,15 +79,15 @@ def overcollateralisation_ratio_expr() -> pl.Expr:
     """Build expression mapping collateral_type to overcollateralisation ratio."""
     ct = _coll_type_lower()
     return (
-        pl.when(ct.is_in(LIFE_INSURANCE_TYPES))
+        pl.when(ct.is_in(LIFE_INSURANCE_COLLATERAL_TYPES))
         .then(pl.lit(OVERCOLLATERALISATION_RATIOS["life_insurance"]))
-        .when(ct.is_in(FINANCIAL_TYPES))
+        .when(ct.is_in(FINANCIAL_COLLATERAL_TYPES))
         .then(pl.lit(OVERCOLLATERALISATION_RATIOS["financial"]))
-        .when(ct.is_in(RECEIVABLE_TYPES))
+        .when(ct.is_in(RECEIVABLE_COLLATERAL_TYPES))
         .then(pl.lit(OVERCOLLATERALISATION_RATIOS["receivables"]))
-        .when(ct.is_in(REAL_ESTATE_TYPES))
+        .when(ct.is_in(REAL_ESTATE_COLLATERAL_TYPES))
         .then(pl.lit(OVERCOLLATERALISATION_RATIOS["real_estate"]))
-        .when(ct.is_in(OTHER_PHYSICAL_TYPES))
+        .when(ct.is_in(OTHER_PHYSICAL_COLLATERAL_TYPES))
         .then(pl.lit(OVERCOLLATERALISATION_RATIOS["other_physical"]))
         .otherwise(pl.lit(1.0))
     )
@@ -152,15 +97,15 @@ def min_collateralisation_threshold_expr() -> pl.Expr:
     """Build expression mapping collateral_type to minimum collateralisation threshold."""
     ct = _coll_type_lower()
     return (
-        pl.when(ct.is_in(LIFE_INSURANCE_TYPES))
+        pl.when(ct.is_in(LIFE_INSURANCE_COLLATERAL_TYPES))
         .then(pl.lit(MIN_COLLATERALISATION_THRESHOLDS["life_insurance"]))
-        .when(ct.is_in(FINANCIAL_TYPES))
+        .when(ct.is_in(FINANCIAL_COLLATERAL_TYPES))
         .then(pl.lit(MIN_COLLATERALISATION_THRESHOLDS["financial"]))
-        .when(ct.is_in(RECEIVABLE_TYPES))
+        .when(ct.is_in(RECEIVABLE_COLLATERAL_TYPES))
         .then(pl.lit(MIN_COLLATERALISATION_THRESHOLDS["receivables"]))
-        .when(ct.is_in(REAL_ESTATE_TYPES))
+        .when(ct.is_in(REAL_ESTATE_COLLATERAL_TYPES))
         .then(pl.lit(MIN_COLLATERALISATION_THRESHOLDS["real_estate"]))
-        .when(ct.is_in(OTHER_PHYSICAL_TYPES))
+        .when(ct.is_in(OTHER_PHYSICAL_COLLATERAL_TYPES))
         .then(pl.lit(MIN_COLLATERALISATION_THRESHOLDS["other_physical"]))
         .otherwise(pl.lit(0.0))
     )
@@ -168,26 +113,26 @@ def min_collateralisation_threshold_expr() -> pl.Expr:
 
 def is_financial_collateral_type_expr() -> pl.Expr:
     """Build expression returning True for financial collateral types."""
-    return _coll_type_lower().is_in(FINANCIAL_TYPES)
+    return _coll_type_lower().is_in(FINANCIAL_COLLATERAL_TYPES)
 
 
 def collateral_category_expr() -> pl.Expr:
     """Build expression classifying collateral into COREP categories (C 08.01 cols 0170-0210)."""
     ct = _coll_type_lower()
     return (
-        pl.when(ct.is_in(LIFE_INSURANCE_TYPES))
+        pl.when(ct.is_in(LIFE_INSURANCE_COLLATERAL_TYPES))
         .then(pl.lit("life_insurance"))
         .when(ct.is_in(["cash", "deposit"]))
         .then(pl.lit("cash"))
-        .when(ct.is_in(COVERED_BOND_TYPES))
+        .when(ct.is_in(COVERED_BOND_COLLATERAL_TYPES))
         .then(pl.lit("covered_bond"))
-        .when(ct.is_in(FINANCIAL_TYPES))
+        .when(ct.is_in(FINANCIAL_COLLATERAL_TYPES))
         .then(pl.lit("financial"))
-        .when(ct.is_in(RECEIVABLE_TYPES))
+        .when(ct.is_in(RECEIVABLE_COLLATERAL_TYPES))
         .then(pl.lit("receivables"))
-        .when(ct.is_in(REAL_ESTATE_TYPES))
+        .when(ct.is_in(REAL_ESTATE_COLLATERAL_TYPES))
         .then(pl.lit("real_estate"))
-        .when(ct.is_in(OTHER_PHYSICAL_TYPES))
+        .when(ct.is_in(OTHER_PHYSICAL_COLLATERAL_TYPES))
         .then(pl.lit("other_physical"))
         .otherwise(pl.lit("other"))
     )

--- a/src/rwa_calc/engine/crm/guarantees.py
+++ b/src/rwa_calc/engine/crm/guarantees.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING
 
 import polars as pl
 
+from rwa_calc.data.schemas import DIRECT_BENEFICIARY_TYPES
 from rwa_calc.data.tables.crr_haircuts import FX_HAIRCUT, RESTRUCTURING_EXCLUSION_HAIRCUT
 from rwa_calc.domain.enums import ApproachType
 from rwa_calc.engine.ccf import (
@@ -30,7 +31,6 @@ from rwa_calc.engine.ccf import (
     sa_ccf_expression,
 )
 from rwa_calc.engine.classifier import ENTITY_TYPE_TO_SA_CLASS
-from rwa_calc.engine.crm.constants import DIRECT_BENEFICIARY_TYPES
 
 if TYPE_CHECKING:
     from rwa_calc.contracts.config import CalculationConfig

--- a/src/rwa_calc/engine/crm/haircuts.py
+++ b/src/rwa_calc/engine/crm/haircuts.py
@@ -28,6 +28,10 @@ from typing import TYPE_CHECKING
 
 import polars as pl
 
+from rwa_calc.data.schemas import (
+    REAL_ESTATE_COLLATERAL_TYPES,
+    RECEIVABLE_COLLATERAL_TYPES,
+)
 from rwa_calc.data.tables.crm_supervisory import ZERO_HAIRCUT_MAX_SOVEREIGN_CQS
 from rwa_calc.data.tables.crr_haircuts import (
     FX_HAIRCUT,
@@ -36,10 +40,6 @@ from rwa_calc.data.tables.crr_haircuts import (
     get_haircut_table,
     lookup_collateral_haircut,
     lookup_fx_haircut,
-)
-from rwa_calc.engine.crm.constants import (
-    REAL_ESTATE_TYPES,
-    RECEIVABLE_TYPES,
 )
 
 if TYPE_CHECKING:
@@ -390,9 +390,9 @@ class HaircutCalculator:
             .then(pl.lit("corp_bond"))
             .when(ct.is_in(["equity", "shares", "stock"]))
             .then(pl.lit("equity"))
-            .when(ct.is_in(RECEIVABLE_TYPES))
+            .when(ct.is_in(RECEIVABLE_COLLATERAL_TYPES))
             .then(pl.lit("receivables"))
-            .when(ct.is_in(REAL_ESTATE_TYPES))
+            .when(ct.is_in(REAL_ESTATE_COLLATERAL_TYPES))
             .then(pl.lit("real_estate"))
             .otherwise(pl.lit("other_physical"))
         )

--- a/src/rwa_calc/engine/crm/life_insurance.py
+++ b/src/rwa_calc/engine/crm/life_insurance.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING
 
 import polars as pl
 
-from rwa_calc.engine.crm.constants import LIFE_INSURANCE_TYPES
+from rwa_calc.data.schemas import LIFE_INSURANCE_COLLATERAL_TYPES
 
 if TYPE_CHECKING:
     from rwa_calc.contracts.config import CalculationConfig
@@ -97,7 +97,9 @@ def compute_life_insurance_columns(
     if ctype_col not in coll_schema.names():
         return _add_default_life_ins_columns(exposures)
 
-    li_coll = collateral.filter(pl.col(ctype_col).str.to_lowercase().is_in(LIFE_INSURANCE_TYPES))
+    li_coll = collateral.filter(
+        pl.col(ctype_col).str.to_lowercase().is_in(LIFE_INSURANCE_COLLATERAL_TYPES)
+    )
 
     # Check if insurer_risk_weight column exists
     has_insurer_rw = "insurer_risk_weight" in coll_schema.names()

--- a/src/rwa_calc/engine/crm/processor.py
+++ b/src/rwa_calc/engine/crm/processor.py
@@ -159,7 +159,7 @@ def _join_collateral_to_lookups(
 
     When beneficiary_type is absent, falls back to a single direct join.
     """
-    from rwa_calc.engine.crm.constants import DIRECT_BENEFICIARY_TYPES
+    from rwa_calc.data.schemas import DIRECT_BENEFICIARY_TYPES
 
     coll_schema = collateral.collect_schema()
 

--- a/src/rwa_calc/engine/crm/provisions.py
+++ b/src/rwa_calc/engine/crm/provisions.py
@@ -19,9 +19,9 @@ from typing import TYPE_CHECKING
 
 import polars as pl
 
+from rwa_calc.data.schemas import DIRECT_BENEFICIARY_TYPES
 from rwa_calc.domain.enums import ApproachType
 from rwa_calc.engine.ccf import interest_for_ead
-from rwa_calc.engine.crm.constants import DIRECT_BENEFICIARY_TYPES
 
 if TYPE_CHECKING:
     from rwa_calc.contracts.config import CalculationConfig

--- a/tests/unit/crm/test_art227_zero_haircut.py
+++ b/tests/unit/crm/test_art227_zero_haircut.py
@@ -37,8 +37,8 @@ from decimal import Decimal
 import polars as pl
 import pytest
 
+from rwa_calc.data.schemas import ZERO_HAIRCUT_ELIGIBLE_TYPES
 from rwa_calc.data.tables.crm_supervisory import ZERO_HAIRCUT_MAX_SOVEREIGN_CQS
-from rwa_calc.engine.crm.constants import ZERO_HAIRCUT_ELIGIBLE_TYPES
 from rwa_calc.engine.crm.haircuts import HaircutCalculator
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Move the seven CRM collateral type-set lists (`FINANCIAL`, `RECEIVABLE`, `REAL_ESTATE`, `OTHER_PHYSICAL`, `COVERED_BOND`, `LIFE_INSURANCE`, `CREDIT_LINKED_NOTE`) plus `ZERO_HAIRCUT_ELIGIBLE_TYPES`, `NON_ELIGIBLE_RE_TYPES`, and `DIRECT_BENEFICIARY_TYPES` out of `engine/crm/constants.py` into `data/schemas.py` alongside `VALID_COLLATERAL_TYPES`. Renamed with a `_COLLATERAL_TYPES` suffix to make schema-layer ownership explicit.
- Add `COLLATERAL_TYPE_CATEGORY: dict[str, str]` — single source of truth mapping each accepted collateral_type string to its CRM category (`financial`, `receivables`, `real_estate`, `other_physical`, `covered_bond`, `life_insurance`).
- `engine/crm/constants.py` is now scoped purely to Polars expression builders + CRM allocation mechanics (`WATERFALL_ORDER`, `CRM_ALLOC_COLUMNS`).
- Engine consumers (`collateral.py`, `haircuts.py`, `life_insurance.py`, `provisions.py`, `processor.py`, `guarantees.py`) and one test import the type-set lists from `data/schemas.py` directly.

This is **Step 2 of 3** in the architectural refactor (plan: `cosmic-sleeping-avalanche.md`). Step 1 was PR #246. Step 3 (scattered regulatory scalars: `FCSM_RW_FLOOR`, `GCRA_CAP_RATE`, `_CRR_SCALING_FACTOR`, etc.) is the next PR.

## Deviation from the plan

The original plan said `validate_bundle_values()` should validate `collateral_type` against `COLLATERAL_TYPE_CATEGORY.keys()`, broadening the validator to accept every engine synonym. **I did not make that change** because:

1. `tests/unit/test_loader.py:1085` asserts `collateral_type='PROPERTY'` is invalid, and `property` is in `REAL_ESTATE_COLLATERAL_TYPES` — broadening would have flipped that test from pass to fail.
2. `IMPLEMENTATION_PLAN.md:1338` documents the narrow-validator-vs-broad-engine split as intentional (\"by design\").

`VALID_COLLATERAL_TYPES` is therefore unchanged in this PR; `COLLATERAL_TYPE_CATEGORY` is added as a separate engine-acceptance map. Whether to consolidate the two is a follow-up decision worth a separate discussion.

## Files changed

- **Edited**: `src/rwa_calc/data/schemas.py` — new \"Engine-side collateral classification (CRM)\" section with the relocated lists + `COLLATERAL_TYPE_CATEGORY` mapping
- **Edited**: `src/rwa_calc/engine/crm/constants.py` — deleted moved lists; updated docstring; imports type-set lists from `data/schemas.py` for expression builder use
- **Edited**: `engine/crm/{collateral,haircuts,life_insurance,provisions,processor,guarantees}.py` — import directly from `data/schemas.py`
- **Edited**: `tests/unit/crm/test_art227_zero_haircut.py` — `ZERO_HAIRCUT_ELIGIBLE_TYPES` import path updated

## Test plan

- [x] `uv run pytest tests/` — 5246 passed, 11 deselected (155.7s)
- [x] `uv run ruff check src/rwa_calc/ tests/unit/crm/` clean
- [x] No regulatory or behavioural changes — pure relocation; acceptance tests against golden files in `tests/expected_outputs/{crr,basel31}/` confirm no numeric drift
- [x] `COLLATERAL_TYPE_CATEGORY` is derived from the moved lists, so adding/removing accepted strings stays a single-edit operation