### PR TITLE
fix(guarantees): domestic CGCB 0% beats internal-PD IRB routing

### DIFF
--- a/docs/appendix/changelog.md
+++ b/docs/appendix/changelog.md
@@ -5,6 +5,11 @@ All notable changes to the RWA Calculator are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Domestic sovereign guarantor 0% RW vs internal rating (CRR Art. 114(4)/(7))**: When a guarantee from an EU/UK central government/central bank in its domestic currency was provided by a counterparty that the firm rates internally (i.e. carries an `internal_pd`) and the firm holds IRB permission for the CGCB exposure class, the guarantor was being routed to the IRB substitution path. The downstream `_apply_parameter_substitution` step in `engine/irb/guarantee.py` then overwrote the SA branch's correct 0% RW with the parametric F-IRB risk weight derived from the PD, so e.g. a DE sovereign + EUR guarantor with `internal_pd = 0.001` produced ~2.6% instead of the regulatory 0%. The previous EU/UK domestic 0% fix (PR #253) handled the FX-conversion edge case but only inside the SA branch — it did not change routing, so internal-PD guarantors bypassed it. Promoted the Art. 114(4)/(7) check into the guarantor-approach routing step in `engine/crm/guarantees.py`: domestic-currency CGCB guarantors are now forced to `guarantor_approach = "sa"` ahead of the internal-PD branch, so the existing SA 0% short-circuit fires regardless of whether the guarantor has an internal rating. The `guarantor_rating_type` audit field is unchanged — still reports `"internal"` when an internal PD exists, since the override is an approach decision, not a rating-source decision. Reuses `build_eu_domestic_currency_expr` and `denomination_currency_expr` (post-FX safe). Applies under both CRR (Art. 114(4) UK/GBP, Art. 114(7) EU member states) and Basel 3.1 (PRA PS1/26 preserves Art. 114(7) by cross-reference via third-country reciprocity). Added `TestDomesticSovereignGuarantorForcedToSA` regression class in `tests/unit/crm/test_guarantor_rating_type.py` covering UK/GBP, DE/EUR (post-FX), PL/PLN (non-euro EU) and a non-domestic DE/USD counter-case under both frameworks.
+
 ## [0.1.193] — 2026-04-13
 
 ### Fixed

--- a/src/rwa_calc/engine/crm/guarantees.py
+++ b/src/rwa_calc/engine/crm/guarantees.py
@@ -22,8 +22,12 @@ from typing import TYPE_CHECKING
 import polars as pl
 
 from rwa_calc.data.schemas import DIRECT_BENEFICIARY_TYPES
+from rwa_calc.data.tables.eu_sovereign import (
+    build_eu_domestic_currency_expr,
+    denomination_currency_expr,
+)
 from rwa_calc.data.tables.haircuts import FX_HAIRCUT, RESTRUCTURING_EXCLUSION_HAIRCUT
