### PR TITLE
fix(guarantees): preserve EU sovereign 0% RW after FX conversion

### DIFF
--- a/docs/appendix/changelog.md
+++ b/docs/appendix/changelog.md
@@ -5,6 +5,11 @@ All notable changes to the RWA Calculator are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.193] — 2026-04-13
+
+### Fixed
+- **EU sovereign guarantee 0% RW (CRR Art. 114(4))**: Exposures guaranteed by an EU member state central government/central bank in that state's domestic currency (e.g. a German sovereign guaranteeing a EUR-denominated exposure) were failing to receive the mandated 0% risk weight when the pipeline's FX converter was active. Root cause: `engine/fx_converter.py` overwrites the exposure's `currency` column with the reporting currency and stores the pre-conversion denomination in `original_currency`, but every downstream "denominated in domestic currency" check read the now-overwritten `currency` column. After FX conversion a DE sovereign + EUR exposure appeared as DE + GBP (or whatever the reporting currency was), so the Art. 114(4) short-circuit never fired; unrated EU sovereign guarantors then fell through to `.otherwise(1.0)` = 100% instead of 0%. Added `denomination_currency_expr()` helper in `data/tables/eu_sovereign.py` that returns `pl.col("original_currency")` when present, else `pl.col("currency")`. Extended `build_eu_domestic_currency_expr` to accept a `pl.Expr` for the currency side. Updated all seven affected call sites in `engine/sa/calculator.py` (borrower + guarantor), `engine/irb/guarantee.py` (guarantor, IRB path), and `engine/classifier.py` (forced-SA check for EU domestic sovereigns). Existing `TestSAEUDomesticSovereignTreatment` unit tests were bypassing the bug because they fabricated LazyFrames with `currency` set to the denomination directly; added `TestSAEUDomesticSovereignPostFX` / `TestIRBEUDomesticSovereignPostFX` regression classes covering the post-FX pipeline state.
+
 ## [0.1.192] — 2026-04-12
 
 ### Changed

