### PR TITLE
chore(arch): enforce data/engine separation in arch_check + CI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,6 +20,7 @@
 - [ ] Unit tests pass
 - [ ] Calculation outputs verified against manual/Excel check
 - [ ] Edge cases considered (e.g. missing data, boundary values)
+- [ ] Any new regulatory value lives in `src/rwa_calc/data/tables/`; any new input-domain validation enum lives in `src/rwa_calc/data/schemas.py` (not in `engine/**`) — `uv run python scripts/arch_check.py` passes
 
 ## Assumptions & Interpretations
 <!-- Document any regulatory interpretation decisions made - these are valuable for audit trail -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Ruff format check
         run: uv run ruff format --check src/ tests/
 
+      - name: Architectural invariants
+        run: uv run python scripts/arch_check.py
+
   typecheck:
     name: Type Check
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ Each stage receives an immutable bundle, returns a new immutable bundle. Never m
 - **Frozen dataclass bundles** (`contracts/bundles.py`): All inter-stage data transfer uses `@dataclass(frozen=True)`. Never use plain dicts for stage outputs.
 - **Polars custom namespaces**: Domain logic is exposed via registered namespace extensions (e.g., `df.rwa_sa.calculate()`). Place namespace code in `namespace.py` within each engine subpackage.
 - **Factory methods on config**: Use `CalculationConfig.crr()` / `.basel_3_1()` for self-documenting configuration. Don't construct configs with raw kwargs.
+- **Data/engine separation**: Regulatory values (risk weights, LGDs, CCFs, floors, scaling factors) live in `src/rwa_calc/data/tables/*.py`. Input-domain / validation constants (eligible type-strings, category maps) live in `src/rwa_calc/data/schemas.py`. `engine/**` imports these — it must not declare its own regulatory scalars or string-enum collections at module scope. Enforced by `scripts/arch_check.py` (checks 5 & 6) and `tests/contracts/test_data_layer_boundary.py`; new exceptions must be justified in the allowlist at the top of `arch_check.py`.
 - **Error accumulation**: Errors are collected in `list[CalculationError]` and propagated through bundles — never raise exceptions for data quality issues. Reserve exceptions for programming errors only.
 
 ## Reference Documentation

--- a/scripts/arch_check.py
+++ b/scripts/arch_check.py
@@ -6,6 +6,13 @@ Checks machine-verifiable invariants from CLAUDE.md:
 2. No ABC imports (Protocol only)
 3. No raw .collect().lazy() outside materialise.py (use materialise_barrier)
 4. No engine= passed to collect/collect_all (engine choice is config-driven)
