### PR TITLE
refactor: relocate scattered regulatory scalars to data/tables/

### DIFF
--- a/src/rwa_calc/data/tables/crr_firb_lgd.py
+++ b/src/rwa_calc/data/tables/crr_firb_lgd.py
@@ -112,6 +112,10 @@ CRR_PD_FLOOR: Decimal = Decimal("0.0003")  # 0.03%
 CRR_MATURITY_FLOOR: Decimal = Decimal("1.0")  # 1 year minimum
 CRR_MATURITY_CAP: Decimal = Decimal("5.0")  # 5 year maximum
 
+# IRB K scaling factor (CRR Art. 153(1)). Removed under Basel 3.1 (set to 1.0).
+# Used in CRR-vs-B31 attribution math to isolate the scaling-factor delta.
+CRR_K_SCALING_FACTOR: Decimal = Decimal("1.06")
+
 
 def _create_firb_lgd_df() -> pl.DataFrame:
     """Create F-IRB supervisory LGD lookup DataFrame.

--- a/src/rwa_calc/data/tables/crr_simple_method.py
+++ b/src/rwa_calc/data/tables/crr_simple_method.py
@@ -1,0 +1,28 @@
+"""
+Financial Collateral Simple Method regulatory constants (CRR Art. 222).
+
+Pipeline position:
+    Data Tables -> CRMProcessor (FCSM branch) -> SACalculator
+
+Key responsibilities:
+- Hold the SA risk-weight floor and sovereign-bond market-value discount
+  used by the Financial Collateral Simple Method
+- Both retained unchanged under PRA PS1/26 (Basel 3.1 keeps Art. 222 for
+  SA exposures), so no separate B31 variants are required
+
+References:
+- CRR Art. 222(1): minimum 20% RW floor for the secured portion
+- CRR Art. 222(4)(b): 20% market-value discount for 0%-RW sovereign bonds
+- PRA PS1/26 Art. 222: Retained for SA exposures under Basel 3.1
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+# Art. 222(1): minimum 20% RW floor for the secured portion (general case)
+FCSM_RW_FLOOR: Decimal = Decimal("0.20")
+
+# Art. 222(4)(b): 20% market-value discount applied to 0%-RW sovereign bonds
+# eligible for the same-currency 0% RW exception
+SOVEREIGN_BOND_DISCOUNT: Decimal = Decimal("0.20")

