### PR TITLE
refactor(tables): derive DataFrame values from authoritative dicts

### DIFF
--- a/docs/appendix/changelog.md
+++ b/docs/appendix/changelog.md
@@ -5,6 +5,11 @@ All notable changes to the RWA Calculator are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.192] — 2026-04-12
+
+### Changed
+- **Data tables**: Eliminated duplicated regulatory values in `data/tables/`. Previously most `_create_*_df` builders hardcoded numeric literals that were already defined in the module's constant dicts (`CENTRAL_GOVT_CENTRAL_BANK_RISK_WEIGHTS`, `CORPORATE_RISK_WEIGHTS`, `COLLATERAL_HAIRCUTS`, `BASEL31_FIRB_SUPERVISORY_LGD`, etc.), meaning a regulatory update required changes in 2+ places. Builders now derive their values by iterating the authoritative dict: new helpers `_build_cqs_rw_df` (crr), `_build_int_cqs_rw_df` (b31), `_build_haircut_df` (haircuts), and `_build_firb_lgd_df` / `_build_b31_firb_lgd_df` (firb_lgd) read values from the dicts via small row-spec tuples that define column ordering. `B31_FIRB_LGD_*` scalar aliases now derive from `BASEL31_FIRB_SUPERVISORY_LGD`. Matches the gold-standard pattern already used in `b31_equity_rw.py`. New test `tests/unit/test_tables_dict_dataframe_parity.py` (18 cases) locks in the invariant so regressions cannot reintroduce duplication. DataFrame schemas, column/row ordering, and public API are unchanged — no regulatory values changed.
+
 ## [0.1.191] — 2026-04-12
 
 ### Changed

--- a/src/rwa_calc/data/tables/b31_risk_weights.py
+++ b/src/rwa_calc/data/tables/b31_risk_weights.py
@@ -287,16 +287,21 @@ B31_COVERED_BOND_UNRATED_FROM_SCRA: dict[str, Decimal] = {
 }
 
 
-def _create_b31_covered_bond_df() -> pl.DataFrame:
-    """Create Basel 3.1 covered bond risk weight lookup DataFrame.
+def _build_int_cqs_rw_df(
+    weights: dict[int | None, Decimal],
+    exposure_class: str,
+    order: tuple[int | None, ...],
+) -> pl.DataFrame:
+    """Build a CQS risk-weight lookup DataFrame from an int-keyed dict.
 
-    PRA PS1/26 Art. 129(4) Table 7 — identical to CRR Table 6A.
+    Used for Basel 3.1 tables whose constant dicts are keyed by the raw
+    CQS integer (1..6, or None for unrated) rather than the CQS enum.
     """
     return pl.DataFrame(
         {
-            "cqs": [1, 2, 3, 4, 5, 6],
-            "risk_weight": [0.10, 0.20, 0.20, 0.50, 0.50, 1.00],
-            "exposure_class": ["COVERED_BOND"] * 6,
+            "cqs": list(order),
+            "risk_weight": [float(weights[k]) for k in order],
+            "exposure_class": [exposure_class] * len(order),
         }
     ).with_columns(
         [
@@ -306,19 +311,28 @@ def _create_b31_covered_bond_df() -> pl.DataFrame:
     )
 
 
+_B31_CQS_RATED_ORDER: tuple[int, ...] = (1, 2, 3, 4, 5, 6)
+_B31_CQS_ORDER_WITH_UNRATED: tuple[int | None, ...] = (1, 2, 3, 4, 5, 6, None)
+
+
+def _create_b31_covered_bond_df() -> pl.DataFrame:
+    """Create Basel 3.1 covered bond risk weight lookup DataFrame.
+
+    PRA PS1/26 Art. 129(4) Table 7 — identical to CRR Table 6A.
+    """
+    return _build_int_cqs_rw_df(
+        B31_COVERED_BOND_RISK_WEIGHTS,
+        "COVERED_BOND",
+        order=_B31_CQS_RATED_ORDER,
+    )
+
+
 def _create_b31_corporate_df() -> pl.DataFrame:
     """Create Basel 3.1 corporate risk weight lookup DataFrame."""
-    return pl.DataFrame(
-        {
-            "cqs": [1, 2, 3, 4, 5, 6, None],
-            "risk_weight": [0.20, 0.50, 0.75, 1.00, 1.50, 1.50, 1.00],
-            "exposure_class": ["CORPORATE"] * 7,
-        }
-    ).with_columns(
-        [
-            pl.col("cqs").cast(pl.Int8),
-            pl.col("risk_weight").cast(pl.Float64),
-        ]
+    return _build_int_cqs_rw_df(
+        B31_CORPORATE_RISK_WEIGHTS,
+        "CORPORATE",
+        order=_B31_CQS_ORDER_WITH_UNRATED,
     )
 
 

--- a/src/rwa_calc/data/tables/crr_risk_weights.py
+++ b/src/rwa_calc/data/tables/crr_risk_weights.py
@@ -27,6 +27,68 @@ import polars as pl
 from rwa_calc.domain.enums import CQS
 
 # =============================================================================
+# INTERNAL DATAFRAME-BUILD HELPERS
+#
+# Each `_create_*_df` builder below derives its numeric values from the
+# corresponding regulatory constant dict declared in this module. The helpers
+# guarantee there is exactly one source of truth for every regulatory scalar —
+# update the dict and the DataFrame tracks automatically.
+# =============================================================================
+
+_CQS_ORDER_WITH_UNRATED: tuple[CQS, ...] = (
+    CQS.CQS1,
+    CQS.CQS2,
+    CQS.CQS3,
+    CQS.CQS4,
+    CQS.CQS5,
+    CQS.CQS6,
+    CQS.UNRATED,
+)
+_CQS_ORDER_RATED_ONLY: tuple[CQS, ...] = _CQS_ORDER_WITH_UNRATED[:-1]
+
+
+def _cqs_to_int(c: CQS) -> int | None:
+    """Map a CQS enum member to its DataFrame `cqs` column value.
+
+    UNRATED maps to SQL NULL (``None``) so downstream joins can match
+    unrated rows via null-safe joins.
+    """
+    return None if c is CQS.UNRATED else int(c.value)
+
+
+def _build_cqs_rw_df(
+    weights: dict[CQS, Decimal],
+    exposure_class: str,
+    order: tuple[CQS, ...] = _CQS_ORDER_WITH_UNRATED,
+    extra_cols: dict[str, list[object]] | None = None,
+) -> pl.DataFrame:
+    """Build a CQS risk-weight lookup DataFrame from a CQS-keyed dict.
+
+    Args:
+        weights: CQS → risk weight (Decimal) mapping
+        exposure_class: Value for the `exposure_class` column
+        order: Iteration order controlling row order in the output DataFrame
+        extra_cols: Optional additional columns (same length as ``order``)
+
+    Returns:
+        DataFrame with columns [cqs (Int8), risk_weight (Float64), exposure_class, ...]
+    """
+    data: dict[str, list[object]] = {
+        "cqs": [_cqs_to_int(c) for c in order],
+        "risk_weight": [float(weights[c]) for c in order],
+        "exposure_class": [exposure_class] * len(order),
+    }
+    if extra_cols:
+        data.update(extra_cols)
+    return pl.DataFrame(data).with_columns(
+        [
+            pl.col("cqs").cast(pl.Int8),
+            pl.col("risk_weight").cast(pl.Float64),
+        ]
+    )
+
+
+# =============================================================================
 # CENTRAL GOVT / CENTRAL BANK RISK WEIGHTS (CRR Art. 114)
 # =============================================================================
 
@@ -43,17 +105,9 @@ CENTRAL_GOVT_CENTRAL_BANK_RISK_WEIGHTS: dict[CQS, Decimal] = {
 
 def _create_cgcb_df() -> pl.DataFrame:
     """Create central govt/central bank risk weight lookup DataFrame."""
-    return pl.DataFrame(
-        {
-            "cqs": [1, 2, 3, 4, 5, 6, None],
-            "risk_weight": [0.00, 0.20, 0.50, 1.00, 1.00, 1.50, 1.00],
-            "exposure_class": ["CENTRAL_GOVT_CENTRAL_BANK"] * 7,
-        }
-    ).with_columns(
-        [
-            pl.col("cqs").cast(pl.Int8),
-            pl.col("risk_weight").cast(pl.Float64),
-        ]
+    return _build_cqs_rw_df(
+        CENTRAL_GOVT_CENTRAL_BANK_RISK_WEIGHTS,
+        "CENTRAL_GOVT_CENTRAL_BANK",
     )
 
 
@@ -85,23 +139,12 @@ INSTITUTION_RISK_WEIGHTS_STANDARD: dict[CQS, Decimal] = {
 
 def _create_institution_df(use_uk_deviation: bool = True) -> pl.DataFrame:
     """Create institution risk weight lookup DataFrame."""
-    if use_uk_deviation:
-        weights = [0.20, 0.30, 0.50, 1.00, 1.00, 1.50, 0.40]
-    else:
-        weights = [0.20, 0.50, 0.50, 1.00, 1.00, 1.50, 1.00]
-
-    return pl.DataFrame(
-        {
-            "cqs": [1, 2, 3, 4, 5, 6, None],
-            "risk_weight": weights,
-            "exposure_class": ["INSTITUTION"] * 7,
-            "uk_deviation": [use_uk_deviation] * 7,
-        }
-    ).with_columns(
-        [
-            pl.col("cqs").cast(pl.Int8),
-            pl.col("risk_weight").cast(pl.Float64),
-        ]
+    weights = INSTITUTION_RISK_WEIGHTS_UK if use_uk_deviation else INSTITUTION_RISK_WEIGHTS_STANDARD
+    n = len(_CQS_ORDER_WITH_UNRATED)
+    return _build_cqs_rw_df(
+        weights,
+        "INSTITUTION",
+        extra_cols={"uk_deviation": [use_uk_deviation] * n},
     )
 
 
@@ -146,17 +189,10 @@ def _create_pse_df() -> pl.DataFrame:
     Rated PSEs join against this table via their own CQS.
     Unrated PSEs use sovereign-derived treatment handled in the SA calculator.
     """