+5. No regulatory scalar literals declared in engine/** (must live in data/tables/)
+6. No input-domain string-enum collections declared in engine/** (must live in data/schemas.py)
+
+Checks 5 and 6 enforce the data/engine separation established by PRs
+#244, #246, #247, #248, #249. Rare intentional exceptions are listed in
+REGULATORY_SCALAR_ALLOWLIST / VALIDATION_ENUM_ALLOWLIST below; adding a new
+entry there should be a deliberate, reviewed decision.
 
 Usage:
     python scripts/arch_check.py [path]  # defaults to src/rwa_calc/
@@ -17,12 +24,52 @@ Exit codes:
 
 from __future__ import annotations
 
+import ast
 import re
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 
 # The abstraction layer itself is allowed to use raw collect patterns
 COLLECT_ALLOWLIST = {"materialise.py"}
+
+# Existing module-level regulatory-like scalars in engine/** that were
+# deliberately kept in place (see PR notes next to each). New entries require
+# explicit regulatory justification — regulatory values otherwise belong in
+# src/rwa_calc/data/tables/.
+REGULATORY_SCALAR_ALLOWLIST: dict[str, set[str]] = {
+    # float alias of imported Decimal (PR #248)
+    "engine/aggregator/_floor.py": {"GCRA_CAP_RATE"},
+    # CRR Art. 62(d) 0.6% T2 credit cap — candidate for relocation to data/tables/
+    "engine/aggregator/_schemas.py": {"T2_CREDIT_CAP_RATE"},
+    # float alias of imported CRR_K_SCALING_FACTOR Decimal (PR #248)
+    "engine/comparison.py": {"_CRR_SCALING_FACTOR"},
+    "engine/equity/calculator.py": {
+        "_CIU_THIRD_PARTY_MULTIPLIER",  # Art. 132b(2) 20% uplift multiplier
+        "_RW_TO_PERCENT",  # audit formatting constant (not regulatory)
+    },
+    # Inverse standard-normal at 0.999 used by IRB formulas (mathematical, not reg)
+    "engine/irb/formulas.py": {"G_999"},
+    # CRR Art. 153(5) short-maturity threshold — candidate for relocation
+    "engine/slotting/namespace.py": {"_SHORT_MATURITY_THRESHOLD_YEARS"},
+}
+
+# Existing engine-side string collections that are internal approach/column/driver
+# identifiers, not input-domain validation enums. Adding a new entry should be a
+# deliberate, reviewed decision — input-domain validation enums belong in
+# src/rwa_calc/data/schemas.py.
+VALIDATION_ENUM_ALLOWLIST: dict[str, set[str]] = {
+    # ApproachType enum values + aggregator fallback labels (internal routing)
+    "engine/aggregator/_schemas.py": {"IRB_APPROACHES"},
+    "engine/comparison.py": {
+        "_COMPARISON_COLUMNS",  # output column names
+        "_OPTIONAL_COLUMNS",  # output column names
+        "_IRB_APPROACHES",  # approach IDs
+        "_ATTRIBUTION_DRIVERS",  # internal driver labels
+    },
+    # Art. 231 allocation column mapping (PR #249 — retained as engine config)
+    "engine/crm/expressions.py": {"CRM_ALLOC_COLUMNS"},
+}
 
 
 def _is_excluded(py_file: Path) -> bool:
@@ -115,6 +162,160 @@ def check_no_engine_arg(path: Path) -> list[str]:
     return violations
 
 
+# ---------------------------------------------------------------------------
+# Data/engine separation checks (PRs #244, #246, #247, #248, #249)
+# ---------------------------------------------------------------------------
+
+
+def _is_upper_const_name(name: str) -> bool:
+    """True when name is UPPER_SNAKE_CASE (leading underscores allowed)."""
+    stripped = name.lstrip("_")
+    if not stripped:
+        return False
+    if not any(c.isalpha() for c in stripped):
+        return False
+    return stripped == stripped.upper()
+
+
+def _iter_module_assignments(tree: ast.Module) -> Iterator[tuple[int, str, ast.AST]]:
+    """Yield (lineno, target_name, value_node) for top-level `NAME = value` assigns."""
+    for stmt in tree.body:
+        if isinstance(stmt, ast.Assign) and stmt.value is not None:
+            for tgt in stmt.targets:
+                if isinstance(tgt, ast.Name):
+                    yield stmt.lineno, tgt.id, stmt.value
+        elif (
+            isinstance(stmt, ast.AnnAssign)
+            and stmt.value is not None
+            and isinstance(stmt.target, ast.Name)
+        ):
+            yield stmt.lineno, stmt.target.id, stmt.value
+
+
+def _rhs_is_regulatory_scalar(node: ast.AST) -> bool:
+    """True when the RHS looks like a hardcoded regulatory scalar literal.
+
+    Covers:
+    - bare numeric literals (int/float) other than the trivial 0, 1, -1
+    - Decimal("...") / Decimal(...) calls
+    - float(...) / int(...) calls with a single argument (typical alias pattern)
+    """
+    if isinstance(node, ast.Constant):
+        if isinstance(node.value, bool):
+            return False
+        if isinstance(node.value, (int, float)):
+            return node.value not in (0, 1, -1)
+        return False
+    if isinstance(node, ast.UnaryOp) and isinstance(node.operand, ast.Constant):
+        val = node.operand.value
+        if isinstance(val, bool):
+            return False
+        if isinstance(val, (int, float)):
+            return val not in (0, 1)
+        return False
+    if isinstance(node, ast.Call):
+        fn = node.func
+        fn_name: str | None = None
+        if isinstance(fn, ast.Name):
+            fn_name = fn.id
+        elif isinstance(fn, ast.Attribute):
+            fn_name = fn.attr
+        if fn_name == "Decimal":
+            return True
+        if fn_name in {"float", "int"} and len(node.args) == 1 and not node.keywords:
+            return True
+    return False
+
+
+def _rhs_is_str_collection(node: ast.AST) -> bool:
+    """True when the RHS is a non-trivial all-string-literal collection.
+
+    Matches:
+    - list/tuple/set literal with >= 2 string-literal elements
+    - dict with >= 2 string-literal keys AND all string-literal values
+    - frozenset(...)/set(...)/tuple(...)/list(...) wrapping such a collection
+    """
+    if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+        elts = node.elts
+        if len(elts) < 2:
+            return False
+        return all(isinstance(e, ast.Constant) and isinstance(e.value, str) for e in elts)
+    if isinstance(node, ast.Dict):
+        if len(node.keys) < 2:
+            return False
+        keys_ok = all(
+            k is not None and isinstance(k, ast.Constant) and isinstance(k.value, str)
+            for k in node.keys
+        )
+        vals_ok = all(isinstance(v, ast.Constant) and isinstance(v.value, str) for v in node.values)
+        return keys_ok and vals_ok
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id in {"frozenset", "set", "tuple", "list"}
+        and len(node.args) == 1
+    ):
+        return _rhs_is_str_collection(node.args[0])
+    return False
+
+
+def _iter_engine_files(path: Path) -> Iterator[Path]:
+    """Yield every .py file under `<path>/engine/`, skipping __init__.py."""
+    engine_root = path / "engine"
+    if not engine_root.exists():
+        return
+    for py_file in sorted(engine_root.rglob("*.py")):
+        if py_file.name == "__init__.py":
+            continue
+        yield py_file
+
+
+def check_no_regulatory_scalars_in_engine(path: Path) -> list[str]:
+    """Module-level regulatory scalar literals belong in data/tables/, not engine/**."""
+    violations: list[str] = []
+    for py_file in _iter_engine_files(path):
+        rel = py_file.relative_to(path).as_posix()
+        allowed = REGULATORY_SCALAR_ALLOWLIST.get(rel, set())
+        try:
+            tree = ast.parse(py_file.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, SyntaxError):
+            continue
+        for lineno, name, value in _iter_module_assignments(tree):
+            if not _is_upper_const_name(name):
+                continue
+            if name in allowed:
+                continue
+            if _rhs_is_regulatory_scalar(value):
+                violations.append(
+                    f"  {py_file}:{lineno}: {name} -- regulatory scalar in engine/ "
+                    "(move to src/rwa_calc/data/tables/ or allowlist in arch_check.py)"
+                )
+    return violations
+
+
+def check_no_validation_enums_in_engine(path: Path) -> list[str]:
+    """Module-level string-enum collections belong in data/schemas.py, not engine/**."""
+    violations: list[str] = []
+    for py_file in _iter_engine_files(path):
+        rel = py_file.relative_to(path).as_posix()
+        allowed = VALIDATION_ENUM_ALLOWLIST.get(rel, set())
+        try:
+            tree = ast.parse(py_file.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, SyntaxError):
+            continue
+        for lineno, name, value in _iter_module_assignments(tree):
+            if not _is_upper_const_name(name):
+                continue
+            if name in allowed:
+                continue
+            if _rhs_is_str_collection(value):
+                violations.append(
+                    f"  {py_file}:{lineno}: {name} -- string-literal collection in engine/ "
+                    "(move to src/rwa_calc/data/schemas.py or allowlist in arch_check.py)"
+                )
+    return violations
+
+
 def main() -> int:
     target = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("src/rwa_calc")
     if not target.exists():
@@ -126,6 +327,14 @@ def main() -> int:
         ("No ABC imports (use Protocol)", check_no_abc),
         ("No .collect().lazy() (use materialise_barrier)", check_no_collect_lazy),
         ("No engine= in collect (use materialise.py)", check_no_engine_arg),
+        (
+            "No regulatory scalars in engine/ (use data/tables/)",
+            check_no_regulatory_scalars_in_engine,
+        ),
+        (
+            "No validation string-enums in engine/ (use data/schemas.py)",
+            check_no_validation_enums_in_engine,
+        ),
     ]
 
     all_violations: list[tuple[str, list[str]]] = []

--- a/tests/contracts/test_data_layer_boundary.py
+++ b/tests/contracts/test_data_layer_boundary.py
@@ -1,0 +1,60 @@
+"""Contract tests for data/engine separation.
+
+Enforces the architectural invariant established by PRs #244, #246, #247,
+#248, #249:
+
+- Regulatory values (risk weights, LGDs, CCFs, floors, scaling factors) live
+  in ``src/rwa_calc/data/tables/``.
+- Input-domain validation enums (eligible type strings, category maps) live
+  in ``src/rwa_calc/data/schemas.py``.
+- ``engine/**`` imports these values; it must not declare its own regulatory
+  scalar literals or string-enum collections at module scope.
+
+These tests re-use the check functions from ``scripts/arch_check.py`` so the
+rules and their allowlists live in exactly one place. A failure here means a
+new module-level constant was introduced in ``engine/**`` that needs to move
+to ``data/tables/`` or ``data/schemas.py`` (or — if genuinely engine-internal
+— be added to the relevant allowlist in ``scripts/arch_check.py``).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = REPO_ROOT / "src" / "rwa_calc"
+
+
+def _load_arch_check():
+    """Load scripts/arch_check.py as a module without polluting sys.path."""
+    script_path = REPO_ROOT / "scripts" / "arch_check.py"
+    spec = importlib.util.spec_from_file_location("_arch_check", script_path)
+    assert spec is not None and spec.loader is not None, f"cannot load {script_path}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_arch_check"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_no_regulatory_scalars_in_engine() -> None:
+    """Regulatory scalar literals must live in src/rwa_calc/data/tables/."""
+    arch_check = _load_arch_check()
+    violations = arch_check.check_no_regulatory_scalars_in_engine(SRC_ROOT)
+    assert not violations, (
+        "Regulatory scalar literal declared in engine/** — move to "
+        "src/rwa_calc/data/tables/ (or add to REGULATORY_SCALAR_ALLOWLIST in "
+        "scripts/arch_check.py with justification):\n" + "\n".join(violations)
+    )
+
+
+def test_no_validation_enums_in_engine() -> None:
+    """Input-domain string-enum collections must live in src/rwa_calc/data/schemas.py."""
+    arch_check = _load_arch_check()
+    violations = arch_check.check_no_validation_enums_in_engine(SRC_ROOT)
+    assert not violations, (
+        "String-literal collection declared in engine/** — move to "
+        "src/rwa_calc/data/schemas.py (or add to VALIDATION_ENUM_ALLOWLIST in "
+        "scripts/arch_check.py with justification):\n" + "\n".join(violations)
+    )


### PR DESCRIPTION
Locks in the architectural rule established by PRs #244, #246, #247, #248,
#249: regulatory values live in src/rwa_calc/data/tables/, input-domain
validation enums live in src/rwa_calc/data/schemas.py, and engine/**
imports them — it must not declare its own module-level regulatory
scalars or string-enum collections.

- scripts/arch_check.py gains two AST-based checks scoped to engine/**:
  check_no_regulatory_scalars_in_engine (numeric literals, Decimal(...),
  float(...) aliases) and check_no_validation_enums_in_engine (lists,
  tuples, sets, dicts of string literals, plus frozenset/set/tuple/list
  call wrappers). Existing intentional exceptions (GCRA_CAP_RATE float
  alias, _CRR_SCALING_FACTOR, CIU multipliers, G_999, slotting threshold,
  Art. 231 waterfall config, internal approach/column enums) are listed in
  REGULATORY_SCALAR_ALLOWLIST / VALIDATION_ENUM_ALLOWLIST with PR refs, so
  any new addition is a deliberate, reviewed decision.
- .github/workflows/ci.yml wires arch_check into the lint job so all six
  invariants block PRs instead of relying on local invocation.
- tests/contracts/test_data_layer_boundary.py surfaces the same two rules
  during local pytest runs by loading and re-using the arch_check
  functions (single source of rule + allowlist).
- CLAUDE.md adds a Data/engine separation bullet under Key Design
  Patterns pointing at both enforcement mechanisms.
- .github/PULL_REQUEST_TEMPLATE.md adds a Testing checkbox for the rule.

Verification: arch_check passes clean on master; injecting a test
violation flags both rules with file:line and canonical-home pointer;
ruff + ty + non-benchmark pytest all green (5221 passed).

https://claude.ai/code/session_01DDfc67LJyx4yBoGX1EgWCb