-from rwa_calc.domain.enums import ApproachType
+from rwa_calc.domain.enums import ApproachType, ExposureClass
 from rwa_calc.engine.ccf import (
     drawn_for_ead,
     interest_for_ead,
@@ -184,9 +188,31 @@ def apply_guarantees(
         if ApproachType.FIRB in approaches or ApproachType.AIRB in approaches:
             irb_exposure_class_values.add(ec.value)
 
+    # Art. 114(4)/(7): an EU/UK domestic-currency CGCB guarantor must receive 0% RW
+    # via the SA short-circuit, even if the guarantor has an internal PD that would
+    # otherwise route to IRB parameter substitution.
+    schema_names = exposures.collect_schema().names()
+    has_currency = "original_currency" in schema_names or "currency" in schema_names
+    if has_currency:
+        ccy_expr = denomination_currency_expr(schema_names)
+        cgcb = ExposureClass.CENTRAL_GOVT_CENTRAL_BANK.value
+        is_uk_domestic_cgcb_guarantor = (
+            (pl.col("guarantor_exposure_class") == cgcb)
+            & (pl.col("guarantor_country_code").fill_null("") == "GB")
+            & (ccy_expr == "GBP")
+        )
+        is_eu_domestic_cgcb_guarantor = (
+            pl.col("guarantor_exposure_class") == cgcb
+        ) & build_eu_domestic_currency_expr("guarantor_country_code", ccy_expr)
+        is_domestic_cgcb_guarantor = is_uk_domestic_cgcb_guarantor | is_eu_domestic_cgcb_guarantor
+    else:
+        is_domestic_cgcb_guarantor = pl.lit(False)
+
     exposures = exposures.with_columns(
         [
-            pl.when(
+            pl.when(is_domestic_cgcb_guarantor)
+            .then(pl.lit("sa"))
+            .when(
                 (pl.col("guarantor_exposure_class") != "")
                 & pl.col("guarantor_exposure_class").is_in(list(irb_exposure_class_values))
                 & pl.col("guarantor_internal_pd").is_not_null()

--- a/tests/unit/crm/test_guarantor_rating_type.py
+++ b/tests/unit/crm/test_guarantor_rating_type.py
@@ -22,7 +22,7 @@ from rwa_calc.contracts.bundles import (
     ClassifiedExposuresBundle,
     CounterpartyLookup,
 )
-from rwa_calc.contracts.config import CalculationConfig
+from rwa_calc.contracts.config import CalculationConfig, PermissionMode
 from rwa_calc.engine.crm.guarantees import apply_guarantees
 from rwa_calc.engine.crm.processor import CRMProcessor
 
@@ -39,6 +39,22 @@ def crr_config() -> CalculationConfig:
 @pytest.fixture
 def b31_config() -> CalculationConfig:
     return CalculationConfig.basel_3_1(reporting_date=date(2027, 6, 30))
+
+
+@pytest.fixture
+def crr_irb_config() -> CalculationConfig:
+    """CRR config with full IRB permissions — needed to exercise IRB guarantor routing."""
+    return CalculationConfig.crr(
+        reporting_date=date(2024, 12, 31), permission_mode=PermissionMode.IRB
+    )
+
+
+@pytest.fixture
+def b31_irb_config() -> CalculationConfig:
+    """Basel 3.1 config with full IRB permissions."""
+    return CalculationConfig.basel_3_1(
+        reporting_date=date(2027, 6, 30), permission_mode=PermissionMode.IRB
+    )
 
 
 @pytest.fixture
@@ -444,3 +460,149 @@ class TestGuarantorRatingTypeEdgeCases:
         # Second exposure guaranteed by external-only guarantor
         row1 = result.filter(pl.col("exposure_reference") == "EXP002")
         assert row1["guarantor_rating_type"][0] == "external"
+
+
+# ---------------------------------------------------------------------------
+# Art. 114(4)/(7) priority over internal-rating routing
+# ---------------------------------------------------------------------------
+
+
+def _sovereign_exposure(currency: str, original_currency: str | None = None) -> pl.LazyFrame:
+    """Exposure with currency columns so the EU/UK domestic check has data to read."""
+    cols = {
+        "exposure_reference": ["EXP001"],
+        "counterparty_reference": ["CP001"],
+        "exposure_class": ["corporate"],
+        "approach": ["IRB"],
+        "ead_pre_crm": [1_000_000.0],
+        "lgd": [0.45],
+        "cqs": [3],
+        "product_type": ["LOAN"],
+        "drawn_amount": [1_000_000.0],
+        "undrawn_amount": [0.0],
+        "nominal_amount": [0.0],
+        "risk_type": [None],
+        "interest": [0.0],
+        "maturity_date": [date(2029, 12, 31)],
+        "ead_after_collateral": [1_000_000.0],
+        "ead_from_ccf": [0.0],
+        "ccf": [1.0],
+        "collateral_adjusted_value": [0.0],
+        "lgd_pre_crm": [0.45],
+        "lgd_post_crm": [0.45],
+        "currency": [currency],
+    }
+    if original_currency is not None:
+        cols["original_currency"] = [original_currency]
+    return pl.LazyFrame(cols)
+
+
+def _sovereign_counterparty_lookup(country_code: str) -> pl.LazyFrame:
+    return pl.LazyFrame(
+        {
+            "counterparty_reference": ["GUAR001"],
+            "entity_type": ["sovereign"],
+            "country_code": [country_code],
+        }
+    )
+
+
+class TestDomesticSovereignGuarantorForcedToSA:
+    """Art. 114(4)/(7): EU/UK domestic-currency CGCB guarantor must be routed through
+    SA so the 0% RW short-circuit applies — even when the guarantor has an internal
+    PD that would otherwise route it to IRB parameter substitution.
+    """
+
+    def test_uk_sovereign_with_internal_pd_forced_to_sa(
+        self, crr_irb_config: CalculationConfig
+    ) -> None:
+        """UK sovereign guarantor + GBP + internal PD -> guarantor_approach == 'sa'.
+
+        Without the Art. 114(4) override, the firm's CGCB IRB permission combined with
+        the internal PD would route this to 'irb' and apply parametric IRB RW.
+        """
+        result = apply_guarantees(
+            _sovereign_exposure(currency="GBP"),
+            _guarantee(),
+            _sovereign_counterparty_lookup("GB"),
+            crr_irb_config,
+            rating_inheritance=_rating_inheritance(cqs=2, internal_pd=0.001),
+        ).collect()
+
+        assert result["guarantor_approach"][0] == "sa"
+        # Rating type still reports the underlying rating source
+        assert result["guarantor_rating_type"][0] == "internal"
+
+    def test_de_sovereign_eur_with_internal_pd_forced_to_sa(
+        self, crr_irb_config: CalculationConfig
+    ) -> None:
+        """DE sovereign + EUR (post-FX to GBP) + internal PD -> 'sa' via Art. 114(7)."""
+        result = apply_guarantees(
+            _sovereign_exposure(currency="GBP", original_currency="EUR"),
+            _guarantee(),
+            _sovereign_counterparty_lookup("DE"),
+            crr_irb_config,
+            rating_inheritance=_rating_inheritance(cqs=2, internal_pd=0.001),
+        ).collect()
+
+        assert result["guarantor_approach"][0] == "sa"
+
+    def test_pl_sovereign_pln_with_internal_pd_forced_to_sa(
+        self, crr_irb_config: CalculationConfig
+    ) -> None:
+        """PL sovereign + PLN (post-FX to GBP) + internal PD -> 'sa' (non-euro EU)."""
+        result = apply_guarantees(
+            _sovereign_exposure(currency="GBP", original_currency="PLN"),
+            _guarantee(),
+            _sovereign_counterparty_lookup("PL"),
+            crr_irb_config,
+            rating_inheritance=_rating_inheritance(cqs=2, internal_pd=0.001),
+        ).collect()
+
+        assert result["guarantor_approach"][0] == "sa"
+
+    def test_de_sovereign_usd_with_internal_pd_stays_irb(
+        self, crr_irb_config: CalculationConfig
+    ) -> None:
+        """DE sovereign + USD (non-domestic) + internal PD -> still routed to 'irb'.
+
+        Non-domestic currency means Art. 114(7) does not apply, so the internal-PD
+        routing wins and the guarantor uses the parametric IRB RW.
+        """
+        result = apply_guarantees(
+            _sovereign_exposure(currency="GBP", original_currency="USD"),
+            _guarantee(),
+            _sovereign_counterparty_lookup("DE"),
+            crr_irb_config,
+            rating_inheritance=_rating_inheritance(cqs=2, internal_pd=0.001),
+        ).collect()
+
+        assert result["guarantor_approach"][0] == "irb"
+
+    def test_b31_uk_sovereign_with_internal_pd_forced_to_sa(
+        self, b31_irb_config: CalculationConfig
+    ) -> None:
+        """Basel 3.1: UK sovereign + GBP + internal PD -> 'sa' (Art. 114(4) preserved)."""
+        result = apply_guarantees(
+            _sovereign_exposure(currency="GBP"),
+            _guarantee(),
+            _sovereign_counterparty_lookup("GB"),
+            b31_irb_config,
+            rating_inheritance=_rating_inheritance(cqs=2, internal_pd=0.001),
+        ).collect()
+
+        assert result["guarantor_approach"][0] == "sa"
+
+    def test_b31_de_sovereign_eur_with_internal_pd_forced_to_sa(
+        self, b31_irb_config: CalculationConfig
+    ) -> None:
+        """Basel 3.1: DE sovereign + EUR + internal PD -> 'sa' (Art. 114(7) preserved)."""
+        result = apply_guarantees(
+            _sovereign_exposure(currency="GBP", original_currency="EUR"),
+            _guarantee(),
+            _sovereign_counterparty_lookup("DE"),
+            b31_irb_config,
+            rating_inheritance=_rating_inheritance(cqs=2, internal_pd=0.001),
+        ).collect()
+
+        assert result["guarantor_approach"][0] == "sa"


### PR DESCRIPTION
## Summary

- PR #253 fixed the post-FX `original_currency` handling for the EU/UK domestic CGCB 0% RW, but only inside the SA branch. When the guarantor also carried an internal PD and the firm held IRB permission for CGCB, `apply_guarantees` still routed the guarantor to `guarantor_approach = "irb"`, and `_apply_parameter_substitution` overwrote the 0% SA RW with the parametric F-IRB RW (so a DE sovereign + EUR + `internal_pd = 0.001` produced ~2.6% instead of 0%).
- Promote the Art. 114(4)/(7) domestic CGCB check into the guarantor-approach routing step in `engine/crm/guarantees.py`: domestic-currency CGCB guarantors are now forced to `"sa"` ahead of the internal-PD branch, so the existing SA 0% short-circuit always wins. Mirrors the classifier's existing forced-SA pattern for domestic-sovereign borrowers.
- Framework-agnostic — applies under both CRR (Art. 114(4) UK/GBP, Art. 114(7) EU member states) and Basel 3.1 (PS1/26 preserves Art. 114(7) via third-country reciprocity per `docs/user-guide/exposure-classes/central-govt-central-bank.md`). Reuses `build_eu_domestic_currency_expr` and `denomination_currency_expr` so the post-FX fix from PR #253 still applies.

Resulting priority:
1. EU/UK domestic CGCB -> SA (0%)
2. Internal PD + IRB permission -> IRB
3. External rating -> SA

`guarantor_rating_type` audit field is unchanged — still reports `"internal"` when an internal PD exists; the override is an approach decision, not a rating-source decision.

## Test plan

- [x] `uv run pytest tests/unit/crm/test_guarantor_rating_type.py` — 21 passed incl. 6 new `TestDomesticSovereignGuarantorForcedToSA` cases (UK/GBP, DE/EUR post-FX, PL/PLN post-FX, DE/USD counter-case, plus B3.1 UK and B3.1 DE)
- [x] `uv run pytest tests/` — 5277 passed, 11 deselected
- [x] `uv run python scripts/arch_check.py` — all checks passed