-    return pl.DataFrame(
-        {
-            "cqs": [1, 2, 3, 4, 5, 6],
-            "risk_weight": [0.20, 0.50, 0.50, 1.00, 1.00, 1.50],
-            "exposure_class": ["PSE"] * 6,
-        }
-    ).with_columns(
-        [
-            pl.col("cqs").cast(pl.Int8),
-            pl.col("risk_weight").cast(pl.Float64),
-        ]
+    return _build_cqs_rw_df(
+        PSE_RISK_WEIGHTS_OWN_RATING,
+        "PSE",
+        order=_CQS_ORDER_RATED_ONLY,
     )
 
 
@@ -208,17 +244,10 @@ def _create_rgla_df() -> pl.DataFrame:
     Unrated RGLAs use sovereign-derived treatment handled in the SA calculator.
     UK devolved govts (0%) and UK local authorities (20%) are overrides in the calculator.
     """
-    return pl.DataFrame(
-        {
-            "cqs": [1, 2, 3, 4, 5, 6],
-            "risk_weight": [0.20, 0.50, 0.50, 1.00, 1.00, 1.50],
-            "exposure_class": ["RGLA"] * 6,
-        }
-    ).with_columns(
-        [
-            pl.col("cqs").cast(pl.Int8),
-            pl.col("risk_weight").cast(pl.Float64),
-        ]
+    return _build_cqs_rw_df(
+        RGLA_RISK_WEIGHTS_OWN_RATING,
+        "RGLA",
+        order=_CQS_ORDER_RATED_ONLY,
     )
 
 
@@ -253,18 +282,7 @@ def _create_mdb_df() -> pl.DataFrame:
     Rated non-named MDBs join against this table via their own CQS.
     Unrated non-named MDBs get 50% (Table 2B unrated row).
     """
-    return pl.DataFrame(
-        {
-            "cqs": [1, 2, 3, 4, 5, 6, None],
-            "risk_weight": [0.20, 0.30, 0.50, 1.00, 1.00, 1.50, 0.50],
-            "exposure_class": ["MDB"] * 7,
-        }
-    ).with_columns(
-        [
-            pl.col("cqs").cast(pl.Int8),
-            pl.col("risk_weight").cast(pl.Float64),
-        ]
-    )
+    return _build_cqs_rw_df(MDB_RISK_WEIGHTS_TABLE_2B, "MDB")
 
 
 # =============================================================================
@@ -293,18 +311,7 @@ CORPORATE_RISK_WEIGHTS: dict[CQS, Decimal] = {
 
 def _create_corporate_df() -> pl.DataFrame:
     """Create corporate risk weight lookup DataFrame."""
-    return pl.DataFrame(
-        {
-            "cqs": [1, 2, 3, 4, 5, 6, None],
-            "risk_weight": [0.20, 0.50, 1.00, 1.00, 1.50, 1.50, 1.00],
-            "exposure_class": ["CORPORATE"] * 7,
-        }
-    ).with_columns(
-        [
-            pl.col("cqs").cast(pl.Int8),
-            pl.col("risk_weight").cast(pl.Float64),
-        ]
-    )
+    return _build_cqs_rw_df(CORPORATE_RISK_WEIGHTS, "CORPORATE")
 
 
 # =============================================================================
@@ -355,7 +362,7 @@ def _create_retail_df() -> pl.DataFrame:
     return pl.DataFrame(
         {
             "cqs": [None],
-            "risk_weight": [0.75],
+            "risk_weight": [float(RETAIL_RISK_WEIGHT)],
             "exposure_class": ["RETAIL"],
         }
     ).with_columns(
@@ -399,9 +406,9 @@ def _create_residential_mortgage_df() -> pl.DataFrame:
     return pl.DataFrame(
         {
             "exposure_class": ["RESIDENTIAL_MORTGAGE"],
-            "ltv_threshold": [0.80],
-            "rw_low_ltv": [0.35],
-            "rw_high_ltv": [0.75],
+            "ltv_threshold": [float(RESIDENTIAL_MORTGAGE_PARAMS["ltv_threshold"])],
+            "rw_low_ltv": [float(RESIDENTIAL_MORTGAGE_PARAMS["rw_low_ltv"])],
+            "rw_high_ltv": [float(RESIDENTIAL_MORTGAGE_PARAMS["rw_high_ltv"])],
         }
     ).with_columns(
         [
@@ -443,9 +450,9 @@ def _create_commercial_re_df() -> pl.DataFrame:
     return pl.DataFrame(
         {
             "exposure_class": ["COMMERCIAL_RE"],
-            "ltv_threshold": [0.50],
-            "rw_low_ltv": [0.50],
-            "rw_standard": [1.00],
+            "ltv_threshold": [float(COMMERCIAL_RE_PARAMS["ltv_threshold"])],
+            "rw_low_ltv": [float(COMMERCIAL_RE_PARAMS["rw_low_ltv"])],
+            "rw_standard": [float(COMMERCIAL_RE_PARAMS["rw_standard"])],
             "income_cover_required": [True],
         }
     ).with_columns(
@@ -485,17 +492,10 @@ COVERED_BOND_UNRATED_DERIVATION: dict[Decimal, Decimal] = {
 
 def _create_covered_bond_df() -> pl.DataFrame:
     """Create covered bond risk weight lookup DataFrame (CRR Art. 129)."""
-    return pl.DataFrame(
-        {
-            "cqs": [1, 2, 3, 4, 5, 6],
-            "risk_weight": [0.10, 0.20, 0.20, 0.50, 0.50, 1.00],
-            "exposure_class": ["COVERED_BOND"] * 6,
-        }
-    ).with_columns(
-        [
-            pl.col("cqs").cast(pl.Int8),
-            pl.col("risk_weight").cast(pl.Float64),
-        ]
+    return _build_cqs_rw_df(
+        COVERED_BOND_RISK_WEIGHTS,
+        "COVERED_BOND",
+        order=_CQS_ORDER_RATED_ONLY,
     )
 
 

--- a/src/rwa_calc/data/tables/firb_lgd.py
+++ b/src/rwa_calc/data/tables/firb_lgd.py
@@ -120,137 +120,274 @@ CRR_MATURITY_CAP: Decimal = Decimal("5.0")  # 5 year maximum
 CRR_K_SCALING_FACTOR: Decimal = Decimal("1.06")
 
 
-def _create_firb_lgd_df() -> pl.DataFrame:
-    """Create F-IRB supervisory LGD lookup DataFrame.
+# =============================================================================
+# DATAFRAME ROW SPECIFICATIONS
+#
+# Each row-spec tuple names the dict keys from which the LGD, OC ratio, and
+# min threshold are looked up. Row ordering is part of the DataFrame contract
+# and must be preserved.
+# =============================================================================
 
-    Includes overcollateralisation ratios and minimum thresholds per CRR Art. 230 / CRE32.9-12.
-    """
-    rows = [
-        # Unsecured exposures
-        {
-            "collateral_type": "unsecured",
-            "seniority": "senior",
-            "lgd": 0.45,
-            "overcollateralisation_ratio": 1.0,
-            "min_threshold": 0.0,
-            "description": "Unsecured senior claims",
-        },
-        {
-            "collateral_type": "unsecured",
-            "seniority": "subordinated",
-            "lgd": 0.75,
-            "overcollateralisation_ratio": 1.0,
-            "min_threshold": 0.0,
-            "description": "Subordinated claims",
-        },
-        # Financial collateral (eligible)
-        {
-            "collateral_type": "financial_collateral",
-            "seniority": "senior",
-            "lgd": 0.00,
-            "overcollateralisation_ratio": 1.0,
-            "min_threshold": 0.0,
-            "description": "Eligible financial collateral (after haircuts)",
-        },
-        {
-            "collateral_type": "cash",
-            "seniority": "senior",
-            "lgd": 0.00,
-            "overcollateralisation_ratio": 1.0,
-            "min_threshold": 0.0,
-            "description": "Cash collateral",
-        },
-        # Receivables — Art. 230 Table 5
-        {
-            "collateral_type": "receivables",
-            "seniority": "senior",
-            "lgd": 0.35,
-            "overcollateralisation_ratio": 1.25,
-            "min_threshold": 0.0,
-            "description": "Secured by receivables (senior)",
-        },
-        {
-            "collateral_type": "receivables",
-            "seniority": "subordinated",
-            "lgd": 0.65,
-            "overcollateralisation_ratio": 1.25,
-            "min_threshold": 0.0,
-            "description": "Secured by receivables (subordinated)",
-        },
-        # Real estate — Art. 230 Table 5
-        {
-            "collateral_type": "residential_re",
-            "seniority": "senior",
-            "lgd": 0.35,
-            "overcollateralisation_ratio": 1.40,
-            "min_threshold": 0.30,
-            "description": "Secured by residential real estate (senior)",
-        },
-        {
-            "collateral_type": "residential_re",
-            "seniority": "subordinated",
-            "lgd": 0.65,
-            "overcollateralisation_ratio": 1.40,
-            "min_threshold": 0.30,
-            "description": "Secured by residential real estate (subordinated)",
-        },
-        {
-            "collateral_type": "commercial_re",
-            "seniority": "senior",
-            "lgd": 0.35,
-            "overcollateralisation_ratio": 1.40,
-            "min_threshold": 0.30,
-            "description": "Secured by commercial real estate (senior)",
-        },
-        {
-            "collateral_type": "commercial_re",
-            "seniority": "subordinated",
-            "lgd": 0.65,
-            "overcollateralisation_ratio": 1.40,
-            "min_threshold": 0.30,
-            "description": "Secured by commercial real estate (subordinated)",
-        },
-        {
-            "collateral_type": "real_estate",
-            "seniority": "senior",
-            "lgd": 0.35,
-            "overcollateralisation_ratio": 1.40,
-            "min_threshold": 0.30,
-            "description": "Secured by real estate (general, senior)",
-        },
-        {
-            "collateral_type": "real_estate",
-            "seniority": "subordinated",
-            "lgd": 0.65,
-            "overcollateralisation_ratio": 1.40,
-            "min_threshold": 0.30,
-            "description": "Secured by real estate (general, subordinated)",
-        },
-        # Other physical collateral — Art. 230 Table 5
-        {
-            "collateral_type": "other_physical",
-            "seniority": "senior",
-            "lgd": 0.40,
-            "overcollateralisation_ratio": 1.40,
-            "min_threshold": 0.30,
-            "description": "Other eligible physical collateral (senior)",
-        },
-        {
-            "collateral_type": "other_physical",
-            "seniority": "subordinated",
-            "lgd": 0.70,
-            "overcollateralisation_ratio": 1.40,
-            "min_threshold": 0.30,
-            "description": "Other eligible physical collateral (subordinated)",
-        },
-    ]
+# CRR spec tuple fields:
+#   (collateral_type, seniority, lgd_key, oc_key, description)
+_FirbRowSpec = tuple[str, str, str, str, str]
 
-    return pl.DataFrame(rows).with_columns(
+_CRR_FIRB_ROW_SPECS: tuple[_FirbRowSpec, ...] = (
+    # Unsecured exposures
+    ("unsecured", "senior", "unsecured_senior", "financial", "Unsecured senior claims"),
+    ("unsecured", "subordinated", "subordinated", "financial", "Subordinated claims"),
+    # Financial collateral (eligible)
+    (
+        "financial_collateral",
+        "senior",
+        "financial_collateral",
+        "financial",
+        "Eligible financial collateral (after haircuts)",
+    ),
+    ("cash", "senior", "financial_collateral", "financial", "Cash collateral"),
+    # Receivables — Art. 230 Table 5
+    (
+        "receivables",
+        "senior",
+        "receivables",
+        "receivables",
+        "Secured by receivables (senior)",
+    ),
+    (
+        "receivables",
+        "subordinated",
+        "receivables_subordinated",
+        "receivables",
+        "Secured by receivables (subordinated)",
+    ),
+    # Real estate — Art. 230 Table 5
+    (
+        "residential_re",
+        "senior",
+        "residential_re",
+        "real_estate",
+        "Secured by residential real estate (senior)",
+    ),
+    (
+        "residential_re",
+        "subordinated",
+        "residential_re_subordinated",
+        "real_estate",
+        "Secured by residential real estate (subordinated)",
+    ),
+    (
+        "commercial_re",
+        "senior",
+        "commercial_re",
+        "real_estate",
+        "Secured by commercial real estate (senior)",
+    ),
+    (
+        "commercial_re",
+        "subordinated",
+        "commercial_re_subordinated",
+        "real_estate",
+        "Secured by commercial real estate (subordinated)",
+    ),
+    (
+        "real_estate",
+        "senior",
+        "residential_re",
+        "real_estate",
+        "Secured by real estate (general, senior)",
+    ),
+    (
+        "real_estate",
+        "subordinated",
+        "residential_re_subordinated",
+        "real_estate",
+        "Secured by real estate (general, subordinated)",
+    ),
+    # Other physical collateral — Art. 230 Table 5
+    (
+        "other_physical",
+        "senior",
+        "other_physical",
+        "other_physical",
+        "Other eligible physical collateral (senior)",
+    ),
+    (
+        "other_physical",
+        "subordinated",
+        "other_physical_subordinated",
+        "other_physical",
+        "Other eligible physical collateral (subordinated)",
+    ),
+)
+
+
+# Basel 3.1 spec tuple fields:
+#   (collateral_type, seniority, is_fse, lgd_key, oc_key, description)
+_B31FirbRowSpec = tuple[str, str, bool, str, str, str]
+
+_B31_FIRB_ROW_SPECS: tuple[_B31FirbRowSpec, ...] = (
+    # Unsecured — non-FSE (Art. 161(1)(aa))
+    (
+        "unsecured",
+        "senior",
+        False,
+        "unsecured_senior",
+        "financial",
+        "Unsecured senior claims — non-FSE (Art. 161(1)(aa))",
+    ),
+    # Unsecured — FSE (Art. 161(1)(a))
+    (
+        "unsecured",
+        "senior",
+        True,
+        "unsecured_senior_fse",
+        "financial",
+        "Unsecured senior claims — FSE (Art. 161(1)(a))",
+    ),
+    # Subordinated — unchanged
+    (
+        "unsecured",
+        "subordinated",
+        False,
+        "subordinated",
+        "financial",
+        "Subordinated claims (Art. 161(1)(b))",
+    ),
+    # Covered bonds — Art. 161(1B)
+    (
+        "covered_bond",
+        "senior",
+        False,
+        "covered_bond",
+        "financial",
+        "Covered bonds (Art. 161(1B))",
+    ),
+    # Financial collateral — unchanged
+    (
+        "financial_collateral",
+        "senior",
+        False,
+        "financial_collateral",
+        "financial",
+        "Eligible financial collateral (after haircuts)",
+    ),
+    (
+        "cash",
+        "senior",
+        False,
+        "financial_collateral",
+        "financial",
+        "Cash collateral",
+    ),
+    # Receivables — reduced (CRE32.9)
+    (
+        "receivables",
+        "senior",
+        False,
+        "receivables",
+        "receivables",
+        "Secured by receivables (CRR: 35%)",
+    ),
+    # Real estate — reduced (CRE32.10-11)
+    (
+        "residential_re",
+        "senior",
+        False,
+        "residential_re",
+        "real_estate",
+        "Secured by residential RE (CRR: 35%)",
+    ),
+    (
+        "commercial_re",
+        "senior",
+        False,
+        "commercial_re",
+        "real_estate",
+        "Secured by commercial RE (CRR: 35%)",
+    ),
+    (
+        "real_estate",
+        "senior",
+        False,
+        "residential_re",
+        "real_estate",
+        "Secured by real estate — general (CRR: 35%)",
+    ),
+    # Other physical — reduced (CRE32.12)
+    (
+        "other_physical",
+        "senior",
+        False,
+        "other_physical",
+        "other_physical",
+        "Other eligible physical collateral (CRR: 40%)",
+    ),
+)
+
+
+def _build_firb_lgd_df(
+    row_specs: tuple[_FirbRowSpec, ...],
+    lgd_dict: dict[str, Decimal],
+    oc_ratios: dict[str, float],
+    min_thresholds: dict[str, float],
+) -> pl.DataFrame:
+    """Build a CRR F-IRB LGD DataFrame from row specs + authoritative dicts."""
+    return pl.DataFrame(
+        {
+            "collateral_type": [spec[0] for spec in row_specs],
+            "seniority": [spec[1] for spec in row_specs],
+            "lgd": [float(lgd_dict[spec[2]]) for spec in row_specs],
+            "overcollateralisation_ratio": [oc_ratios[spec[3]] for spec in row_specs],
+            "min_threshold": [min_thresholds[spec[3]] for spec in row_specs],
+            "description": [spec[4] for spec in row_specs],
+        }
+    ).with_columns(
         [
             pl.col("lgd").cast(pl.Float64),
             pl.col("overcollateralisation_ratio").cast(pl.Float64),
             pl.col("min_threshold").cast(pl.Float64),
         ]
+    )
+
+
+def _build_b31_firb_lgd_df(
+    row_specs: tuple[_B31FirbRowSpec, ...],
+    lgd_dict: dict[str, Decimal],
+    oc_ratios: dict[str, float],
+    min_thresholds: dict[str, float],
+) -> pl.DataFrame:
+    """Build a Basel 3.1 F-IRB LGD DataFrame from row specs + authoritative dicts."""
+    return pl.DataFrame(
+        {
+            "collateral_type": [spec[0] for spec in row_specs],
+            "seniority": [spec[1] for spec in row_specs],
+            "is_fse": [spec[2] for spec in row_specs],
+            "lgd": [float(lgd_dict[spec[3]]) for spec in row_specs],
+            "overcollateralisation_ratio": [oc_ratios[spec[4]] for spec in row_specs],
+            "min_threshold": [min_thresholds[spec[4]] for spec in row_specs],
+            "description": [spec[5] for spec in row_specs],
+        }
+    ).with_columns(
+        [
+            pl.col("lgd").cast(pl.Float64),
+            pl.col("overcollateralisation_ratio").cast(pl.Float64),
+            pl.col("min_threshold").cast(pl.Float64),
+        ]
+    )
+
+
+def _create_firb_lgd_df() -> pl.DataFrame:
+    """Create F-IRB supervisory LGD lookup DataFrame.
+
+    Values are sourced from ``FIRB_SUPERVISORY_LGD`` (LGD),
+    ``FIRB_OVERCOLLATERALISATION_RATIOS`` and
+    ``FIRB_MIN_COLLATERALISATION_THRESHOLDS`` (Art. 230 / CRE32.9-12).
+    """
+    return _build_firb_lgd_df(
+        _CRR_FIRB_ROW_SPECS,
+        FIRB_SUPERVISORY_LGD,
+        FIRB_OVERCOLLATERALISATION_RATIOS,
+        FIRB_MIN_COLLATERALISATION_THRESHOLDS,
     )
 
 
@@ -565,161 +702,54 @@ def apply_maturity_bounds(maturity: Decimal | float) -> Decimal:
 # - Financial collateral: 0% unchanged
 # - Subordinated: 75% unchanged
 
-B31_FIRB_LGD_UNSECURED_SENIOR: Decimal = Decimal("0.40")
+# The following scalars are thin aliases over ``BASEL31_FIRB_SUPERVISORY_LGD``.
+# The dict above is the single source of truth — update it to change a value.
+B31_FIRB_LGD_UNSECURED_SENIOR: Decimal = BASEL31_FIRB_SUPERVISORY_LGD["unsecured_senior"]
 """Non-FSE senior unsecured LGD under Basel 3.1 (Art. 161(1)(aa))."""
 
-B31_FIRB_LGD_UNSECURED_SENIOR_FSE: Decimal = Decimal("0.45")
+B31_FIRB_LGD_UNSECURED_SENIOR_FSE: Decimal = BASEL31_FIRB_SUPERVISORY_LGD["unsecured_senior_fse"]
 """FSE senior unsecured LGD under Basel 3.1 (Art. 161(1)(a))."""
 
-B31_FIRB_LGD_SUBORDINATED: Decimal = Decimal("0.75")
+B31_FIRB_LGD_SUBORDINATED: Decimal = BASEL31_FIRB_SUPERVISORY_LGD["subordinated"]
 """Subordinated LGD, unchanged from CRR (Art. 161(1)(b))."""
 
-B31_FIRB_LGD_COVERED_BOND: Decimal = Decimal("0.1125")
+B31_FIRB_LGD_COVERED_BOND: Decimal = BASEL31_FIRB_SUPERVISORY_LGD["covered_bond"]
 """Covered bond LGD (Art. 161(1B))."""
 
-B31_FIRB_LGD_FINANCIAL_COLLATERAL: Decimal = Decimal("0.00")
+B31_FIRB_LGD_FINANCIAL_COLLATERAL: Decimal = BASEL31_FIRB_SUPERVISORY_LGD["financial_collateral"]
 """Financial collateral LGD, unchanged from CRR."""
 
-B31_FIRB_LGD_RECEIVABLES: Decimal = Decimal("0.20")
+B31_FIRB_LGD_RECEIVABLES: Decimal = BASEL31_FIRB_SUPERVISORY_LGD["receivables"]
 """Receivables LGDS under Basel 3.1 (CRR: 35%, CRE32.9)."""
 
-B31_FIRB_LGD_RESIDENTIAL_RE: Decimal = Decimal("0.20")
+B31_FIRB_LGD_RESIDENTIAL_RE: Decimal = BASEL31_FIRB_SUPERVISORY_LGD["residential_re"]
 """Residential RE LGDS under Basel 3.1 (CRR: 35%, CRE32.10)."""
 
-B31_FIRB_LGD_COMMERCIAL_RE: Decimal = Decimal("0.20")
+B31_FIRB_LGD_COMMERCIAL_RE: Decimal = BASEL31_FIRB_SUPERVISORY_LGD["commercial_re"]
 """Commercial RE LGDS under Basel 3.1 (CRR: 35%, CRE32.11)."""
 
-B31_FIRB_LGD_OTHER_PHYSICAL: Decimal = Decimal("0.25")
+B31_FIRB_LGD_OTHER_PHYSICAL: Decimal = BASEL31_FIRB_SUPERVISORY_LGD["other_physical"]
 """Other physical collateral LGDS under Basel 3.1 (CRR: 40%, CRE32.12)."""
 
 
 def _create_b31_firb_lgd_df() -> pl.DataFrame:
     """Create Basel 3.1 F-IRB supervisory LGD lookup DataFrame.
 
-    Includes FSE/non-FSE distinction for unsecured exposures and all
-    B31-revised collateral LGDS values. Overcollateralisation ratios
-    are unchanged from CRR (Art. 230).
+    Values are sourced from ``BASEL31_FIRB_SUPERVISORY_LGD`` (LGD),
+    ``FIRB_OVERCOLLATERALISATION_RATIOS`` and
+    ``FIRB_MIN_COLLATERALISATION_THRESHOLDS`` (Art. 230 / CRE32.9-12,
+    unchanged from CRR). Includes FSE/non-FSE distinction for unsecured
+    exposures per Art. 161(1)(a) vs (aa).
 
     Returns:
         DataFrame with columns: collateral_type, seniority, is_fse, lgd,
         overcollateralisation_ratio, min_threshold, description
     """
-    rows = [
-        # Unsecured — non-FSE (Art. 161(1)(aa))
-        {
-            "collateral_type": "unsecured",
-            "seniority": "senior",
-            "is_fse": False,
-            "lgd": float(B31_FIRB_LGD_UNSECURED_SENIOR),
-            "overcollateralisation_ratio": 1.0,
-            "min_threshold": 0.0,
-            "description": "Unsecured senior claims — non-FSE (Art. 161(1)(aa))",
-        },
-        # Unsecured — FSE (Art. 161(1)(a))
-        {
-            "collateral_type": "unsecured",
-            "seniority": "senior",
-            "is_fse": True,
-            "lgd": float(B31_FIRB_LGD_UNSECURED_SENIOR_FSE),
-            "overcollateralisation_ratio": 1.0,
-            "min_threshold": 0.0,
-            "description": "Unsecured senior claims — FSE (Art. 161(1)(a))",
-        },
-        # Subordinated — unchanged
-        {
-            "collateral_type": "unsecured",
-            "seniority": "subordinated",
-            "is_fse": False,
-            "lgd": float(B31_FIRB_LGD_SUBORDINATED),
-            "overcollateralisation_ratio": 1.0,
-            "min_threshold": 0.0,
-            "description": "Subordinated claims (Art. 161(1)(b))",
-        },
-        # Covered bonds — Art. 161(1B)
-        {
-            "collateral_type": "covered_bond",
-            "seniority": "senior",
-            "is_fse": False,
-            "lgd": float(B31_FIRB_LGD_COVERED_BOND),
-            "overcollateralisation_ratio": 1.0,
-            "min_threshold": 0.0,
-            "description": "Covered bonds (Art. 161(1B))",
-        },
-        # Financial collateral — unchanged
-        {
-            "collateral_type": "financial_collateral",
-            "seniority": "senior",
-            "is_fse": False,
-            "lgd": float(B31_FIRB_LGD_FINANCIAL_COLLATERAL),
-            "overcollateralisation_ratio": FIRB_OVERCOLLATERALISATION_RATIOS["financial"],
-            "min_threshold": FIRB_MIN_COLLATERALISATION_THRESHOLDS["financial"],
-            "description": "Eligible financial collateral (after haircuts)",
-        },
-        {
-            "collateral_type": "cash",
-            "seniority": "senior",
-            "is_fse": False,
-            "lgd": float(B31_FIRB_LGD_FINANCIAL_COLLATERAL),
-            "overcollateralisation_ratio": FIRB_OVERCOLLATERALISATION_RATIOS["financial"],
-            "min_threshold": FIRB_MIN_COLLATERALISATION_THRESHOLDS["financial"],
-            "description": "Cash collateral",
-        },
-        # Receivables — reduced (CRE32.9)
-        {
-            "collateral_type": "receivables",
-            "seniority": "senior",
-            "is_fse": False,
-            "lgd": float(B31_FIRB_LGD_RECEIVABLES),
-            "overcollateralisation_ratio": FIRB_OVERCOLLATERALISATION_RATIOS["receivables"],
-            "min_threshold": FIRB_MIN_COLLATERALISATION_THRESHOLDS["receivables"],
-            "description": "Secured by receivables (CRR: 35%)",
-        },
-        # Real estate — reduced (CRE32.10-11)
-        {
-            "collateral_type": "residential_re",
-            "seniority": "senior",
-            "is_fse": False,
-            "lgd": float(B31_FIRB_LGD_RESIDENTIAL_RE),
-            "overcollateralisation_ratio": FIRB_OVERCOLLATERALISATION_RATIOS["real_estate"],
-            "min_threshold": FIRB_MIN_COLLATERALISATION_THRESHOLDS["real_estate"],
-            "description": "Secured by residential RE (CRR: 35%)",
-        },
-        {
-            "collateral_type": "commercial_re",
-            "seniority": "senior",
-            "is_fse": False,
-            "lgd": float(B31_FIRB_LGD_COMMERCIAL_RE),
-            "overcollateralisation_ratio": FIRB_OVERCOLLATERALISATION_RATIOS["real_estate"],
-            "min_threshold": FIRB_MIN_COLLATERALISATION_THRESHOLDS["real_estate"],
-            "description": "Secured by commercial RE (CRR: 35%)",
-        },
-        {
-            "collateral_type": "real_estate",
-            "seniority": "senior",
-            "is_fse": False,
-            "lgd": float(B31_FIRB_LGD_RESIDENTIAL_RE),
-            "overcollateralisation_ratio": FIRB_OVERCOLLATERALISATION_RATIOS["real_estate"],
-            "min_threshold": FIRB_MIN_COLLATERALISATION_THRESHOLDS["real_estate"],
-            "description": "Secured by real estate — general (CRR: 35%)",
-        },
-        # Other physical — reduced (CRE32.12)
-        {
-            "collateral_type": "other_physical",
-            "seniority": "senior",
-            "is_fse": False,
-            "lgd": float(B31_FIRB_LGD_OTHER_PHYSICAL),
-            "overcollateralisation_ratio": FIRB_OVERCOLLATERALISATION_RATIOS["other_physical"],
-            "min_threshold": FIRB_MIN_COLLATERALISATION_THRESHOLDS["other_physical"],
-            "description": "Other eligible physical collateral (CRR: 40%)",
-        },
-    ]
-
-    return pl.DataFrame(rows).with_columns(
-        [
-            pl.col("lgd").cast(pl.Float64),
-            pl.col("overcollateralisation_ratio").cast(pl.Float64),
-            pl.col("min_threshold").cast(pl.Float64),
-        ]
+    return _build_b31_firb_lgd_df(
+        _B31_FIRB_ROW_SPECS,
+        BASEL31_FIRB_SUPERVISORY_LGD,
+        FIRB_OVERCOLLATERALISATION_RATIOS,
+        FIRB_MIN_COLLATERALISATION_THRESHOLDS,
     )
 
 

--- a/src/rwa_calc/data/tables/haircuts.py
+++ b/src/rwa_calc/data/tables/haircuts.py
@@ -167,6 +167,133 @@ def scale_haircut_for_liquidation_period(
     return base_haircut_10day * math.sqrt(liquidation_period_days / 10.0)
 
 
+# =============================================================================
+# DATAFRAME ROW SPECIFICATIONS
+#
+# Each tuple is (collateral_type, cqs, maturity_band, dict_key, is_main_index).
+# The haircut value itself is NOT stored here — it is looked up from the
+# authoritative haircut dict via ``dict_key`` when the DataFrame is built.
+# Row ordering is part of the public DataFrame contract and must be preserved.
+# =============================================================================
+
+# Each spec tuple:
+#   (collateral_type, cqs, maturity_band, dict_key, is_main_index)
+_HaircutRowSpec = tuple[str, int | None, str | None, str, bool | None]
+
+_CRR_HAIRCUT_ROW_SPECS: tuple[_HaircutRowSpec, ...] = (
+    # Cash and gold
+    ("cash", None, None, "cash", None),
+    ("gold", None, None, "gold", None),
+    # Government bonds CQS 1
+    ("govt_bond", 1, "0_1y", "govt_bond_cqs1_0_1y", None),
+    ("govt_bond", 1, "1_5y", "govt_bond_cqs1_1_5y", None),
+    ("govt_bond", 1, "5y_plus", "govt_bond_cqs1_5y_plus", None),
+    # Government bonds CQS 2-3 (shared dict key)
+    ("govt_bond", 2, "0_1y", "govt_bond_cqs2_3_0_1y", None),
+    ("govt_bond", 2, "1_5y", "govt_bond_cqs2_3_1_5y", None),
+    ("govt_bond", 2, "5y_plus", "govt_bond_cqs2_3_5y_plus", None),
+    ("govt_bond", 3, "0_1y", "govt_bond_cqs2_3_0_1y", None),
+    ("govt_bond", 3, "1_5y", "govt_bond_cqs2_3_1_5y", None),
+    ("govt_bond", 3, "5y_plus", "govt_bond_cqs2_3_5y_plus", None),
+    # Government bonds CQS 4 (BB+ to BB-)
+    ("govt_bond", 4, "0_1y", "govt_bond_cqs4_0_1y", None),
+    ("govt_bond", 4, "1_5y", "govt_bond_cqs4_1_5y", None),
+    ("govt_bond", 4, "5y_plus", "govt_bond_cqs4_5y_plus", None),
+    # Corporate bonds CQS 1 (AAA to AA-)
+    ("corp_bond", 1, "0_1y", "corp_bond_cqs1_0_1y", None),
+    ("corp_bond", 1, "1_5y", "corp_bond_cqs1_1_5y", None),
+    ("corp_bond", 1, "5y_plus", "corp_bond_cqs1_5y_plus", None),
+    # Corporate bonds CQS 2-3 (shared dict key)
+    ("corp_bond", 2, "0_1y", "corp_bond_cqs2_3_0_1y", None),
+    ("corp_bond", 2, "1_5y", "corp_bond_cqs2_3_1_5y", None),
+    ("corp_bond", 2, "5y_plus", "corp_bond_cqs2_3_5y_plus", None),
+    ("corp_bond", 3, "0_1y", "corp_bond_cqs2_3_0_1y", None),
+    ("corp_bond", 3, "1_5y", "corp_bond_cqs2_3_1_5y", None),
+    ("corp_bond", 3, "5y_plus", "corp_bond_cqs2_3_5y_plus", None),
+    # Equity
+    ("equity", None, None, "equity_main_index", True),
+    ("equity", None, None, "equity_other", False),
+    # Other
+    ("real_estate", None, None, "real_estate", None),
+    ("receivables", None, None, "receivables", None),
+    ("other_physical", None, None, "other_physical", None),
+)
+
+_B31_HAIRCUT_ROW_SPECS: tuple[_HaircutRowSpec, ...] = (
+    # Cash and gold
+    ("cash", None, None, "cash", None),
+    ("gold", None, None, "gold", None),
+    # Government bonds CQS 1
+    ("govt_bond", 1, "0_1y", "govt_bond_cqs1_0_1y", None),
+    ("govt_bond", 1, "1_3y", "govt_bond_cqs1_1_3y", None),
+    ("govt_bond", 1, "3_5y", "govt_bond_cqs1_3_5y", None),
+    ("govt_bond", 1, "5_10y", "govt_bond_cqs1_5_10y", None),
+    ("govt_bond", 1, "10y_plus", "govt_bond_cqs1_10y_plus", None),
+    # Government bonds CQS 2-3 (shared dict key)
+    ("govt_bond", 2, "0_1y", "govt_bond_cqs2_3_0_1y", None),
+    ("govt_bond", 2, "1_3y", "govt_bond_cqs2_3_1_3y", None),
+    ("govt_bond", 2, "3_5y", "govt_bond_cqs2_3_3_5y", None),
+    ("govt_bond", 2, "5_10y", "govt_bond_cqs2_3_5_10y", None),
+    ("govt_bond", 2, "10y_plus", "govt_bond_cqs2_3_10y_plus", None),
+    ("govt_bond", 3, "0_1y", "govt_bond_cqs2_3_0_1y", None),
+    ("govt_bond", 3, "1_3y", "govt_bond_cqs2_3_1_3y", None),
+    ("govt_bond", 3, "3_5y", "govt_bond_cqs2_3_3_5y", None),
+    ("govt_bond", 3, "5_10y", "govt_bond_cqs2_3_5_10y", None),
+    ("govt_bond", 3, "10y_plus", "govt_bond_cqs2_3_10y_plus", None),
+    # Government bonds CQS 4 (BB+ to BB-)
+    ("govt_bond", 4, "0_1y", "govt_bond_cqs4_0_1y", None),
+    ("govt_bond", 4, "1_3y", "govt_bond_cqs4_1_3y", None),
+    ("govt_bond", 4, "3_5y", "govt_bond_cqs4_3_5y", None),
+    ("govt_bond", 4, "5_10y", "govt_bond_cqs4_5_10y", None),
+    ("govt_bond", 4, "10y_plus", "govt_bond_cqs4_10y_plus", None),
+    # Corporate bonds CQS 1 (AAA to AA-)
+    ("corp_bond", 1, "0_1y", "corp_bond_cqs1_0_1y", None),
+    ("corp_bond", 1, "1_3y", "corp_bond_cqs1_1_3y", None),
+    ("corp_bond", 1, "3_5y", "corp_bond_cqs1_3_5y", None),
+    ("corp_bond", 1, "5_10y", "corp_bond_cqs1_5_10y", None),
+    ("corp_bond", 1, "10y_plus", "corp_bond_cqs1_10y_plus", None),
+    # Corporate bonds CQS 2-3 (shared dict key)
+    ("corp_bond", 2, "0_1y", "corp_bond_cqs2_3_0_1y", None),
+    ("corp_bond", 2, "1_3y", "corp_bond_cqs2_3_1_3y", None),
+    ("corp_bond", 2, "3_5y", "corp_bond_cqs2_3_3_5y", None),
+    ("corp_bond", 2, "5_10y", "corp_bond_cqs2_3_5_10y", None),
+    ("corp_bond", 2, "10y_plus", "corp_bond_cqs2_3_10y_plus", None),
+    ("corp_bond", 3, "0_1y", "corp_bond_cqs2_3_0_1y", None),
+    ("corp_bond", 3, "1_3y", "corp_bond_cqs2_3_1_3y", None),
+    ("corp_bond", 3, "3_5y", "corp_bond_cqs2_3_3_5y", None),
+    ("corp_bond", 3, "5_10y", "corp_bond_cqs2_3_5_10y", None),
+    ("corp_bond", 3, "10y_plus", "corp_bond_cqs2_3_10y_plus", None),
+    # Equity
+    ("equity", None, None, "equity_main_index", True),
+    ("equity", None, None, "equity_other", False),
+    # Other
+    ("real_estate", None, None, "real_estate", None),
+    ("receivables", None, None, "receivables", None),
+    ("other_physical", None, None, "other_physical", None),
+)
+
+
+def _build_haircut_df(
+    row_specs: tuple[_HaircutRowSpec, ...],
+    haircut_dict: dict[str, Decimal],
+) -> pl.DataFrame:
+    """Build a haircut lookup DataFrame from row specs + authoritative dict."""
+    return pl.DataFrame(
+        {
+            "collateral_type": [spec[0] for spec in row_specs],
+            "cqs": [spec[1] for spec in row_specs],
+            "maturity_band": [spec[2] for spec in row_specs],
+            "haircut": [float(haircut_dict[spec[3]]) for spec in row_specs],
+            "is_main_index": [spec[4] for spec in row_specs],
+        }
+    ).with_columns(
+        [
+            pl.col("cqs").cast(pl.Int8),
+            pl.col("haircut").cast(pl.Float64),
+        ]
+    )
+
+
 def _create_haircut_df(is_basel_3_1: bool = False) -> pl.DataFrame:
     """Create haircut lookup DataFrame for the specified framework."""
     if is_basel_3_1:
@@ -175,536 +302,21 @@ def _create_haircut_df(is_basel_3_1: bool = False) -> pl.DataFrame:
 
 
 def _create_crr_haircut_df() -> pl.DataFrame:
-    """Create CRR haircut lookup DataFrame (3 maturity bands)."""
-    rows = [
-        # Cash and gold
-        {
-            "collateral_type": "cash",
-            "cqs": None,
-            "maturity_band": None,
-            "haircut": 0.00,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "gold",
-            "cqs": None,
-            "maturity_band": None,
-            "haircut": 0.15,
-            "is_main_index": None,
-        },
-        # Government bonds CQS 1
-        {
-            "collateral_type": "govt_bond",
-            "cqs": 1,
-            "maturity_band": "0_1y",
-            "haircut": 0.005,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "govt_bond",
-            "cqs": 1,
-            "maturity_band": "1_5y",
-            "haircut": 0.02,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "govt_bond",
-            "cqs": 1,
-            "maturity_band": "5y_plus",
-            "haircut": 0.04,
-            "is_main_index": None,
-        },
-        # Government bonds CQS 2-3
-        {
-            "collateral_type": "govt_bond",
-            "cqs": 2,
-            "maturity_band": "0_1y",
-            "haircut": 0.01,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "govt_bond",
-            "cqs": 2,
-            "maturity_band": "1_5y",
-            "haircut": 0.03,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "govt_bond",
-            "cqs": 2,
-            "maturity_band": "5y_plus",
-            "haircut": 0.06,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "govt_bond",
-            "cqs": 3,
-            "maturity_band": "0_1y",
-            "haircut": 0.01,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "govt_bond",
-            "cqs": 3,
-            "maturity_band": "1_5y",
-            "haircut": 0.03,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "govt_bond",
-            "cqs": 3,
-            "maturity_band": "5y_plus",
-            "haircut": 0.06,
-            "is_main_index": None,
-        },
-        # Government bonds CQS 4 (BB+ to BB-) — Art. 197(1)(b): eligible, Art. 224 Table 1
-        {
-            "collateral_type": "govt_bond",
-            "cqs": 4,
-            "maturity_band": "0_1y",
-            "haircut": 0.15,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "govt_bond",
-            "cqs": 4,
-            "maturity_band": "1_5y",
-            "haircut": 0.15,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "govt_bond",
-            "cqs": 4,
-            "maturity_band": "5y_plus",
-            "haircut": 0.15,
-            "is_main_index": None,
-        },
-        # Corporate bonds CQS 1 (AAA to AA-)
-        {
-            "collateral_type": "corp_bond",
-            "cqs": 1,
-            "maturity_band": "0_1y",
-            "haircut": 0.01,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "corp_bond",
-            "cqs": 1,
-            "maturity_band": "1_5y",
-            "haircut": 0.04,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "corp_bond",
-            "cqs": 1,
-            "maturity_band": "5y_plus",
-            "haircut": 0.08,
-            "is_main_index": None,
-        },
-        # Corporate bonds CQS 2-3 (A+ to BBB-)
-        {
-            "collateral_type": "corp_bond",
-            "cqs": 2,
-            "maturity_band": "0_1y",
-            "haircut": 0.02,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "corp_bond",
-            "cqs": 2,
-            "maturity_band": "1_5y",
-            "haircut": 0.06,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "corp_bond",
-            "cqs": 2,
-            "maturity_band": "5y_plus",
-            "haircut": 0.12,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "corp_bond",
-            "cqs": 3,
-            "maturity_band": "0_1y",
-            "haircut": 0.02,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "corp_bond",
-            "cqs": 3,
-            "maturity_band": "1_5y",
-            "haircut": 0.06,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "corp_bond",
-            "cqs": 3,
-            "maturity_band": "5y_plus",
-            "haircut": 0.12,
-            "is_main_index": None,
-        },
-        # Equity
-        {
-            "collateral_type": "equity",
-            "cqs": None,
-            "maturity_band": None,
-            "haircut": 0.15,
-            "is_main_index": True,
-        },
-        {
-            "collateral_type": "equity",
-            "cqs": None,
-            "maturity_band": None,
-            "haircut": 0.25,
-            "is_main_index": False,
-        },
-        # Other
-        {
-            "collateral_type": "real_estate",
-            "cqs": None,
-            "maturity_band": None,
-            "haircut": 0.00,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "receivables",
-            "cqs": None,
-            "maturity_band": None,
-            "haircut": 0.20,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "other_physical",
-            "cqs": None,
-            "maturity_band": None,
-            "haircut": 0.40,
-            "is_main_index": None,
-        },
-    ]
+    """Create CRR haircut lookup DataFrame (3 maturity bands).
 
-    return pl.DataFrame(rows).with_columns(
-        [
-            pl.col("cqs").cast(pl.Int8),
-            pl.col("haircut").cast(pl.Float64),
-        ]
-    )
+    Values are sourced from ``COLLATERAL_HAIRCUTS``; ``_CRR_HAIRCUT_ROW_SPECS``
+    defines row order and the dict keys used for lookup.
+    """
+    return _build_haircut_df(_CRR_HAIRCUT_ROW_SPECS, COLLATERAL_HAIRCUTS)
 
 
 def _create_basel31_haircut_df() -> pl.DataFrame:
-    """Create Basel 3.1 haircut lookup DataFrame (5 maturity bands per CRE22.52-53)."""
-    rows = [
-        # Cash (unchanged) and gold (20% under B31, was 15% under CRR)
-        {
-            "collateral_type": "cash",
-            "cqs": None,
-            "maturity_band": None,
-            "haircut": 0.00,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "gold",
-            "cqs": None,
-            "maturity_band": None,
-            "haircut": 0.20,
-            "is_main_index": None,
-        },
-        # Government bonds CQS 1
-        {
-            "collateral_type": "govt_bond",
-            "cqs": 1,
-            "maturity_band": "0_1y",
-            "haircut": 0.005,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "govt_bond",
-            "cqs": 1,
-            "maturity_band": "1_3y",
-            "haircut": 0.02,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "govt_bond",
-            "cqs": 1,
-            "maturity_band": "3_5y",
-            "haircut": 0.02,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "govt_bond",
-            "cqs": 1,
-            "maturity_band": "5_10y",
-            "haircut": 0.04,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "govt_bond",
-            "cqs": 1,
-            "maturity_band": "10y_plus",
-            "haircut": 0.04,
-            "is_main_index": None,
-        },
-        # Government bonds CQS 2-3
-        {
-            "collateral_type": "govt_bond",
-            "cqs": 2,
-            "maturity_band": "0_1y",
-            "haircut": 0.01,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "govt_bond",
-            "cqs": 2,
-            "maturity_band": "1_3y",
-            "haircut": 0.03,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "govt_bond",
-            "cqs": 2,
-            "maturity_band": "3_5y",
-            "haircut": 0.04,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "govt_bond",
-            "cqs": 2,
-            "maturity_band": "5_10y",
-            "haircut": 0.06,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "govt_bond",
-            "cqs": 2,
-            "maturity_band": "10y_plus",
-            "haircut": 0.12,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "govt_bond",
-            "cqs": 3,
-            "maturity_band": "0_1y",
-            "haircut": 0.01,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "govt_bond",
-            "cqs": 3,
-            "maturity_band": "1_3y",
-            "haircut": 0.03,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "govt_bond",
-            "cqs": 3,
-            "maturity_band": "3_5y",
-            "haircut": 0.04,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "govt_bond",
-            "cqs": 3,
-            "maturity_band": "5_10y",
-            "haircut": 0.06,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "govt_bond",
-            "cqs": 3,
-            "maturity_band": "10y_plus",
-            "haircut": 0.12,
-            "is_main_index": None,
-        },
-        # Government bonds CQS 4 (BB+ to BB-) — Art. 197(1)(b): eligible, Art. 224 Table 1
-        {
-            "collateral_type": "govt_bond",
-            "cqs": 4,
-            "maturity_band": "0_1y",
-            "haircut": 0.15,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "govt_bond",
-            "cqs": 4,
-            "maturity_band": "1_3y",
-            "haircut": 0.15,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "govt_bond",
-            "cqs": 4,
-            "maturity_band": "3_5y",
-            "haircut": 0.15,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "govt_bond",
-            "cqs": 4,
-            "maturity_band": "5_10y",
-            "haircut": 0.15,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "govt_bond",
-            "cqs": 4,
-            "maturity_band": "10y_plus",
-            "haircut": 0.15,
-            "is_main_index": None,
-        },
-        # Corporate bonds CQS 1 (AAA to AA-)
-        {
-            "collateral_type": "corp_bond",
-            "cqs": 1,
-            "maturity_band": "0_1y",
-            "haircut": 0.01,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "corp_bond",
-            "cqs": 1,
-            "maturity_band": "1_3y",
-            "haircut": 0.04,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "corp_bond",
-            "cqs": 1,
-            "maturity_band": "3_5y",
-            "haircut": 0.06,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "corp_bond",
-            "cqs": 1,
-            "maturity_band": "5_10y",
-            "haircut": 0.10,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "corp_bond",
-            "cqs": 1,
-            "maturity_band": "10y_plus",
-            "haircut": 0.12,
-            "is_main_index": None,
-        },
-        # Corporate bonds CQS 2-3 (A+ to BBB-)
-        {
-            "collateral_type": "corp_bond",
-            "cqs": 2,
-            "maturity_band": "0_1y",
-            "haircut": 0.02,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "corp_bond",
-            "cqs": 2,
-            "maturity_band": "1_3y",
-            "haircut": 0.06,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "corp_bond",
-            "cqs": 2,
-            "maturity_band": "3_5y",
-            "haircut": 0.08,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "corp_bond",
-            "cqs": 2,
-            "maturity_band": "5_10y",
-            "haircut": 0.15,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "corp_bond",
-            "cqs": 2,
-            "maturity_band": "10y_plus",
-            "haircut": 0.15,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "corp_bond",
-            "cqs": 3,
-            "maturity_band": "0_1y",
-            "haircut": 0.02,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "corp_bond",
-            "cqs": 3,
-            "maturity_band": "1_3y",
-            "haircut": 0.06,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "corp_bond",
-            "cqs": 3,
-            "maturity_band": "3_5y",
-            "haircut": 0.08,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "corp_bond",
-            "cqs": 3,
-            "maturity_band": "5_10y",
-            "haircut": 0.15,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "corp_bond",
-            "cqs": 3,
-            "maturity_band": "10y_plus",
-            "haircut": 0.15,
-            "is_main_index": None,
-        },
-        # Equity — PRA PS1/26 Art. 224 Table 3: main=20%, other=30% (10-day)
-        {
-            "collateral_type": "equity",
-            "cqs": None,
-            "maturity_band": None,
-            "haircut": 0.20,
-            "is_main_index": True,
-        },
-        {
-            "collateral_type": "equity",
-            "cqs": None,
-            "maturity_band": None,
-            "haircut": 0.30,
-            "is_main_index": False,
-        },
-        # Non-financial collateral — Art. 230(2) HC values (PRA PS1/26)
-        # HC=40% for receivables, RE, and other physical in the LGD* formula
-        {
-            "collateral_type": "real_estate",
-            "cqs": None,
-            "maturity_band": None,
-            "haircut": 0.00,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "receivables",
-            "cqs": None,
-            "maturity_band": None,
-            "haircut": 0.40,
-            "is_main_index": None,
-        },
-        {
-            "collateral_type": "other_physical",
-            "cqs": None,
-            "maturity_band": None,
-            "haircut": 0.40,
-            "is_main_index": None,
-        },
-    ]
+    """Create Basel 3.1 haircut lookup DataFrame (5 maturity bands per CRE22.52-53).
 
-    return pl.DataFrame(rows).with_columns(
-        [
-            pl.col("cqs").cast(pl.Int8),
-            pl.col("haircut").cast(pl.Float64),
-        ]
-    )
+    Values are sourced from ``BASEL31_COLLATERAL_HAIRCUTS``;
+    ``_B31_HAIRCUT_ROW_SPECS`` defines row order and dict keys used for lookup.
+    """
+    return _build_haircut_df(_B31_HAIRCUT_ROW_SPECS, BASEL31_COLLATERAL_HAIRCUTS)
 
 
 def get_haircut_table(is_basel_3_1: bool = False) -> pl.DataFrame:

--- a/tests/unit/test_tables_dict_dataframe_parity.py
+++ b/tests/unit/test_tables_dict_dataframe_parity.py
@@ -1,0 +1,230 @@
+"""
+Parity tests: data/tables/ DataFrames must be derived from their dict constants.
+
+Guards against regressions of the pattern fixed in commit introducing
+`_build_cqs_rw_df` / `_build_haircut_df` / `_build_firb_lgd_df`. If a future
+change hardcodes a numeric value in a DataFrame builder instead of reading it
+from the authoritative constant dict, the corresponding test here will fail.
+
+The authoritative dict for each DataFrame:
+
+| DataFrame builder                         | Authoritative dict(s)                                 |
+|-------------------------------------------|-------------------------------------------------------|
+| crr._create_cgcb_df                       | CENTRAL_GOVT_CENTRAL_BANK_RISK_WEIGHTS                |
+| crr._create_institution_df(True)          | INSTITUTION_RISK_WEIGHTS_UK                           |
+| crr._create_institution_df(False)         | INSTITUTION_RISK_WEIGHTS_STANDARD                     |
+| crr._create_pse_df                        | PSE_RISK_WEIGHTS_OWN_RATING                           |
+| crr._create_rgla_df                       | RGLA_RISK_WEIGHTS_OWN_RATING                          |
+| crr._create_mdb_df                        | MDB_RISK_WEIGHTS_TABLE_2B                             |
+| crr._create_corporate_df                  | CORPORATE_RISK_WEIGHTS                                |
+| crr._create_retail_df                     | RETAIL_RISK_WEIGHT                                    |
+| crr._create_residential_mortgage_df       | RESIDENTIAL_MORTGAGE_PARAMS                           |
+| crr._create_commercial_re_df              | COMMERCIAL_RE_PARAMS                                  |
+| crr._create_covered_bond_df               | COVERED_BOND_RISK_WEIGHTS                             |
+| b31._create_b31_corporate_df              | B31_CORPORATE_RISK_WEIGHTS                            |
+| b31._create_b31_covered_bond_df           | B31_COVERED_BOND_RISK_WEIGHTS                         |
+| haircuts._create_crr_haircut_df           | COLLATERAL_HAIRCUTS                                   |
+| haircuts._create_basel31_haircut_df       | BASEL31_COLLATERAL_HAIRCUTS                           |
+| firb_lgd._create_firb_lgd_df              | FIRB_SUPERVISORY_LGD + OC ratios + min thresholds     |
+| firb_lgd._create_b31_firb_lgd_df          | BASEL31_FIRB_SUPERVISORY_LGD + OC ratios + thresholds |
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from rwa_calc.data.tables import b31_risk_weights as b31
+from rwa_calc.data.tables import crr_risk_weights as crr
+from rwa_calc.data.tables import firb_lgd, haircuts
+from rwa_calc.domain.enums import CQS
+
+# =============================================================================
+# CQS-based risk-weight DataFrames (crr_risk_weights.py)
+# =============================================================================
+
+_CQS_CASES: list[tuple[str, object, dict[CQS, Decimal], str]] = [
+    (
+        "cgcb",
+        crr._create_cgcb_df(),
+        crr.CENTRAL_GOVT_CENTRAL_BANK_RISK_WEIGHTS,
+        "CENTRAL_GOVT_CENTRAL_BANK",
+    ),
+    ("inst_uk", crr._create_institution_df(True), crr.INSTITUTION_RISK_WEIGHTS_UK, "INSTITUTION"),
+    (
+        "inst_std",
+        crr._create_institution_df(False),
+        crr.INSTITUTION_RISK_WEIGHTS_STANDARD,
+        "INSTITUTION",
+    ),
+    ("pse", crr._create_pse_df(), crr.PSE_RISK_WEIGHTS_OWN_RATING, "PSE"),
+    ("rgla", crr._create_rgla_df(), crr.RGLA_RISK_WEIGHTS_OWN_RATING, "RGLA"),
+    ("mdb", crr._create_mdb_df(), crr.MDB_RISK_WEIGHTS_TABLE_2B, "MDB"),
+    ("corporate", crr._create_corporate_df(), crr.CORPORATE_RISK_WEIGHTS, "CORPORATE"),
+    ("covered_bond", crr._create_covered_bond_df(), crr.COVERED_BOND_RISK_WEIGHTS, "COVERED_BOND"),
+]
+
+
+@pytest.mark.parametrize("name,df,source_dict,exposure_class", _CQS_CASES)
+def test_cqs_dataframe_matches_source_dict(name, df, source_dict, exposure_class):
+    """Each row's risk_weight equals float(source_dict[CQS(cqs)])."""
+    rows = df.to_dicts()
+    assert rows, f"{name}: DataFrame is empty"
+    for row in rows:
+        assert row["exposure_class"] == exposure_class
+        cqs_val = row["cqs"]
+        cqs_key = CQS.UNRATED if cqs_val is None else CQS(cqs_val)
+        assert cqs_key in source_dict, f"{name}: CQS {cqs_key} not in source dict"
+        expected = float(source_dict[cqs_key])
+        assert row["risk_weight"] == pytest.approx(expected), (
+            f"{name}: cqs={cqs_val} DataFrame value {row['risk_weight']} != "
+            f"source dict value {expected}"
+        )
+
+
+def test_retail_df_matches_constant():
+    df = crr._create_retail_df()
+    assert df.shape == (1, 3)
+    assert df["risk_weight"][0] == pytest.approx(float(crr.RETAIL_RISK_WEIGHT))
+
+
+def test_residential_mortgage_df_matches_params():
+    df = crr._create_residential_mortgage_df()
+    p = crr.RESIDENTIAL_MORTGAGE_PARAMS
+    row = df.row(0, named=True)
+    assert row["ltv_threshold"] == pytest.approx(float(p["ltv_threshold"]))
+    assert row["rw_low_ltv"] == pytest.approx(float(p["rw_low_ltv"]))
+    assert row["rw_high_ltv"] == pytest.approx(float(p["rw_high_ltv"]))
+
+
+def test_commercial_re_df_matches_params():
+    df = crr._create_commercial_re_df()
+    p = crr.COMMERCIAL_RE_PARAMS
+    row = df.row(0, named=True)
+    assert row["ltv_threshold"] == pytest.approx(float(p["ltv_threshold"]))
+    assert row["rw_low_ltv"] == pytest.approx(float(p["rw_low_ltv"]))
+    assert row["rw_standard"] == pytest.approx(float(p["rw_standard"]))
+
+
+# =============================================================================
+# Basel 3.1 CQS-based risk-weight DataFrames (b31_risk_weights.py)
+# =============================================================================
+
+_B31_CQS_CASES: list[tuple[str, object, dict[int | None, Decimal], str]] = [
+    ("b31_corporate", b31._create_b31_corporate_df(), b31.B31_CORPORATE_RISK_WEIGHTS, "CORPORATE"),
+    (
+        "b31_covered_bond",
+        b31._create_b31_covered_bond_df(),
+        b31.B31_COVERED_BOND_RISK_WEIGHTS,
+        "COVERED_BOND",
+    ),
+]
+
+
+@pytest.mark.parametrize("name,df,source_dict,exposure_class", _B31_CQS_CASES)
+def test_b31_cqs_dataframe_matches_source_dict(name, df, source_dict, exposure_class):
+    """Each row's risk_weight equals float(source_dict[cqs])."""
+    for row in df.to_dicts():
+        assert row["exposure_class"] == exposure_class
+        key = row["cqs"]  # already int | None matching dict key type
+        assert key in source_dict, f"{name}: key {key!r} missing from source dict"
+        assert row["risk_weight"] == pytest.approx(float(source_dict[key]))
+
+
+# =============================================================================
+# Haircut DataFrames (haircuts.py)
+# =============================================================================
+
+_HAIRCUT_CASES: list[tuple[str, object, tuple, dict[str, Decimal]]] = [
+    (
+        "haircut_crr",
+        haircuts._create_crr_haircut_df(),
+        haircuts._CRR_HAIRCUT_ROW_SPECS,
+        haircuts.COLLATERAL_HAIRCUTS,
+    ),
+    (
+        "haircut_b31",
+        haircuts._create_basel31_haircut_df(),
+        haircuts._B31_HAIRCUT_ROW_SPECS,
+        haircuts.BASEL31_COLLATERAL_HAIRCUTS,
+    ),
+]
+
+
+@pytest.mark.parametrize("name,df,specs,source_dict", _HAIRCUT_CASES)
+def test_haircut_dataframe_matches_source_dict(name, df, specs, source_dict):
+    """Each DataFrame row's haircut equals float(source_dict[spec.dict_key])."""
+    rows = df.to_dicts()
+    assert len(rows) == len(specs), f"{name}: row count mismatch"
+    for row, spec in zip(rows, specs, strict=True):
+        coll_type, cqs, maturity_band, dict_key, is_main_index = spec
+        assert row["collateral_type"] == coll_type
+        assert row["cqs"] == cqs
+        assert row["maturity_band"] == maturity_band
+        assert row["is_main_index"] == is_main_index
+        expected = float(source_dict[dict_key])
+        assert row["haircut"] == pytest.approx(expected), (
+            f"{name}: row {spec} — DataFrame haircut {row['haircut']} != "
+            f"source dict value {expected}"
+        )
+
+
+# =============================================================================
+# F-IRB supervisory LGD DataFrames (firb_lgd.py)
+# =============================================================================
+
+
+def test_firb_lgd_df_matches_source_dicts():
+    """CRR F-IRB rows draw LGD, OC ratio, and min threshold from dicts."""
+    df = firb_lgd._create_firb_lgd_df()
+    specs = firb_lgd._CRR_FIRB_ROW_SPECS
+    rows = df.to_dicts()
+    assert len(rows) == len(specs)
+    for row, spec in zip(rows, specs, strict=True):
+        coll_type, seniority, lgd_key, oc_key, description = spec
+        assert row["collateral_type"] == coll_type
+        assert row["seniority"] == seniority
+        assert row["description"] == description
+        assert row["lgd"] == pytest.approx(float(firb_lgd.FIRB_SUPERVISORY_LGD[lgd_key]))
+        assert row["overcollateralisation_ratio"] == pytest.approx(
+            firb_lgd.FIRB_OVERCOLLATERALISATION_RATIOS[oc_key]
+        )
+        assert row["min_threshold"] == pytest.approx(
+            firb_lgd.FIRB_MIN_COLLATERALISATION_THRESHOLDS[oc_key]
+        )
+
+
+def test_b31_firb_lgd_df_matches_source_dicts():
+    """Basel 3.1 F-IRB rows draw LGD, OC ratio, and min threshold from dicts."""
+    df = firb_lgd._create_b31_firb_lgd_df()
+    specs = firb_lgd._B31_FIRB_ROW_SPECS
+    rows = df.to_dicts()
+    assert len(rows) == len(specs)
+    for row, spec in zip(rows, specs, strict=True):
+        coll_type, seniority, is_fse, lgd_key, oc_key, description = spec
+        assert row["collateral_type"] == coll_type
+        assert row["seniority"] == seniority
+        assert row["is_fse"] == is_fse
+        assert row["description"] == description
+        assert row["lgd"] == pytest.approx(float(firb_lgd.BASEL31_FIRB_SUPERVISORY_LGD[lgd_key]))
+        assert row["overcollateralisation_ratio"] == pytest.approx(
+            firb_lgd.FIRB_OVERCOLLATERALISATION_RATIOS[oc_key]
+        )
+        assert row["min_threshold"] == pytest.approx(
+            firb_lgd.FIRB_MIN_COLLATERALISATION_THRESHOLDS[oc_key]
+        )
+
+
+def test_b31_firb_scalar_aliases_match_dict():
+    """B31_FIRB_LGD_* scalars must equal their corresponding dict entry."""
+    d = firb_lgd.BASEL31_FIRB_SUPERVISORY_LGD
+    assert d["unsecured_senior"] == firb_lgd.B31_FIRB_LGD_UNSECURED_SENIOR
+    assert d["unsecured_senior_fse"] == firb_lgd.B31_FIRB_LGD_UNSECURED_SENIOR_FSE
+    assert d["subordinated"] == firb_lgd.B31_FIRB_LGD_SUBORDINATED
+    assert d["covered_bond"] == firb_lgd.B31_FIRB_LGD_COVERED_BOND
+    assert d["financial_collateral"] == firb_lgd.B31_FIRB_LGD_FINANCIAL_COLLATERAL
+    assert d["receivables"] == firb_lgd.B31_FIRB_LGD_RECEIVABLES
+    assert d["residential_re"] == firb_lgd.B31_FIRB_LGD_RESIDENTIAL_RE
+    assert d["commercial_re"] == firb_lgd.B31_FIRB_LGD_COMMERCIAL_RE
+    assert d["other_physical"] == firb_lgd.B31_FIRB_LGD_OTHER_PHYSICAL


### PR DESCRIPTION
Most _create_*_df builders in src/rwa_calc/data/tables/ previously
hardcoded regulatory numeric literals that were already defined in the
module's constant dicts. Updating a regulatory value required changes
in 2+ places with no compiler help to catch drift.

Builders now iterate the authoritative dicts to derive their values,
matching the gold-standard pattern already used in b31_equity_rw.py:

- crr_risk_weights.py: new _build_cqs_rw_df helper + _CQS_ORDER_*
  tuples; all CQS-keyed builders (CGCB, institution, PSE, RGLA, MDB,
  corporate, covered bond) now read from the constant dicts. Retail,
  residential mortgage, and commercial RE builders reference their
  scalar/TypedDict constants directly.
- b31_risk_weights.py: new _build_int_cqs_rw_df helper for int-keyed
  dicts (B31_CORPORATE_RISK_WEIGHTS, B31_COVERED_BOND_RISK_WEIGHTS).
- haircuts.py: row-spec tuples (_CRR_HAIRCUT_ROW_SPECS,
  _B31_HAIRCUT_ROW_SPECS) define column ordering; values come from
  COLLATERAL_HAIRCUTS / BASEL31_COLLATERAL_HAIRCUTS via
  _build_haircut_df.
- firb_lgd.py: row-spec tuples (_CRR_FIRB_ROW_SPECS,
  _B31_FIRB_ROW_SPECS) with _build_firb_lgd_df / _build_b31_firb_lgd_df
  helpers. B31_FIRB_LGD_* scalar aliases now derive from
  BASEL31_FIRB_SUPERVISORY_LGD.

Invariant locked in by tests/unit/test_tables_dict_dataframe_parity.py
(18 parametrised cases) which asserts every DataFrame row's numeric
value equals float(source_dict[row_key]).

DataFrame schemas, column/row ordering, and public API unchanged. All
parity snapshots match byte-for-byte. No regulatory values changed.

https://claude.ai/code/session_01LzNGgEcDhvk9CaMcrDCrAJ