--- a/src/rwa_calc/data/tables/eu_sovereign.py
+++ b/src/rwa_calc/data/tables/eu_sovereign.py
@@ -100,7 +100,7 @@ EU_COUNTRY_DOMESTIC_CURRENCY: dict[str, str] = {
 
 def build_eu_domestic_currency_expr(
     country_col: str,
-    currency_col: str = "currency",
+    currency_col: str | pl.Expr = "currency",
 ) -> pl.Expr:
     """
     Build a Polars expression that checks if an exposure is to an EU member
@@ -108,19 +108,52 @@ def build_eu_domestic_currency_expr(
     domestic currency.
 
     Uses replace_strict to map country code → domestic currency, then compares
-    with the exposure currency column.
+    with the exposure denomination currency.
 
     Args:
         country_col: Column name containing the ISO country code
-        currency_col: Column name containing the exposure currency
+        currency_col: Column name (str) or Polars expression for the
+            exposure's denomination currency. A string is wrapped in
+            ``pl.col(...)``. Callers operating on a post-FX-conversion
+            LazyFrame should pass ``denomination_currency_expr(...)`` so the
+            original (pre-conversion) currency is compared — not the reporting
+            currency.
 
     Returns:
         Boolean Polars expression: True when country is EU and currency matches
         that country's domestic currency.
     """
+    currency_expr = pl.col(currency_col) if isinstance(currency_col, str) else currency_col
     return (
         pl.col(country_col)
         .fill_null("")
         .replace_strict(EU_COUNTRY_DOMESTIC_CURRENCY, default=None)
-        .eq(pl.col(currency_col))
+        .eq(currency_expr)
     )
+
+
+def denomination_currency_expr(schema_names: list[str] | set[str]) -> pl.Expr:
+    """
+    Return the expression for an exposure's denomination (pre-FX) currency.
+
+    The pipeline's FX converter (``engine/fx_converter.py``) overwrites
+    ``currency`` with the reporting currency and stores the original
+    denomination in ``original_currency``. Every check that compares the
+    exposure's currency against a regulatory domestic currency (CRR Art. 114(3)
+    /(4), Art. 115(5)) must use the pre-conversion denomination — the
+    reporting currency is irrelevant to Art. 114(4).
+
+    This helper returns ``pl.col("original_currency")`` if it exists in the
+    schema, else falls back to ``pl.col("currency")`` (matches unit tests and
+    pipelines where FX conversion is skipped).
+
+    Args:
+        schema_names: Column names from ``lf.collect_schema().names()``.
+
+    Returns:
+        Polars expression yielding the denomination currency per row.
+    """
+    names = set(schema_names)
+    if "original_currency" in names:
+        return pl.col("original_currency")
+    return pl.col("currency")

--- a/src/rwa_calc/engine/classifier.py
+++ b/src/rwa_calc/engine/classifier.py
@@ -47,7 +47,10 @@ from rwa_calc.contracts.errors import (
     CalculationError,
     classification_warning,
 )
-from rwa_calc.data.tables.eu_sovereign import build_eu_domestic_currency_expr
+from rwa_calc.data.tables.eu_sovereign import (
+    build_eu_domestic_currency_expr,
+    denomination_currency_expr,
+)
 from rwa_calc.domain.enums import (
     ApproachType,
     ExposureClass,
@@ -938,9 +941,14 @@ class ExposureClassifier:
 
         # Art. 114(3)/(4): EU domestic sovereign exposures must use SA
         # to receive the 0% RW — forced to standardised regardless of IRB permissions.
+        # Use original (pre-FX) denomination — `currency` is overwritten by the
+        # FX converter with the reporting currency, which would otherwise reject
+        # legitimate Art. 114(4) treatment for any non-base-currency exposure.
         _is_eu_domestic_sovereign = (
             pl.col("exposure_class") == ExposureClass.CENTRAL_GOVT_CENTRAL_BANK.value
-        ) & build_eu_domestic_currency_expr("cp_country_code", "currency")
+        ) & build_eu_domestic_currency_expr(
+            "cp_country_code", denomination_currency_expr(schema_names)
+        )
 
         # --- B31 Art. 147A classifier-level approach restrictions ---
         # These supplement the permissions-level restrictions in full_irb_b31()

--- a/src/rwa_calc/engine/irb/guarantee.py
+++ b/src/rwa_calc/engine/irb/guarantee.py
@@ -26,7 +26,10 @@ from typing import TYPE_CHECKING
 import polars as pl
 
 from rwa_calc.data.tables.crr_risk_weights import QCCP_CLIENT_CLEARED_RW, QCCP_PROPRIETARY_RW
-from rwa_calc.data.tables.eu_sovereign import build_eu_domestic_currency_expr
+from rwa_calc.data.tables.eu_sovereign import (
+    build_eu_domestic_currency_expr,
+    denomination_currency_expr,
+)
 from rwa_calc.engine.irb.formulas import (
     _double_default_multiplier_expr,
     _parametric_irb_risk_weight_expr,
@@ -192,15 +195,20 @@ def _compute_guarantor_rw_sa(
 
     _gec = pl.col("guarantor_exposure_class").fill_null("")
 
-    # Art. 114(3)/(4): Domestic CGCB guarantors -> 0% RW regardless of CQS
-    _has_country = "guarantor_country_code" in lf.collect_schema().names()
+    # Art. 114(3)/(4): Domestic CGCB guarantors -> 0% RW regardless of CQS.
+    # Use the exposure's ORIGINAL denomination (pre-FX-conversion) — the FX
+    # converter overwrites `currency` with the reporting currency, which would
+    # otherwise block the Art. 114(4) 0% short-circuit.
+    _irb_schema_names = lf.collect_schema().names()
+    _has_country = "guarantor_country_code" in _irb_schema_names
+    _ccy_expr_irb = denomination_currency_expr(_irb_schema_names)
     _is_uk_domestic_guarantor = (
-        (pl.col("guarantor_country_code").fill_null("") == "GB") & (pl.col("currency") == "GBP")
+        (pl.col("guarantor_country_code").fill_null("") == "GB") & (_ccy_expr_irb == "GBP")
         if _has_country
         else pl.lit(False)
     )
     _is_eu_domestic_guarantor = (
-        build_eu_domestic_currency_expr("guarantor_country_code", "currency")
+        build_eu_domestic_currency_expr("guarantor_country_code", _ccy_expr_irb)
         if _has_country
         else pl.lit(False)
     )

--- a/src/rwa_calc/engine/sa/calculator.py
+++ b/src/rwa_calc/engine/sa/calculator.py
@@ -99,7 +99,10 @@ from rwa_calc.data.tables.crr_risk_weights import (
     RGLA_UNRATED_DEFAULT_RW,
     get_combined_cqs_risk_weights,
 )
-from rwa_calc.data.tables.eu_sovereign import build_eu_domestic_currency_expr
+from rwa_calc.data.tables.eu_sovereign import (
+    build_eu_domestic_currency_expr,
+    denomination_currency_expr,
+)
 from rwa_calc.domain.enums import CQS, ApproachType, CRMCollateralMethod
 from rwa_calc.engine.sa.supporting_factors import SupportingFactorCalculator
 
@@ -558,11 +561,14 @@ class SACalculator:
             exposures = exposures.with_columns(missing_cols)
 
         # CRR Art. 114(3)/(4): Domestic CGCB exposures → 0% RW
-        # UK sovereign in GBP, or EU sovereign in that member state's domestic currency
-        _is_uk_domestic_currency = (pl.col("cp_country_code") == "GB") & (
-            pl.col("currency") == "GBP"
-        )
-        _is_eu_domestic_currency = build_eu_domestic_currency_expr("cp_country_code", "currency")
+        # UK sovereign in GBP, or EU sovereign in that member state's domestic currency.
+        # Must compare against the exposure's ORIGINAL denomination — the FX
+        # converter overwrites `currency` with the reporting currency, so using
+        # it directly would reject legitimate Art. 114(4) 0% treatment for any
+        # non-base-currency exposure.
+        _ccy_expr = denomination_currency_expr(schema.names())
+        _is_uk_domestic_currency = (pl.col("cp_country_code") == "GB") & (_ccy_expr == "GBP")
+        _is_eu_domestic_currency = build_eu_domestic_currency_expr("cp_country_code", _ccy_expr)
         _is_domestic_currency = _is_uk_domestic_currency | _is_eu_domestic_currency
 
         # Prepare exposures for join
@@ -1517,17 +1523,22 @@ class SACalculator:
         use_uk_deviation = config.base_currency == "GBP"
 
         # Art. 114(3)/(4): Domestic CGCB guarantors → 0% RW regardless of CQS
-        # UK guarantor in GBP, or EU guarantor in that member state's domestic currency
+        # UK guarantor in GBP, or EU guarantor in that member state's domestic currency.
+        # Use the exposure's ORIGINAL denomination (pre-FX-conversion) — the FX
+        # converter overwrites `currency` with the reporting currency, which
+        # would otherwise block the Art. 114(4) 0% short-circuit.
         schema_now = exposures.collect_schema()
-        _has_country = "guarantor_country_code" in schema_now.names()
-        _has_currency = "currency" in schema_now.names()
+        _schema_names = schema_now.names()
+        _has_country = "guarantor_country_code" in _schema_names
+        _has_currency = "currency" in _schema_names or "original_currency" in _schema_names
+        _ccy_expr_guar = denomination_currency_expr(_schema_names)
         _is_uk_domestic_guarantor = (
-            (pl.col("guarantor_country_code").fill_null("") == "GB") & (pl.col("currency") == "GBP")
+            (pl.col("guarantor_country_code").fill_null("") == "GB") & (_ccy_expr_guar == "GBP")
             if (_has_country and _has_currency)
             else pl.lit(False)
         )
         _is_eu_domestic_guarantor = (
-            build_eu_domestic_currency_expr("guarantor_country_code", "currency")
+            build_eu_domestic_currency_expr("guarantor_country_code", _ccy_expr_guar)
             if (_has_country and _has_currency)
             else pl.lit(False)
         )

--- a/tests/unit/test_guarantor_exposure_class_rw.py
+++ b/tests/unit/test_guarantor_exposure_class_rw.py
@@ -44,8 +44,14 @@ def _sa_guarantee_result(
     guarantor_country_code: str | None = None,
     guarantor_is_ccp_client_cleared: bool | None = None,
     currency: str = "GBP",
+    original_currency: str | None = None,
 ) -> pl.DataFrame:
-    """Run SA guarantee substitution and return the result."""
+    """Run SA guarantee substitution and return the result.
+
+    When ``original_currency`` is provided, both ``currency`` (reporting) and
+    ``original_currency`` (pre-FX-conversion denomination) columns are added,
+    simulating the post-FX-conversion pipeline state.
+    """
     data: dict[str, list] = {
         "exposure_reference": ["EXP001"],
         "ead": [1_000_000.0],
@@ -56,6 +62,8 @@ def _sa_guarantee_result(
         "guarantor_cqs": [guarantor_cqs],
         "currency": [currency],
     }
+    if original_currency is not None:
+        data["original_currency"] = [original_currency]
     if guarantor_country_code is not None:
         data["guarantor_country_code"] = [guarantor_country_code]
     if guarantor_is_ccp_client_cleared is not None:
@@ -77,8 +85,14 @@ def _irb_guarantee_result(
     guarantor_country_code: str | None = None,
     guarantor_is_ccp_client_cleared: bool | None = None,
     currency: str = "GBP",
+    original_currency: str | None = None,
 ) -> pl.DataFrame:
-    """Run IRB guarantee substitution and return the result."""
+    """Run IRB guarantee substitution and return the result.
+
+    When ``original_currency`` is provided, both ``currency`` (reporting) and
+    ``original_currency`` (pre-FX-conversion denomination) columns are added,
+    simulating the post-FX-conversion pipeline state.
+    """
     data: dict[str, list] = {
         "exposure_reference": ["EXP001"],
         "pd": [0.01],
@@ -94,6 +108,8 @@ def _irb_guarantee_result(
         "guarantor_cqs": [guarantor_cqs],
         "currency": [currency],
     }
+    if original_currency is not None:
+        data["original_currency"] = [original_currency]
     if guarantor_country_code is not None:
         data["guarantor_country_code"] = [guarantor_country_code]
     if guarantor_is_ccp_client_cleared is not None:
@@ -295,6 +311,92 @@ class TestIRBEUDomesticSovereignTreatment:
             "sovereign", 3, crr_config, guarantor_country_code="DE", currency="USD"
         )
         assert result["guarantor_rw"][0] == pytest.approx(0.50)
+
+
+class TestSAEUDomesticSovereignPostFX:
+    """Art. 114(4) 0% RW must hold after FX conversion.
+
+    The ``FXConverter`` overwrites ``currency`` with the reporting currency and
+    stores the pre-conversion denomination in ``original_currency``. The
+    domestic-currency check must honour the denomination, not the reporting
+    currency — otherwise every non-base-currency EU sovereign guarantee would
+    fall through to the CQS ladder and (for unrated sovereigns) land on 100%.
+    """
+
+    def test_de_sovereign_eur_exposure_post_fx_to_gbp_zero_rw(
+        self, crr_config: CalculationConfig
+    ) -> None:
+        """DE sovereign guarantor, EUR exposure converted to GBP reporting → 0%."""
+        result = _sa_guarantee_result(
+            "sovereign",
+            None,  # unrated: without the fix this falls to `.otherwise(1.0)`
+            crr_config,
+            guarantor_country_code="DE",
+            currency="GBP",  # reporting currency after FX conversion
+            original_currency="EUR",  # pre-conversion denomination
+        )
+        assert result["guarantor_rw"][0] == pytest.approx(0.0)
+
+    def test_pl_sovereign_pln_exposure_post_fx_to_gbp_zero_rw(
+        self, crr_config: CalculationConfig
+    ) -> None:
+        """Polish sovereign guarantor, PLN exposure converted to GBP → 0% (non-euro EU)."""
+        result = _sa_guarantee_result(
+            "sovereign",
+            None,
+            crr_config,
+            guarantor_country_code="PL",
+            currency="GBP",
+            original_currency="PLN",
+        )
+        assert result["guarantor_rw"][0] == pytest.approx(0.0)
+
+    def test_de_sovereign_usd_exposure_post_fx_does_not_get_zero(
+        self, crr_config: CalculationConfig
+    ) -> None:
+        """DE sovereign guarantor but USD exposure (non-domestic) → Art. 114(4) does NOT apply."""
+        result = _sa_guarantee_result(
+            "sovereign",
+            None,  # unrated
+            crr_config,
+            guarantor_country_code="DE",
+            currency="GBP",
+            original_currency="USD",  # USD, not EUR → foreign currency
+        )
+        # Unrated CGCB foreign-currency → 100% per CQS ladder otherwise branch
+        assert result["guarantor_rw"][0] == pytest.approx(1.0)
+
+
+class TestIRBEUDomesticSovereignPostFX:
+    """IRB path: same Art. 114(4) preservation across FX conversion."""
+
+    def test_de_sovereign_eur_exposure_post_fx_to_gbp_zero_rw(
+        self, crr_config: CalculationConfig
+    ) -> None:
+        """IRB: DE sovereign guarantor, EUR exposure post-FX → 0% SA RW substitution."""
+        result = _irb_guarantee_result(
+            "sovereign",
+            None,
+            crr_config,
+            guarantor_country_code="DE",
+            currency="GBP",
+            original_currency="EUR",
+        )
+        assert result["guarantor_rw"][0] == pytest.approx(0.0)
+
+    def test_se_sovereign_sek_exposure_post_fx_to_gbp_zero_rw(
+        self, crr_config: CalculationConfig
+    ) -> None:
+        """IRB: Swedish sovereign, SEK exposure post-FX → 0% SA RW substitution."""
+        result = _irb_guarantee_result(
+            "sovereign",
+            None,
+            crr_config,
+            guarantor_country_code="SE",
+            currency="GBP",
+            original_currency="SEK",
+        )
+        assert result["guarantor_rw"][0] == pytest.approx(0.0)
 
 
 class TestSACCPGuarantorRiskWeight:


### PR DESCRIPTION
An exposure guaranteed by an EU member state CGCB in that state's
domestic currency must receive a 0% RW under CRR Art. 114(4) via the
CRM substitution. The check was comparing the guarantor's country
against `pl.col("currency")`, but the FX converter overwrites `currency`
with the reporting currency and stores the pre-conversion denomination
in `original_currency`. After FX conversion a DE sovereign + EUR
exposure appeared as DE + GBP, so the Art. 114(4) short-circuit never
fired; unrated sovereign guarantors then fell through to 100% instead
of 0%.

- Add `denomination_currency_expr()` helper in `data/tables/eu_sovereign.py`
  returning `pl.col("original_currency")` when present, else `pl.col("currency")`.
- Extend `build_eu_domestic_currency_expr()` to accept a `pl.Expr` for
  the currency side.
- Update the four affected call sites: borrower + guarantor in
  `engine/sa/calculator.py`, guarantor in `engine/irb/guarantee.py`,
  and the forced-SA EU-domestic-sovereign check in `engine/classifier.py`.
- Add `TestSAEUDomesticSovereignPostFX` / `TestIRBEUDomesticSovereignPostFX`
  regression classes that exercise the post-FX pipeline state — existing
  EU tests bypassed the bug by setting `currency` to the denomination
  directly.

All 5244 tests pass; arch_check clean.

https://claude.ai/code/session_017sMDFE94vd6DVtnRhXdeeE