--- a/src/rwa_calc/data/tables/output_floor.py
+++ b/src/rwa_calc/data/tables/output_floor.py
@@ -1,0 +1,24 @@
+"""
+Output floor regulatory constants (PRA PS1/26 / Basel 3.1).
+
+Pipeline position:
+    Data Tables -> aggregator._floor (OF-ADJ + portfolio floor)
+
+Key responsibilities:
+- Hold the GCRA cap rate used in the OF-ADJ formula. GCRA is capped at
+  1.25% of S-TREA before entering OF-ADJ = 12.5 * (IRB_T2 - IRB_CET1
+  - GCRA + SA_T2).
+- Basel 3.1 only — the output floor and OF-ADJ are introduced by PS1/26.
+
+References:
+- PRA PS1/26 Art. 92 para 2A: TREA = max(U-TREA, x * S-TREA + OF-ADJ)
+- PRA PS1/26 Art. 92 para 2A: GCRA cap definition (1.25% of S-TREA)
+- CRE99.1-8: Basel 3.1 output floor
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+# GCRA cap: 1.25% of S-TREA per Art. 92 para 2A definition
+GCRA_CAP_RATE: Decimal = Decimal("0.0125")

--- a/src/rwa_calc/engine/aggregator/_floor.py
+++ b/src/rwa_calc/engine/aggregator/_floor.py
@@ -42,11 +42,14 @@ from __future__ import annotations
 import polars as pl
 
 from rwa_calc.contracts.bundles import OutputFloorSummary
+from rwa_calc.data.tables.output_floor import GCRA_CAP_RATE as _GCRA_CAP_RATE_DECIMAL
 from rwa_calc.engine.aggregator._schemas import FLOOR_ELIGIBLE_APPROACHES, FLOOR_IMPACT_SCHEMA
 from rwa_calc.engine.aggregator._utils import col_or_default, empty_frame, resolve_rwa_col
 
-# GCRA cap: 1.25% of S-TREA per Art. 92 para 2A definition
-GCRA_CAP_RATE = 0.0125
+# GCRA cap: 1.25% of S-TREA per Art. 92 para 2A definition.
+# Stored as Decimal in data/tables/output_floor.py; the aggregator works in
+# float space, so it's converted once at import time.
+GCRA_CAP_RATE: float = float(_GCRA_CAP_RATE_DECIMAL)
 
 
 def compute_of_adj(

--- a/src/rwa_calc/engine/comparison.py
+++ b/src/rwa_calc/engine/comparison.py
@@ -55,6 +55,7 @@ from rwa_calc.contracts.bundles import (
     ComparisonBundle,
     TransitionalScheduleBundle,
 )
+from rwa_calc.data.tables.crr_firb_lgd import CRR_K_SCALING_FACTOR as _CRR_K_SCALING_FACTOR_DECIMAL
 from rwa_calc.domain.enums import PermissionMode
 from rwa_calc.engine.pipeline import PipelineOrchestrator
 
@@ -155,8 +156,10 @@ class DualFrameworkRunner:
 # from ApproachType enum, plus "FIRB" from aggregator fallback
 _IRB_APPROACHES = ["foundation_irb", "advanced_irb", "FIRB"]
 
-# CRR scaling factor for IRB RWA (CRR Art. 153(1))
-_CRR_SCALING_FACTOR = 1.06
+# CRR scaling factor for IRB RWA (CRR Art. 153(1)). The Decimal value is the
+# canonical regulatory constant in data/tables/; comparison math runs in float
+# space, so it's converted once at import time.
+_CRR_SCALING_FACTOR: float = float(_CRR_K_SCALING_FACTOR_DECIMAL)
 
 # Attribution driver labels for the portfolio waterfall
 _DRIVER_SCALING = "Scaling factor removal (1.06x)"

--- a/src/rwa_calc/engine/crm/simple_method.py
+++ b/src/rwa_calc/engine/crm/simple_method.py
@@ -20,21 +20,17 @@ References:
 
 from __future__ import annotations
 
-from decimal import Decimal
 from typing import TYPE_CHECKING
 
 import polars as pl
 
+from rwa_calc.data.tables.crr_simple_method import (
+    SOVEREIGN_BOND_DISCOUNT,
+)
 from rwa_calc.domain.enums import ApproachType
 
 if TYPE_CHECKING:
     from rwa_calc.contracts.config import CalculationConfig
-
-# Art. 222(1): minimum 20% RW floor for secured portion (general case)
-FCSM_RW_FLOOR = Decimal("0.20")
-
-# Art. 222(4)(b): 20% market value discount for 0%-RW sovereign bonds
-SOVEREIGN_BOND_DISCOUNT = Decimal("0.20")
 
 
 def _derive_collateral_rw_expr(is_basel_3_1: bool = False) -> pl.Expr:

--- a/tests/unit/crm/test_simple_method.py
+++ b/tests/unit/crm/test_simple_method.py
@@ -33,12 +33,14 @@ import polars as pl
 import pytest
 
 from rwa_calc.contracts.config import CalculationConfig
+from rwa_calc.data.tables.crr_simple_method import (
+    FCSM_RW_FLOOR,
+    SOVEREIGN_BOND_DISCOUNT,
+)
 from rwa_calc.domain.enums import (
     CRMCollateralMethod,
 )
 from rwa_calc.engine.crm.simple_method import (
-    FCSM_RW_FLOOR,
-    SOVEREIGN_BOND_DISCOUNT,
     _add_default_fcsm_columns,
     _derive_collateral_rw_expr,
     compute_fcsm_columns,


### PR DESCRIPTION
## Summary

Final step (3 of 3) of the architectural refactor. Moves the remaining engine-embedded regulatory scalars into `data/tables/` so every regulatory constant has a discoverable home, matching the pattern established in Steps 1 (#246) and 2 (#247).

- **New**: `data/tables/crr_simple_method.py` owns `FCSM_RW_FLOOR` (CRR Art. 222(1), 20% RW floor) and `SOVEREIGN_BOND_DISCOUNT` (Art. 222(4)(b), 20% market-value discount). Both retained unchanged under PRA PS1/26 for SA exposures — no B31 variants.
- **New**: `data/tables/output_floor.py` owns `GCRA_CAP_RATE` (PRA PS1/26 Art. 92 para 2A, 1.25% of S-TREA). Basel 3.1 only.
- **Extended**: `data/tables/crr_firb_lgd.py` gains `CRR_K_SCALING_FACTOR` (CRR Art. 153(1), 1.06) alongside the existing `CRR_PD_FLOOR` / `CRR_MATURITY_FLOOR` / `CRR_MATURITY_CAP` IRB parameters.

## Engine updates

- `engine/crm/simple_method.py` imports `SOVEREIGN_BOND_DISCOUNT` from the new module; `FCSM_RW_FLOOR` has no in-file references (only in tests), so the test now sources it directly from `data/tables/`.
- `engine/aggregator/_floor.py` imports `GCRA_CAP_RATE` (Decimal) under an alias and exposes a module-level `float` for the aggregator's float-space arithmetic. The engine symbol is retained so `tests/unit/test_of_adj.py` keeps importing from the engine.
- `engine/comparison.py` imports `CRR_K_SCALING_FACTOR` (Decimal) and converts to `_CRR_SCALING_FACTOR: float` for the comparison-math expressions.

## Deviations from the original plan

1. **`_CRR_SCALING_FACTOR` was relocated, not replaced with `config.scaling_factor`.** On reading the code, this substitution would be incorrect: `_compute_exposure_attribution(comparison: ComparisonBundle)` has no `CalculationConfig` in scope, and the `1.06` here specifically represents the CRR-side value used in CRR-vs-B31 *delta attribution* math. The active config elsewhere can be either framework, so `config.scaling_factor` would break the math. Relocating to `data/tables/` achieves the architectural goal without changing behaviour.
2. **`_DEFAULT_HOLDING_RW = 1.00` in `engine/equity/calculator.py:77` was kept where it is.** Verified usage at line 458 — it's a Polars `.fill_null()` fallback for an unmatched CIU look-through join, not a regulatory parameter. The regulatory equity weights come from the joined SA equity RW tables.

## Test plan

- [x] `uv run pytest tests/` — 5246 passed, 11 deselected (158s)
- [x] `uv run ruff check src/rwa_calc/ tests/` clean
- [x] No regulatory value changes — pure relocation; acceptance tests against golden files in `tests/expected_outputs/{crr,basel31}/` confirm no numeric drift
- [x] Decimal values in `data/tables/` are converted to `float` at a single module-level import site in the engine, preserving existing arithmetic precision

## Follow-up (not in this PR)

Whether to consolidate `VALID_COLLATERAL_TYPES` (narrow validator set) with `COLLATERAL_TYPE_CATEGORY` (broader engine-acceptance map) in `data/schemas.py` — flagged in the Step 2 PR as a deliberate non-change, worth a separate discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)