### PR TITLE
refactor(crm): rename engine/crm/constants.py to expressions.py

### DIFF
--- a/src/rwa_calc/data/schemas.py
+++ b/src/rwa_calc/data/schemas.py
@@ -511,7 +511,7 @@ VALID_COLLATERAL_TYPES = {
 # "residential_property" for residential real estate, "govt_bond" / "gilt" for
 # sovereign debt). VALID_COLLATERAL_TYPES is the canonical input set used by
 # validate_bundle_values; these engine lists drive Polars expression builders
-# in engine/crm/constants.py for category-based dispatch.
+# in engine/crm/expressions.py for category-based dispatch.
 #
 # References: CRR Art. 161 / 230, CRE22.40-78
 

--- a/src/rwa_calc/engine/crm/collateral.py
+++ b/src/rwa_calc/engine/crm/collateral.py
@@ -30,7 +30,7 @@ import polars as pl
 from rwa_calc.data.schemas import NON_ELIGIBLE_RE_TYPES
 from rwa_calc.data.tables.crm_supervisory import MIN_COLLATERALISATION_THRESHOLDS
 from rwa_calc.domain.enums import AIRBCollateralMethod, ApproachType
-from rwa_calc.engine.crm.constants import (
+from rwa_calc.engine.crm.expressions import (
     CRM_ALLOC_COLUMNS,
     WATERFALL_ORDER,
     beneficiary_level_expr,

--- a/src/rwa_calc/engine/crm/expressions.py
+++ b/src/rwa_calc/engine/crm/expressions.py
@@ -1,16 +1,23 @@
 """
 Polars expression builders for CRM collateral and beneficiary classification.
 
-Input-domain collateral type-set lists (FINANCIAL, RECEIVABLE, REAL_ESTATE,
-OTHER_PHYSICAL, COVERED_BOND, LIFE_INSURANCE) and the canonical
-collateral_type -> category mapping live in data/schemas.py alongside
-VALID_COLLATERAL_TYPES. Regulatory values (supervisory LGD,
-overcollateralisation ratios, minimum thresholds, zero-haircut sovereign
-CQS cap) live in data/tables/crm_supervisory.py. Both are imported here
-for use by the expression builders below.
+Holds the Polars expression builders used across the CRM pipeline to
+classify collateral into regulatory categories, derive supervisory LGD,
+overcollateralisation ratios, and minimum collateralisation thresholds
+per row, plus the waterfall ordering (WATERFALL_ORDER) and allocation
+column naming (CRM_ALLOC_COLUMNS) that drive the Art. 231 sequential
+fill in collateral.py.
+
+Sibling modules providing the data this module consumes:
+- data/schemas.py: input-domain collateral type-set lists and the
+  canonical collateral_type -> category mapping
+- data/tables/crm_supervisory.py: regulatory values (supervisory LGD,
+  overcollateralisation ratios, minimum thresholds, zero-haircut
+  sovereign CQS cap)
 
 References:
-    CRR Art. 161, 224, 230: Supervisory LGD, haircuts, overcollateralisation
+    CRR Art. 161, 224, 230, 231: Supervisory LGD, haircuts,
+        overcollateralisation, waterfall
     CRE22.52-53, CRE32.9-12: Basel 3.1 equivalents
 """
 

--- a/src/rwa_calc/engine/crm/processor.py
+++ b/src/rwa_calc/engine/crm/processor.py
@@ -934,7 +934,7 @@ class CRMProcessor:
         References:
             CRR Art. 230-231, PRA PS1/26 Art. 230-231
         """
-        from rwa_calc.engine.crm.constants import CRM_ALLOC_COLUMNS
+        from rwa_calc.engine.crm.expressions import CRM_ALLOC_COLUMNS
 
         alloc_cols = list(CRM_ALLOC_COLUMNS.values())
         return exposures.select(

--- a/tests/unit/crm/test_collateral_allocation_bundle.py
+++ b/tests/unit/crm/test_collateral_allocation_bundle.py
@@ -26,7 +26,7 @@ from rwa_calc.contracts.bundles import (
 )
 from rwa_calc.contracts.config import CalculationConfig
 from rwa_calc.domain.enums import ApproachType, PermissionMode
-from rwa_calc.engine.crm.constants import CRM_ALLOC_COLUMNS
+from rwa_calc.engine.crm.expressions import CRM_ALLOC_COLUMNS
 from rwa_calc.engine.crm.processor import CRMProcessor
 
 # =============================================================================

--- a/tests/unit/crm/test_life_insurance.py
+++ b/tests/unit/crm/test_life_insurance.py
@@ -20,7 +20,7 @@ from rwa_calc.data.tables.crm_supervisory import (
     BASEL31_SUPERVISORY_LGD,
     CRR_SUPERVISORY_LGD,
 )
-from rwa_calc.engine.crm.constants import (
+from rwa_calc.engine.crm.expressions import (
     WATERFALL_ORDER,
     collateral_category_expr,
     collateral_lgd_expr,

--- a/tests/unit/test_lgd_floor_blended.py
+++ b/tests/unit/test_lgd_floor_blended.py
@@ -355,7 +355,7 @@ class TestCRMAllocColumnsPreserved:
 
     def test_allocation_column_names(self):
         """CRM_ALLOC_COLUMNS mapping covers all waterfall types."""
-        from rwa_calc.engine.crm.constants import CRM_ALLOC_COLUMNS, WATERFALL_ORDER
+        from rwa_calc.engine.crm.expressions import CRM_ALLOC_COLUMNS, WATERFALL_ORDER
 
         suffixes = {suffix for _, _, suffix in WATERFALL_ORDER}
         assert set(CRM_ALLOC_COLUMNS.keys()) == suffixes


### PR DESCRIPTION
## Summary

After the three-step refactor (#246, #247, #248), `engine/crm/constants.py` no longer holds any regulatory constants or input-domain type sets — those moved to `data/tables/` and `data/schemas.py` respectively. The file now contains only Polars expression builders + two small Art. 231 waterfall data tables, so the name `constants.py` is misleading.

This PR renames the module to `expressions.py` to match the dominant content. The small waterfall data tables (`WATERFALL_ORDER`, `CRM_ALLOC_COLUMNS`) stay co-located because they're the config the expression builders implement — classification expressions and waterfall ordering are one concern.

Closes out the architectural refactor started with PR #246.

## Mechanics

- `git mv src/rwa_calc/engine/crm/constants.py src/rwa_calc/engine/crm/expressions.py` (history follows).
- Module docstring rewritten to describe expression builders + Art. 231 waterfall mechanics, with cross-refs to the sibling data modules it consumes (`data/schemas.py`, `data/tables/crm_supervisory.py`).
- Five import sites updated:
  - `engine/crm/collateral.py:33` (imports 9 symbols)
  - `engine/crm/processor.py:937` (deferred import of `CRM_ALLOC_COLUMNS`)
  - `tests/unit/test_lgd_floor_blended.py:358` (deferred import)
  - `tests/unit/crm/test_collateral_allocation_bundle.py:29`
  - `tests/unit/crm/test_life_insurance.py:23-29` (imports 5 symbols)
- Stale comment in `data/schemas.py:514` that still referenced the old filename is also updated.

## What's not changed

- `IMPLEMENTATION_PLAN.md:280` still contains a historical reference to `engine/crm/constants.py`. Left intact because that document is a point-in-time implementation log, not live documentation.
- No symbol renames, no behaviour changes — this is a pure rename + re-import.

## Test plan

- [x] `uv run pytest tests/` — 5246 passed, 11 deselected (168s)
- [x] `uv run ruff check src/rwa_calc/ tests/` clean
- [x] `uv run python -c \"from rwa_calc.engine.crm import expressions; print('OK')\"` returns `OK`
- [x] No regulatory or calculation changes — pure rename, acceptance tests against golden files confirm no numeric drift

## Architectural refactor — final state

With this PR, `engine/crm/` is now layered by responsibility:
- `expressions.py` — Polars expression builders + Art. 231 waterfall config
- Topic modules (`collateral.py`, `haircuts.py`, `guarantees.py`, `provisions.py`, `processor.py`, `life_insurance.py`, `simple_method.py`) — domain logic
- Nothing in `engine/crm/` now defines its own regulatory values or accepted-input strings. Regulatory data flows from `data/tables/`; input-domain lists flow from `data/schemas.py`.
