### PR TITLE
refactor(schemas): schema-driven column defaults via ColumnSpec

### DIFF
--- a/scripts/arch_check.py
+++ b/scripts/arch_check.py
@@ -8,11 +8,12 @@ Checks machine-verifiable invariants from CLAUDE.md:
 4. No engine= passed to collect/collect_all (engine choice is config-driven)
 5. No regulatory scalar literals declared in engine/** (must live in data/tables/)
 6. No input-domain string-enum collections declared in engine/** (must live in data/schemas.py)
+7. No inline `"col" not in schema.names()` defaulting in engine/** (use
+   ensure_columns against a ColumnSpec schema in data/schemas.py instead)
 
-Checks 5 and 6 enforce the data/engine separation established by PRs
-#244, #246, #247, #248, #249. Rare intentional exceptions are listed in
-REGULATORY_SCALAR_ALLOWLIST / VALIDATION_ENUM_ALLOWLIST below; adding a new
-entry there should be a deliberate, reviewed decision.
+Checks 5, 6, 7 enforce the data/engine separation. Rare intentional exceptions
+are listed in the ALLOWLIST dicts below; adding a new entry there should be a
+deliberate, reviewed decision.
 
 Usage:
     python scripts/arch_check.py [path]  # defaults to src/rwa_calc/
@@ -69,6 +70,25 @@ VALIDATION_ENUM_ALLOWLIST: dict[str, set[str]] = {
     },
     # Art. 231 allocation column mapping (PR #249 — retained as engine config)
     "engine/crm/expressions.py": {"CRM_ALLOC_COLUMNS"},
+}
+
+# Files where an inline `"col" not in schema.names()` check is a legitimate
+# non-defaulting pattern (early-exit guard, optional-output-column detection,
+# combined warning+default emission). New entries require explicit justification
+# — schema-driven defaults otherwise belong in ensure_columns + ColumnSpec.
+SCHEMA_DEFAULTS_ALLOWLIST: set[str] = {
+    # Optional-output column detection for COREP comparison frame.
+    "engine/comparison.py",
+    # Early-exit guards (netting / parent-facility detection, CRM output check)
+    # — not defaulting.
+    "engine/crm/collateral.py",
+    "engine/crm/simple_method.py",
+    # Combined warning + default emission for PD / LGD under IRB — the warning
+    # is part of the data-quality contract and doesn't fit ensure_columns.
+    "engine/irb/calculator.py",
+    # `ead_final` derivation (fair_value → carrying_value → ead → 0.0) — this
+    # is a multi-source fallback, not a simple default.
+    "engine/equity/calculator.py",
 }
 
 
@@ -293,6 +313,47 @@ def check_no_regulatory_scalars_in_engine(path: Path) -> list[str]:
     return violations
 
 
+def check_no_inline_schema_defaults(path: Path) -> list[str]:
+    """No inline `"col" not in schema.names()` / `"col" not in df.columns` in engine/**.
+
+    The schema-driven replacement is ``ensure_columns(lf, <SCHEMA>)`` where
+    ``<SCHEMA>`` is a ``dict[str, ColumnSpec]`` from ``data/schemas.py`` (or an
+    ad-hoc fragment). Exemptions:
+
+    - Per-file: listed in ``SCHEMA_DEFAULTS_ALLOWLIST`` (for files that are
+      systematically exempt, e.g. early-exit guards throughout).
+    - Per-line: append ``# arch-exempt: <reason>`` to the line to document why
+      the inline pattern is the right tool (derivation, multi-source fallback,
+      etc.).
+    """
+    violations: list[str] = []
+    pattern = re.compile(
+        r'"[^"]+"\s+not\s+in\s+(?:\w+\.collect_schema\(\)\.names\(\)|\w+\.names\(\)|\w+\.columns)'
+    )
+    exempt_marker = re.compile(r"#\s*arch-exempt\b")
+    for py_file in _iter_engine_files(path):
+        rel = py_file.relative_to(path).as_posix()
+        if rel in SCHEMA_DEFAULTS_ALLOWLIST:
+            continue
+        try:
+            text = py_file.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for i, line in enumerate(text.split("\n"), 1):
+            stripped = line.strip()
+            if stripped.startswith(("#", '"""', "'''")):
+                continue
+            if exempt_marker.search(line):
+                continue
+            if pattern.search(line):
+                violations.append(
+                    f"  {py_file}:{i}: inline `not in schema.names()` -- "
+                    "use ensure_columns against a ColumnSpec schema "
+                    "(or append '# arch-exempt: <reason>' if intentional)"
+                )
+    return violations
+
+
 def check_no_validation_enums_in_engine(path: Path) -> list[str]:
     """Module-level string-enum collections belong in data/schemas.py, not engine/**."""
     violations: list[str] = []
@@ -334,6 +395,10 @@ def main() -> int:
         (
             "No validation string-enums in engine/ (use data/schemas.py)",
             check_no_validation_enums_in_engine,
+        ),
+        (
+            "No inline `not in schema.names()` in engine/ (use ensure_columns)",
+            check_no_inline_schema_defaults,
         ),
     ]
 

--- a/src/rwa_calc/contracts/validation.py
+++ b/src/rwa_calc/contracts/validation.py
@@ -25,6 +25,7 @@ from rwa_calc.contracts.errors import (
     ErrorCategory,
     ErrorSeverity,
 )
+from rwa_calc.data.column_spec import ColumnSpec
 
 if TYPE_CHECKING:
     from rwa_calc.contracts.bundles import (
@@ -35,9 +36,19 @@ if TYPE_CHECKING:
     )
 
 
+def _as_dtype(entry: pl.DataType | ColumnSpec) -> pl.DataType:
+    """Unwrap a schema entry to its dtype — accepts either a raw Polars dtype or a ColumnSpec."""
+    return entry.dtype if isinstance(entry, ColumnSpec) else entry
+
+
+def _is_required(entry: pl.DataType | ColumnSpec) -> bool:
+    """True if a schema entry represents a required column (raw dtypes are treated as required)."""
+    return entry.required if isinstance(entry, ColumnSpec) else True
+
+
 def validate_schema(
     lf: pl.LazyFrame,
-    expected_schema: dict[str, pl.DataType],
+    expected_schema: dict[str, pl.DataType] | dict[str, ColumnSpec],
     context: str = "",
     strict: bool = False,
 ) -> list[str]:
@@ -70,8 +81,11 @@ def validate_schema(
     context_prefix = f"[{context}] " if context else ""
 
     # Check for missing columns
-    for col_name, expected_type in expected_schema.items():
+    for col_name, entry in expected_schema.items():
+        expected_type = _as_dtype(entry)
         if col_name not in actual_schema:
+            if not _is_required(entry):
+                continue
             errors.append(
                 f"{context_prefix}Missing column: '{col_name}' (expected type: {expected_type})"
             )
@@ -146,7 +160,7 @@ def validate_required_columns(
 
 def validate_schema_to_errors(
     lf: pl.LazyFrame,
-    expected_schema: dict[str, pl.DataType],
+    expected_schema: dict[str, pl.DataType] | dict[str, ColumnSpec],
     context: str = "",
     optional_columns: set[str] | None = None,
 ) -> list[CalculationError]:
@@ -158,8 +172,10 @@ def validate_schema_to_errors(
     Args:
         lf: LazyFrame to validate
         expected_schema: Dict mapping column names to expected Polars types
+            or to ColumnSpec entries. Raw dtypes are treated as required.
         context: Context string for error messages
-        optional_columns: Column names that may be absent without error
+        optional_columns: Extra column names that may be absent without error
+            (merged with any ``required=False`` markers on ColumnSpec entries).
 
     Returns:
         List of CalculationError objects for any schema issues
@@ -167,9 +183,12 @@ def validate_schema_to_errors(
     errors: list[CalculationError] = []
     actual_schema = lf.collect_schema()
 
-    for col_name, expected_type in expected_schema.items():
+    for col_name, entry in expected_schema.items():
+        expected_type = _as_dtype(entry)
         if col_name not in actual_schema:
             if optional_columns and col_name in optional_columns:
+                continue
+            if not _is_required(entry):
                 continue
             errors.append(
                 CalculationError(
@@ -201,7 +220,7 @@ def validate_schema_to_errors(
 
 def validate_raw_data_bundle(
     bundle: RawDataBundle,
-    schemas: dict[str, dict[str, pl.DataType]],
+    schemas: dict[str, dict[str, pl.DataType] | dict[str, ColumnSpec]],
 ) -> list[CalculationError]:
     """
     Validate all LazyFrames in a RawDataBundle against expected schemas.
@@ -230,21 +249,11 @@ def validate_raw_data_bundle(
         "model_permissions": bundle.model_permissions,
     }
 
-    from rwa_calc.data.schemas import MODEL_PERMISSIONS_OPTIONAL_COLUMNS
-
-    # Registry of optional columns per table (columns that may be absent from input)
-    optional_columns_registry: dict[str, set[str]] = {
-        "model_permissions": MODEL_PERMISSIONS_OPTIONAL_COLUMNS,
-    }
-
+    # Optional-column semantics now live on ColumnSpec entries (required=False);
+    # no separate optional_columns_registry is needed.
     for name, lf in frame_mapping.items():
         if name in schemas and lf is not None:
-            errors = validate_schema_to_errors(
-                lf,
-                schemas[name],
-                context=name,
-                optional_columns=optional_columns_registry.get(name),
-            )
+            errors = validate_schema_to_errors(lf, schemas[name], context=name)
             all_errors.extend(errors)
 
     return all_errors

--- a/src/rwa_calc/data/column_spec.py
+++ b/src/rwa_calc/data/column_spec.py
@@ -1,0 +1,74 @@
+"""
+Column specification for schema-driven DataFrame defaults.
+
+Pipeline position:
+    Shared data-layer primitive — used by data/schemas.py declarations and
+    by engine stages (loader, calculators) that need to ensure columns exist
+    before calculation.
+
+Key responsibilities:
+- Declare per-column metadata (dtype, default, required) in one place
+- Fill missing optional columns on a LazyFrame with declared defaults
+- Project a ColumnSpec schema down to a plain dtype dict for
+  Polars constructors that require {name: dtype}
+
+References:
+- CLAUDE.md — data/engine separation; data/tables and data/schemas are the
+  only modules permitted to declare regulatory / pipeline-default values.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import polars as pl
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+
+@dataclass(frozen=True, slots=True)
+class ColumnSpec:
+    """Declarative metadata for a single DataFrame column.
+
+    Attributes:
+        dtype: Polars dtype the column is cast to on load.
+        default: Fill value applied by ``ensure_columns`` when the column is
+            absent. Ignored when ``required`` is True.
+        required: When True, a missing column is a data-quality error; the
+            loader must fail (or emit a CalculationError). When False, a
+            missing column is filled via ``ensure_columns`` using ``default``.
+    """
+
+    dtype: pl.DataType
+    default: object = None
+    required: bool = True
+
+
+def ensure_columns(lf: pl.LazyFrame, schema: Mapping[str, ColumnSpec]) -> pl.LazyFrame:
+    """Add optional columns from ``schema`` that are missing on ``lf``.
+
+    Required columns are never added — the loader is responsible for raising
+    a data-quality error when a required input column is missing. Columns
+    already present on ``lf`` are left untouched (including their existing
+    dtype — this function does not re-cast).
+    """
+    existing = set(lf.collect_schema().names())
+    missing = [
+        pl.lit(spec.default).cast(spec.dtype).alias(name)
+        for name, spec in schema.items()
+        if not spec.required and name not in existing
+    ]
+    if not missing:
+        return lf
+    return lf.with_columns(missing)
+
+
+def dtypes_of(schema: Mapping[str, ColumnSpec]) -> dict[str, pl.DataType]:
+    """Project a ColumnSpec schema down to ``{column_name: dtype}``.
+
+    Polars constructors (``pl.DataFrame(..., schema=...)``, ``pl.LazyFrame``)
+    accept a plain dtype dict; this helper is the bridge for those call sites.
+    """
+    return {name: spec.dtype for name, spec in schema.items()}

--- a/src/rwa_calc/data/schemas.py
+++ b/src/rwa_calc/data/schemas.py
@@ -55,89 +55,91 @@ from __future__ import annotations
 
 import polars as pl
 
-FACILITY_SCHEMA = {
-    "facility_reference": pl.String,
-    "product_type": pl.String,
-    "book_code": pl.String,
-    "counterparty_reference": pl.String,
-    "value_date": pl.Date,
-    "maturity_date": pl.Date,
-    "currency": pl.String,
-    "limit": pl.Float64,
-    "committed": pl.Boolean,
-    "lgd": pl.Float64,
-    "lgd_unsecured": pl.Float64,  # Art. 169B(2)(c): firm's own unsecured LGD estimate (no collateral recoveries)
-    "has_sufficient_collateral_data": pl.Boolean,  # Art. 169A/169B: True=full LGD modelling, False=Foundation fallback
-    "beel": pl.Float64,
-    "is_revolving": pl.Boolean,
-    "is_qrre_transactor": pl.Boolean,  # QRRE transactor flag (CRR Art. 147(5), CRE30.55) — True if borrower repays in full each period
-    "seniority": pl.String,  # senior, subordinated - affects F-IRB LGD (45% vs 75%)
-    "risk_type": pl.String,  # Mandatory: FR, FRC, MR, OC, MLR, LR - determines CCF (Art. 111)
-    "underlying_risk_type": pl.String,  # Optional: Art. 111(1)(c) - risk type of OBS item the commitment issues
-    "ccf_modelled": pl.Float64,  # Optional: A-IRB modelled CCF (0.0-1.5, can exceed 100% for retail)
-    "ead_modelled": pl.Float64,  # Optional: A-IRB modelled facility-level EAD (Art. 166D(3)/(4))
-    "is_short_term_trade_lc": pl.Boolean,  # Short-term LC for goods movement - 20% CCF under F-IRB (Art. 166(9))
-    "is_payroll_loan": pl.Boolean,  # Payroll/pension loan — 35% RW under Basel 3.1 (Art. 123(3)(a-b))
-    "is_buy_to_let": pl.Boolean,  # BTL property lending - excluded from SME supporting factor (CRR Art. 501)
-    "has_one_day_maturity_floor": pl.Boolean,  # Art. 162(3): repos/SFTs with daily margining — 1-day M floor
-    "facility_termination_date": pl.Date,  # Art. 162(2A)(k): max contractual termination date for revolving facilities (Basel 3.1 M)
+from rwa_calc.data.column_spec import ColumnSpec
+
+FACILITY_SCHEMA: dict[str, ColumnSpec] = {
+    "facility_reference": ColumnSpec(pl.String),
+    "product_type": ColumnSpec(pl.String, required=False),
+    "book_code": ColumnSpec(pl.String, default="", required=False),
+    "counterparty_reference": ColumnSpec(pl.String),
+    "value_date": ColumnSpec(pl.Date, required=False),
+    "maturity_date": ColumnSpec(pl.Date, required=False),
+    "currency": ColumnSpec(pl.String, required=False),
+    "limit": ColumnSpec(pl.Float64, required=False),
+    "committed": ColumnSpec(pl.Boolean, default=False, required=False),
+    "lgd": ColumnSpec(pl.Float64, required=False),
+    "lgd_unsecured": ColumnSpec(pl.Float64, required=False),
+    "has_sufficient_collateral_data": ColumnSpec(pl.Boolean, default=False, required=False),
+    "beel": ColumnSpec(pl.Float64, required=False),
+    "is_revolving": ColumnSpec(pl.Boolean, default=False, required=False),
+    "is_qrre_transactor": ColumnSpec(pl.Boolean, default=False, required=False),
+    "seniority": ColumnSpec(pl.String, default="senior", required=False),
+    "risk_type": ColumnSpec(pl.String, required=False),
+    "underlying_risk_type": ColumnSpec(pl.String, required=False),
+    "ccf_modelled": ColumnSpec(pl.Float64, required=False),
+    "ead_modelled": ColumnSpec(pl.Float64, required=False),
+    "is_short_term_trade_lc": ColumnSpec(pl.Boolean, default=False, required=False),
+    "is_payroll_loan": ColumnSpec(pl.Boolean, default=False, required=False),
+    "is_buy_to_let": ColumnSpec(pl.Boolean, default=False, required=False),
+    "has_one_day_maturity_floor": ColumnSpec(pl.Boolean, default=False, required=False),
+    "facility_termination_date": ColumnSpec(pl.Date, required=False),
 }
 
-LOAN_SCHEMA = {
-    "loan_reference": pl.String,
-    "product_type": pl.String,
-    "book_code": pl.String,
-    "counterparty_reference": pl.String,
-    "value_date": pl.Date,
-    "maturity_date": pl.Date,
-    "currency": pl.String,
-    "drawn_amount": pl.Float64,
-    "interest": pl.Float64,  # Accrued interest (adds to on-balance-sheet EAD, not undrawn)
-    "lgd": pl.Float64,  # A-IRB modelled LGD (optional)
-    "lgd_unsecured": pl.Float64,  # Art. 169B(2)(c): firm's own unsecured LGD estimate (no collateral recoveries)
-    "has_sufficient_collateral_data": pl.Boolean,  # Art. 169A/169B: True=full LGD modelling, False=Foundation fallback
-    "beel": pl.Float64,  # Best estimate expected loss
-    "seniority": pl.String,  # senior, subordinated - affects F-IRB LGD (45% vs 75%)
-    "is_payroll_loan": pl.Boolean,  # Payroll/pension loan — 35% RW under Basel 3.1 (Art. 123(3)(a-b))
-    "is_buy_to_let": pl.Boolean,  # BTL property lending - excluded from SME supporting factor (CRR Art. 501)
-    "has_one_day_maturity_floor": pl.Boolean,  # Art. 162(3): repos/SFTs with daily margining — 1-day M floor
-    "has_netting_agreement": pl.Boolean,  # CRR Art. 195: on-balance sheet netting
-    "netting_facility_reference": pl.String,  # Facility the netting agreement applies to (defaults to root)
-    "due_diligence_performed": pl.Boolean,  # Art. 110A: firm has performed due diligence (B31 only)
-    "due_diligence_override_rw": pl.Float64,  # Art. 110A: override RW when DD reveals higher risk (B31 only)
+LOAN_SCHEMA: dict[str, ColumnSpec] = {
+    "loan_reference": ColumnSpec(pl.String),
+    "product_type": ColumnSpec(pl.String, required=False),
+    "book_code": ColumnSpec(pl.String, default="", required=False),
+    "counterparty_reference": ColumnSpec(pl.String),
+    "value_date": ColumnSpec(pl.Date, required=False),
+    "maturity_date": ColumnSpec(pl.Date, required=False),
+    "currency": ColumnSpec(pl.String, required=False),
+    "drawn_amount": ColumnSpec(pl.Float64, default=0.0, required=False),
+    "interest": ColumnSpec(pl.Float64, default=0.0, required=False),
+    "lgd": ColumnSpec(pl.Float64, required=False),
+    "lgd_unsecured": ColumnSpec(pl.Float64, required=False),
+    "has_sufficient_collateral_data": ColumnSpec(pl.Boolean, default=False, required=False),
+    "beel": ColumnSpec(pl.Float64, required=False),
+    "seniority": ColumnSpec(pl.String, default="senior", required=False),
+    "is_payroll_loan": ColumnSpec(pl.Boolean, default=False, required=False),
+    "is_buy_to_let": ColumnSpec(pl.Boolean, default=False, required=False),
+    "has_one_day_maturity_floor": ColumnSpec(pl.Boolean, default=False, required=False),
+    "has_netting_agreement": ColumnSpec(pl.Boolean, default=False, required=False),
+    "netting_facility_reference": ColumnSpec(pl.String, required=False),
+    "due_diligence_performed": ColumnSpec(pl.Boolean, default=False, required=False),
+    "due_diligence_override_rw": ColumnSpec(pl.Float64, required=False),
     # Note: CCF fields (risk_type, ccf_modelled, is_short_term_trade_lc) are NOT included
     # because CCF only applies to off-balance sheet items (undrawn commitments, contingents).
     # Drawn loans are already on-balance sheet, so EAD = drawn_amount + interest directly.
 }
 
-CONTINGENTS_SCHEMA = {
-    "contingent_reference": pl.String,
-    "product_type": pl.String,
-    "book_code": pl.String,
-    "counterparty_reference": pl.String,
-    "value_date": pl.Date,
-    "maturity_date": pl.Date,
-    "currency": pl.String,
-    "nominal_amount": pl.Float64,
-    "lgd": pl.Float64,
-    "lgd_unsecured": pl.Float64,  # Art. 169B(2)(c): firm's own unsecured LGD estimate (no collateral recoveries)
-    "has_sufficient_collateral_data": pl.Boolean,  # Art. 169A/169B: True=full LGD modelling, False=Foundation fallback
-    "beel": pl.Float64,
-    "seniority": pl.String,  # senior, subordinated - affects F-IRB LGD (45% vs 75%)
-    "risk_type": pl.String,  # Mandatory: FR, FRC, MR, OC, MLR, LR - determines CCF (Art. 111)
-    "underlying_risk_type": pl.String,  # Optional: Art. 111(1)(c) - risk type of OBS item the commitment issues
-    "ccf_modelled": pl.Float64,  # Optional: A-IRB modelled CCF (0.0-1.5, can exceed 100% for retail)
-    "ead_modelled": pl.Float64,  # Optional: A-IRB modelled facility-level EAD (Art. 166D(3)/(4))
-    "is_short_term_trade_lc": pl.Boolean,  # Short-term LC for goods movement - 20% CCF under F-IRB (Art. 166(9))
-    "has_one_day_maturity_floor": pl.Boolean,  # Art. 162(3): repos/SFTs with daily margining — 1-day M floor
-    "bs_type": pl.String,  # ONB (on-balance-sheet / drawn) or OFB (off-balance-sheet / undrawn), default OFB
-    "due_diligence_performed": pl.Boolean,  # Art. 110A: firm has performed due diligence (B31 only)
-    "due_diligence_override_rw": pl.Float64,  # Art. 110A: override RW when DD reveals higher risk (B31 only)
+CONTINGENTS_SCHEMA: dict[str, ColumnSpec] = {
+    "contingent_reference": ColumnSpec(pl.String),
+    "product_type": ColumnSpec(pl.String, required=False),
+    "book_code": ColumnSpec(pl.String, default="", required=False),
+    "counterparty_reference": ColumnSpec(pl.String),
+    "value_date": ColumnSpec(pl.Date, required=False),
+    "maturity_date": ColumnSpec(pl.Date, required=False),
+    "currency": ColumnSpec(pl.String, required=False),
+    "nominal_amount": ColumnSpec(pl.Float64, default=0.0, required=False),
+    "lgd": ColumnSpec(pl.Float64, required=False),
+    "lgd_unsecured": ColumnSpec(pl.Float64, required=False),
+    "has_sufficient_collateral_data": ColumnSpec(pl.Boolean, default=False, required=False),
+    "beel": ColumnSpec(pl.Float64, required=False),
+    "seniority": ColumnSpec(pl.String, default="senior", required=False),
+    "risk_type": ColumnSpec(pl.String, required=False),
+    "underlying_risk_type": ColumnSpec(pl.String, required=False),
+    "ccf_modelled": ColumnSpec(pl.Float64, required=False),
+    "ead_modelled": ColumnSpec(pl.Float64, required=False),
+    "is_short_term_trade_lc": ColumnSpec(pl.Boolean, default=False, required=False),
+    "has_one_day_maturity_floor": ColumnSpec(pl.Boolean, default=False, required=False),
+    "bs_type": ColumnSpec(pl.String, default="OFB", required=False),
+    "due_diligence_performed": ColumnSpec(pl.Boolean, default=False, required=False),
+    "due_diligence_override_rw": ColumnSpec(pl.Float64, required=False),
 }
 
-COUNTERPARTY_SCHEMA = {
-    "counterparty_reference": pl.String,
-    "counterparty_name": pl.String,
+COUNTERPARTY_SCHEMA: dict[str, ColumnSpec] = {
+    "counterparty_reference": ColumnSpec(pl.String),
+    "counterparty_name": ColumnSpec(pl.String, required=False),
     # entity_type: Single source of truth for exposure class determination.
     # Maps directly to SA and IRB exposure classes. Valid values:
     #   Central govt/central bank class:
@@ -171,119 +173,104 @@ COUNTERPARTY_SCHEMA = {
     #     - "other_items_in_collection" → SA: OTHER, 20% RW (Art. 134(3))
     #     - "other_tangible"          → SA: OTHER, 100% RW (Art. 134(2))
     #     - "other_residual_lease"    → SA: OTHER, 1/t × 100% RW (Art. 134(6))
-    "entity_type": pl.String,
-    "country_code": pl.String,
-    "annual_revenue": pl.Float64,  # For SME classification (EUR 50m threshold)
-    "total_assets": pl.Float64,  # For large financial sector entity threshold (EUR 70bn, CRR Art. 4(1)(146))
-    "default_status": pl.Boolean,
-    "sector_code": pl.String,  # Based on SIC
-    # Retained boolean flags - orthogonal to entity_type classification
-    "apply_fi_scalar": pl.Boolean,  # 1.25x IRB correlation for LFSE/unregulated FSE (CRR Art. 153(2))
-    "is_managed_as_retail": pl.Boolean,  # SME managed on pooled retail basis - 75% RW (CRR Art. 123)
-    "is_natural_person": pl.Boolean,  # Natural person counterparty — Art. 124H(1) CRE loan-splitting
-    "is_social_housing": pl.Boolean,  # Art. 124L: social housing provider — max(75%, unsecured RW) for RRE
-    "is_financial_sector_entity": pl.Boolean,  # All FSEs → F-IRB only under B31 (Art. 147A(1)(e))
-    # Basel 3.1 fields (CRE20.16-21, CRE20.47-49)
-    "scra_grade": pl.String,  # SCRA grade: "A"/"A_ENHANCED"/"B"/"C" (Basel 3.1 CRE20.16-21)
-    "is_investment_grade": pl.Boolean,  # Publicly traded + investment grade → 65% SA RW (Basel 3.1 CRE20.47)
-    # CCP fields (CRR Art. 300-311, CRE54.14-15)
-    "is_ccp_client_cleared": pl.Boolean,  # True = client-cleared (4% RW); False/null = proprietary (2% RW)
-    # Currency mismatch (Basel 3.1 Art. 123B / CRE20.93)
-    "borrower_income_currency": pl.String,  # ISO currency of borrower's primary income source
-    # Sovereign floor for FX institution exposures (Art. 121(6) / CRE20.22)
-    "sovereign_cqs": pl.Int32,  # CQS of the sovereign of the institution's jurisdiction (1-6)
-    "local_currency": pl.String,  # ISO 4217 domestic currency of the institution's jurisdiction
-    # Covered bond issuer institution CQS (Art. 129(5) derivation)
-    "institution_cqs": pl.Int8,  # CQS of the issuing institution (1-6); null = unrated
+    "entity_type": ColumnSpec(pl.String),
+    "country_code": ColumnSpec(pl.String, required=False),
+    "annual_revenue": ColumnSpec(pl.Float64, required=False),
+    "total_assets": ColumnSpec(pl.Float64, required=False),
+    "default_status": ColumnSpec(pl.Boolean, default=False, required=False),
+    "sector_code": ColumnSpec(pl.String, required=False),
+    "apply_fi_scalar": ColumnSpec(pl.Boolean, default=False, required=False),
+    "is_managed_as_retail": ColumnSpec(pl.Boolean, default=False, required=False),
+    "is_natural_person": ColumnSpec(pl.Boolean, default=False, required=False),
+    "is_social_housing": ColumnSpec(pl.Boolean, default=False, required=False),
+    "is_financial_sector_entity": ColumnSpec(pl.Boolean, default=False, required=False),
+    "scra_grade": ColumnSpec(pl.String, required=False),
+    "is_investment_grade": ColumnSpec(pl.Boolean, default=False, required=False),
+    "is_ccp_client_cleared": ColumnSpec(pl.Boolean, required=False),
+    "borrower_income_currency": ColumnSpec(pl.String, required=False),
+    "sovereign_cqs": ColumnSpec(pl.Int32, required=False),
+    "local_currency": ColumnSpec(pl.String, required=False),
+    "institution_cqs": ColumnSpec(pl.Int8, required=False),
 }
 
-COLLATERAL_SCHEMA = {
-    "collateral_reference": pl.String,
-    "collateral_type": pl.String,  # cash, gold, equity, bond, real_estate, receivables, other_physical
-    "currency": pl.String,
-    "maturity_date": pl.Date,
-    "market_value": pl.Float64,
-    "nominal_value": pl.Float64,
-    "pledge_percentage": pl.Float64,  # Fraction of beneficiary EAD (0.5 = 50%), used when market_value not provided
-    "beneficiary_type": pl.String,  # counterparty/loan/facility/contingent
-    "beneficiary_reference": pl.String,  # reference to find on the above tables
-    # For securities collateral - haircut determination (CRE22.52-53)
-    "issuer_cqs": pl.Int8,  # Credit Quality Step of issuer (1-6) for haircut lookup
-    "issuer_type": pl.String,  # sovereign, pse, corporate, securitisation - for haircut table
-    "residual_maturity_years": pl.Float64,  # For haircut bands: <=1yr, 1-3yr, 3-5yr, 5-10yr, >10yr
-    "original_maturity_years": pl.Float64,  # Original contract term — Art. 237(2): <1yr makes protection ineligible
-    # Eligibility flags
-    "is_eligible_financial_collateral": pl.Boolean,  # Meets SA eligibility (CRR Art 197, CRE22.40)
-    "is_eligible_irb_collateral": pl.Boolean,  # Meets IRB eligibility - wider pool (CRR Art 199)
-    # Equity index membership (Art. 224 Table 3/4)
-    "is_main_index": pl.Boolean,  # True = main-index equity (CRR 15%, B31 20%); False = other listed (CRR 25%, B31 30%)
-    # Valuation requirements (CRE22.75-78)
-    "valuation_date": pl.Date,  # Date of last valuation
-    "valuation_type": pl.String,  # market, indexed, independent - RE must be independent
-    # Real estate specific fields (CRE20.71-87)
-    "property_type": pl.String,  # residential, commercial - different RW tables
-    "property_ltv": pl.Float64,  # Loan-to-value ratio for SA RW lookup (20%-70% bands)
-    "is_income_producing": pl.Boolean,  # Material income dependence affects commercial RE RW
-    "is_adc": pl.Boolean,  # Acquisition/Development/Construction - 150% RW unless pre-sold
-    "is_presold": pl.Boolean,  # ADC pre-sold to qualifying buyer - 100% RW
-    "is_qualifying_re": pl.Boolean,  # Art. 124A: meets regulatory RE criteria (valuation, lien, etc.)
-    "prior_charge_ltv": pl.Float64,  # Art. 124F(2): LTV occupied by prior/pari passu charges (0.0 = first charge)
-    "liquidation_period_days": pl.Int32,  # Art. 224(2): 5=repo, 10=capital market (default), 20=secured lending
-    # Art. 227 zero-haircut eligibility for repo-style transactions
-    "qualifies_for_zero_haircut": pl.Boolean,  # Art. 227: all 8 conditions (a)-(h) met (institution certification)
-    # Life insurance collateral (Art. 232)
-    "insurer_risk_weight": pl.Float64,  # SA risk weight of insurer (0.20, 0.30, 0.50, 0.65, 1.00, 1.35, 1.50)
-    # Credit-linked notes (Art. 218): set market_value = nominal_value - credit_event_reduction
-    "credit_event_reduction": pl.Float64,  # Reduction in CLN nominal from credit events
+COLLATERAL_SCHEMA: dict[str, ColumnSpec] = {
+    "collateral_reference": ColumnSpec(pl.String),
+    "collateral_type": ColumnSpec(pl.String),
+    "currency": ColumnSpec(pl.String, required=False),
+    "maturity_date": ColumnSpec(pl.Date, required=False),
+    "market_value": ColumnSpec(pl.Float64, required=False),
+    "nominal_value": ColumnSpec(pl.Float64, required=False),
+    "pledge_percentage": ColumnSpec(pl.Float64, required=False),
+    "beneficiary_type": ColumnSpec(pl.String),
+    "beneficiary_reference": ColumnSpec(pl.String),
+    "issuer_cqs": ColumnSpec(pl.Int8, required=False),
+    "issuer_type": ColumnSpec(pl.String, required=False),
+    "residual_maturity_years": ColumnSpec(pl.Float64, required=False),
+    "original_maturity_years": ColumnSpec(pl.Float64, required=False),
+    "is_eligible_financial_collateral": ColumnSpec(pl.Boolean, default=False, required=False),
+    "is_eligible_irb_collateral": ColumnSpec(pl.Boolean, default=False, required=False),
+    "is_main_index": ColumnSpec(pl.Boolean, default=False, required=False),
+    "valuation_date": ColumnSpec(pl.Date, required=False),
+    "valuation_type": ColumnSpec(pl.String, required=False),
+    "property_type": ColumnSpec(pl.String, required=False),
+    "property_ltv": ColumnSpec(pl.Float64, required=False),
+    "is_income_producing": ColumnSpec(pl.Boolean, default=False, required=False),
+    "is_adc": ColumnSpec(pl.Boolean, default=False, required=False),
+    "is_presold": ColumnSpec(pl.Boolean, default=False, required=False),
+    "is_qualifying_re": ColumnSpec(pl.Boolean, required=False),
+    "prior_charge_ltv": ColumnSpec(pl.Float64, default=0.0, required=False),
+    "liquidation_period_days": ColumnSpec(pl.Int32, required=False),
+    "qualifies_for_zero_haircut": ColumnSpec(pl.Boolean, default=False, required=False),
+    "insurer_risk_weight": ColumnSpec(pl.Float64, required=False),
+    "credit_event_reduction": ColumnSpec(pl.Float64, default=0.0, required=False),
 }
 
-GUARANTEE_SCHEMA = {
-    "guarantee_reference": pl.String,
-    "guarantee_type": pl.String,
-    "guarantor": pl.String,
-    "currency": pl.String,
-    "maturity_date": pl.Date,
-    "amount_covered": pl.Float64,
-    "percentage_covered": pl.Float64,
-    "beneficiary_type": pl.String,
-    "beneficiary_reference": pl.String,
-    "protection_type": pl.String,  # "guarantee" or "credit_derivative" (CDS/CLN/TRS)
-    "includes_restructuring": pl.Boolean,  # CDS credit event coverage (Art. 233(2))
+GUARANTEE_SCHEMA: dict[str, ColumnSpec] = {
+    "guarantee_reference": ColumnSpec(pl.String),
+    "guarantee_type": ColumnSpec(pl.String, required=False),
+    "guarantor": ColumnSpec(pl.String),
+    "currency": ColumnSpec(pl.String, required=False),
+    "maturity_date": ColumnSpec(pl.Date, required=False),
+    "amount_covered": ColumnSpec(pl.Float64, required=False),
+    "percentage_covered": ColumnSpec(pl.Float64, required=False),
+    "beneficiary_type": ColumnSpec(pl.String),
+    "beneficiary_reference": ColumnSpec(pl.String),
+    "protection_type": ColumnSpec(pl.String, default="guarantee", required=False),
+    "includes_restructuring": ColumnSpec(pl.Boolean, default=False, required=False),
 }
 
-PROVISION_SCHEMA = {
-    "provision_reference": pl.String,
-    "provision_type": pl.String,  # SCRA (Specific), GCRA (General)
-    "ifrs9_stage": pl.Int8,  # 1, 2, or 3
-    "currency": pl.String,
-    "amount": pl.Float64,
-    "as_of_date": pl.Date,
-    "beneficiary_type": pl.String,  # counterparty/loan/facility/contingent
-    "beneficiary_reference": pl.String,  # reference to find on the above tables
+PROVISION_SCHEMA: dict[str, ColumnSpec] = {
+    "provision_reference": ColumnSpec(pl.String),
+    "provision_type": ColumnSpec(pl.String, required=False),
+    "ifrs9_stage": ColumnSpec(pl.Int8, required=False),
+    "currency": ColumnSpec(pl.String, required=False),
+    "amount": ColumnSpec(pl.Float64, default=0.0, required=False),
+    "as_of_date": ColumnSpec(pl.Date, required=False),
+    "beneficiary_type": ColumnSpec(pl.String),
+    "beneficiary_reference": ColumnSpec(pl.String),
 }
 
-RATINGS_SCHEMA = {
-    "rating_reference": pl.String,
-    "counterparty_reference": pl.String,
-    "rating_type": pl.String,  # internal, external
-    "rating_agency": pl.String,  # internal, S&P, Moodys, Fitch, DBRS, etc.
-    "rating_value": pl.String,  # AAA, AA+, Aa1, etc.
-    "cqs": pl.Int8,  # Credit Quality Step 1-6
-    "pd": pl.Float64,  # Probability of Default (for internal ratings)
-    "rating_date": pl.Date,
-    "is_solicited": pl.Boolean,
-    # IRB model assignment — flows through rating inheritance pipeline to exposures
-    "model_id": pl.String,  # IRB model identifier — links to model_permissions for per-model approach gating
+RATINGS_SCHEMA: dict[str, ColumnSpec] = {
+    "rating_reference": ColumnSpec(pl.String),
+    "counterparty_reference": ColumnSpec(pl.String),
+    "rating_type": ColumnSpec(pl.String),
+    "rating_agency": ColumnSpec(pl.String, required=False),
+    "rating_value": ColumnSpec(pl.String, required=False),
+    "cqs": ColumnSpec(pl.Int8, required=False),
+    "pd": ColumnSpec(pl.Float64, required=False),
+    "rating_date": ColumnSpec(pl.Date, required=False),
+    "is_solicited": ColumnSpec(pl.Boolean, default=True, required=False),
+    "model_id": ColumnSpec(pl.String, required=False),
 }
 
 # Specialised Lending exposures - slotting approach (CRE33.1-8, PS1/26 Ch.5)
 # These are corporate exposures with specific risk characteristics requiring separate treatment
-SPECIALISED_LENDING_SCHEMA = {
-    "counterparty_reference": pl.String,  # Links to counterparty (all exposures inherit SL treatment)
-    "sl_type": pl.String,  # project_finance, object_finance, commodities_finance, ipre, hvcre
-    "project_phase": pl.String,  # pre_operational, operational, high_quality_operational (project_finance only)
-    "slotting_category": pl.String,  # strong, good, satisfactory, weak, default
-    "is_hvcre": pl.Boolean,  # High-volatility commercial real estate (higher RW)
+SPECIALISED_LENDING_SCHEMA: dict[str, ColumnSpec] = {
+    "counterparty_reference": ColumnSpec(pl.String),
+    "sl_type": ColumnSpec(pl.String),
+    "project_phase": ColumnSpec(pl.String, required=False),
+    "slotting_category": ColumnSpec(pl.String, required=False),
+    "is_hvcre": ColumnSpec(pl.Boolean, default=False, required=False),
     # Supervisory risk weights by category (CRE33.5):
     # strong: 70% (50% if <2.5yr), good: 90% (70% if <2.5yr),
     # satisfactory: 115%, weak: 250%, default: 0%
@@ -291,34 +278,32 @@ SPECIALISED_LENDING_SCHEMA = {
 
 # Equity exposures - must use SA under Basel 3.1 (CRE20.58-62, CRR Art 133)
 # IRB approaches for equity withdrawn under PRA PS1/26
-EQUITY_EXPOSURE_SCHEMA = {
-    "exposure_reference": pl.String,
-    "counterparty_reference": pl.String,
-    "equity_type": pl.String,  # central_bank, listed, exchange_traded, government_supported, unlisted, speculative, private_equity, private_equity_diversified, ciu, other
-    "currency": pl.String,
-    "carrying_value": pl.Float64,  # Balance sheet value
-    "fair_value": pl.Float64,  # For mark-to-market positions
-    # Classification flags affecting risk weight
-    "is_speculative": pl.Boolean,  # Speculative unlisted equity - 400% RW
-    "is_exchange_traded": pl.Boolean,  # Listed on recognised exchange - 100% RW
-    "is_government_supported": pl.Boolean,  # Certain govt-supported programmes - reduced RW
-    "is_significant_investment": pl.Boolean,  # >10% of CET1 - may require deduction
-    # CIU approach selection (Art. 132-132C)
-    "ciu_approach": pl.String,  # "look_through", "mandate_based", "fallback", or null
-    "ciu_mandate_rw": pl.Float64,  # Pre-computed mandate-based risk weight (Art. 132A)
-    "ciu_third_party_calc": pl.Boolean,  # Third-party calc → 1.2x factor (Art. 132(4))
-    "fund_reference": pl.String,  # CIU fund reference for look-through join
-    "fund_nav": pl.Float64,  # CIU fund NAV for leverage adjustment (Art. 132a(3))
+EQUITY_EXPOSURE_SCHEMA: dict[str, ColumnSpec] = {
+    "exposure_reference": ColumnSpec(pl.String),
+    "counterparty_reference": ColumnSpec(pl.String),
+    "equity_type": ColumnSpec(pl.String, default="other", required=False),
+    "currency": ColumnSpec(pl.String, required=False),
+    "carrying_value": ColumnSpec(pl.Float64, required=False),
+    "fair_value": ColumnSpec(pl.Float64, required=False),
+    "is_speculative": ColumnSpec(pl.Boolean, default=False, required=False),
+    "is_exchange_traded": ColumnSpec(pl.Boolean, default=False, required=False),
+    "is_government_supported": ColumnSpec(pl.Boolean, default=False, required=False),
+    "is_significant_investment": ColumnSpec(pl.Boolean, default=False, required=False),
+    "ciu_approach": ColumnSpec(pl.String, required=False),
+    "ciu_mandate_rw": ColumnSpec(pl.Float64, required=False),
+    "ciu_third_party_calc": ColumnSpec(pl.Boolean, default=False, required=False),
+    "fund_reference": ColumnSpec(pl.String, required=False),
+    "fund_nav": ColumnSpec(pl.Float64, required=False),
     # Risk weight: 100% (listed), 250% (unlisted), 400% (speculative)
 }
 
 # CIU fund holdings for look-through approach (Art. 132)
-CIU_HOLDINGS_SCHEMA = {
-    "fund_reference": pl.String,  # Links to equity exposure fund_reference
-    "holding_reference": pl.String,  # Unique holding ID
-    "exposure_class": pl.String,  # SA class of underlying (e.g., "CORPORATE")
-    "cqs": pl.Int8,  # CQS of underlying (nullable for unrated)
-    "holding_value": pl.Float64,  # Market value of the holding
+CIU_HOLDINGS_SCHEMA: dict[str, ColumnSpec] = {
+    "fund_reference": ColumnSpec(pl.String),
+    "holding_reference": ColumnSpec(pl.String),
+    "exposure_class": ColumnSpec(pl.String),
+    "cqs": ColumnSpec(pl.Int8, required=False),
+    "holding_value": ColumnSpec(pl.Float64, required=False),
 }
 
 
@@ -326,10 +311,10 @@ CIU_HOLDINGS_SCHEMA = {
 # FX RATES SCHEMA
 # =============================================================================
 
-FX_RATES_SCHEMA = {
-    "currency_from": pl.String,  # Source currency (e.g., "USD")
-    "currency_to": pl.String,  # Target currency (e.g., "GBP")
-    "rate": pl.Float64,  # Multiply source amount by rate to get target amount
+FX_RATES_SCHEMA: dict[str, ColumnSpec] = {
+    "currency_from": ColumnSpec(pl.String),
+    "currency_to": ColumnSpec(pl.String),
+    "rate": ColumnSpec(pl.Float64),
 }
 
 
@@ -337,20 +322,20 @@ FX_RATES_SCHEMA = {
 # MAPPING SCHEMAS
 # =============================================================================
 
-FACILITY_MAPPING_SCHEMA = {
-    "parent_facility_reference": pl.String,
-    "child_reference": pl.String,
-    "child_type": pl.String,  # facility, loan, contingent
+FACILITY_MAPPING_SCHEMA: dict[str, ColumnSpec] = {
+    "parent_facility_reference": ColumnSpec(pl.String),
+    "child_reference": ColumnSpec(pl.String),
+    "child_type": ColumnSpec(pl.String, required=False),
 }
 
-ORG_MAPPING_SCHEMA = {
-    "parent_counterparty_reference": pl.String,
-    "child_counterparty_reference": pl.String,
+ORG_MAPPING_SCHEMA: dict[str, ColumnSpec] = {
+    "parent_counterparty_reference": ColumnSpec(pl.String),
+    "child_counterparty_reference": ColumnSpec(pl.String),
 }
 
-LENDING_MAPPING_SCHEMA = {
-    "parent_counterparty_reference": pl.String,
-    "child_counterparty_reference": pl.String,
+LENDING_MAPPING_SCHEMA: dict[str, ColumnSpec] = {
+    "parent_counterparty_reference": ColumnSpec(pl.String),
+    "child_counterparty_reference": ColumnSpec(pl.String),
 }
 
 EXPOSURE_CLASS_MAPPING_SCHEMA = {
@@ -439,17 +424,14 @@ CORRELATION_PARAMETER_SCHEMA = {
 # MODEL PERMISSIONS SCHEMA
 # =============================================================================
 
-MODEL_PERMISSIONS_SCHEMA = {
-    "model_id": pl.String,  # Unique model identifier (e.g., "UK_CORP_PD_01")
-    "exposure_class": pl.String,  # ExposureClass value this permission covers
-    "approach": pl.String,  # "foundation_irb", "advanced_irb", or "slotting"
-    "country_codes": pl.String,  # Comma-separated ISO codes, null = all geographies
-    "excluded_book_codes": pl.String,  # Comma-separated book codes to exclude, null = none
+MODEL_PERMISSIONS_SCHEMA: dict[str, ColumnSpec] = {
+    "model_id": ColumnSpec(pl.String),
+    "exposure_class": ColumnSpec(pl.String),
+    "approach": ColumnSpec(pl.String),
+    # country_codes / excluded_book_codes absent → null (all geographies / no exclusions)
+    "country_codes": ColumnSpec(pl.String, required=False),
+    "excluded_book_codes": ColumnSpec(pl.String, required=False),
 }
-
-# Columns in MODEL_PERMISSIONS_SCHEMA that may be absent from input data.
-# When absent, they are treated as null (all geographies permitted / no exclusions).
-MODEL_PERMISSIONS_OPTIONAL_COLUMNS: set[str] = {"country_codes", "excluded_book_codes"}
 
 
 # =============================================================================
@@ -700,6 +682,60 @@ COLUMN_VALUE_CONSTRAINTS: dict[str, dict[str, set[str]]] = {
     "model_permissions": {
         "approach": VALID_MODEL_PERMISSION_APPROACHES,
     },
+}
+
+
+# =============================================================================
+# STAGE-OUTPUT SCHEMAS (calculator-derived columns)
+# =============================================================================
+#
+# Columns produced by upstream pipeline stages (HierarchyResolver, CRMProcessor,
+# Classifier) and consumed by downstream calculators (SA, IRB, Equity, Slotting).
+# These are NOT input columns — they are emitted mid-pipeline. Calculators call
+# ``ensure_columns(lf, <STAGE>_OUTPUT_SCHEMA)`` to guarantee the columns exist
+# with declared defaults before using them, which previously required dozens of
+# hand-written ``if "col" not in schema.names()`` blocks per calculator.
+#
+# All columns here are ``required=False`` — they are produced optionally by the
+# upstream stage (e.g., when a counterparty has no parent, ``cp_scra_grade``
+# stays null) and defaulted when absent.
+
+# Columns joined onto exposures from counterparty data during hierarchy
+# resolution. Prefixed ``cp_`` to distinguish from exposure-native columns.
+HIERARCHY_OUTPUT_SCHEMA: dict[str, ColumnSpec] = {
+    "cp_country_code": ColumnSpec(pl.String, required=False),
+    "cp_entity_type": ColumnSpec(pl.String, required=False),
+    "cp_is_natural_person": ColumnSpec(pl.Boolean, default=False, required=False),
+    "cp_is_social_housing": ColumnSpec(pl.Boolean, default=False, required=False),
+    "cp_is_managed_as_retail": ColumnSpec(pl.Boolean, default=False, required=False),
+    "cp_is_investment_grade": ColumnSpec(pl.Boolean, default=False, required=False),
+    "cp_is_ccp_client_cleared": ColumnSpec(pl.Boolean, required=False),
+    "cp_scra_grade": ColumnSpec(pl.String, required=False),
+    "cp_sovereign_cqs": ColumnSpec(pl.Int32, required=False),
+    "cp_local_currency": ColumnSpec(pl.String, required=False),
+    "cp_institution_cqs": ColumnSpec(pl.Int8, required=False),
+}
+
+# Columns produced by the CRM stage: collateral value buckets and provision
+# allocations. Calculators consume these when computing secured/unsecured
+# splits (Art. 127) and EAD net of provisions (Art. 111(2)).
+CRM_OUTPUT_SCHEMA: dict[str, ColumnSpec] = {
+    "collateral_re_value": ColumnSpec(pl.Float64, default=0.0, required=False),
+    "collateral_receivables_value": ColumnSpec(pl.Float64, default=0.0, required=False),
+    "collateral_other_physical_value": ColumnSpec(pl.Float64, default=0.0, required=False),
+    "provision_allocated": ColumnSpec(pl.Float64, default=0.0, required=False),
+    "provision_deducted": ColumnSpec(pl.Float64, default=0.0, required=False),
+}
+
+# Columns produced by the classification stage: SME / retail / RE / SL flags
+# derived from counterparty attributes + exposure amounts + regulatory rules.
+CLASSIFIER_OUTPUT_SCHEMA: dict[str, ColumnSpec] = {
+    "qualifies_as_retail": ColumnSpec(pl.Boolean, default=True, required=False),
+    "is_sme": ColumnSpec(pl.Boolean, default=False, required=False),
+    "is_defaulted": ColumnSpec(pl.Boolean, default=False, required=False),
+    "has_income_cover": ColumnSpec(pl.Boolean, default=False, required=False),
+    "ltv": ColumnSpec(pl.Float64, required=False),
+    "sl_project_phase": ColumnSpec(pl.String, required=False),
 }
 
 

--- a/src/rwa_calc/engine/classifier.py
+++ b/src/rwa_calc/engine/classifier.py
@@ -47,6 +47,7 @@ from rwa_calc.contracts.errors import (
     CalculationError,
     classification_warning,
 )
+from rwa_calc.data.column_spec import ColumnSpec, ensure_columns
 from rwa_calc.data.tables.eu_sovereign import (
     build_eu_domestic_currency_expr,
     denomination_currency_expr,
@@ -411,12 +412,10 @@ class ExposureClassifier:
         # Ensure cp_is_managed_as_retail always exists — nullable Boolean.
         # When absent from counterparty data, defaults to null (downstream
         # fill_null(True) preserves backward-compatible qualifying behavior).
-        joined_schema = joined.collect_schema()
-        if "cp_is_managed_as_retail" not in joined_schema.names():
-            joined = joined.with_columns(
-                pl.lit(None).cast(pl.Boolean).alias("cp_is_managed_as_retail")
-            )
-
+        joined = ensure_columns(
+            joined,
+            {"cp_is_managed_as_retail": ColumnSpec(pl.Boolean, required=False)},
+        )
         return joined
 
     # =========================================================================

--- a/src/rwa_calc/engine/crm/guarantees.py
+++ b/src/rwa_calc/engine/crm/guarantees.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING
 
 import polars as pl
 
+from rwa_calc.data.column_spec import ColumnSpec, ensure_columns
 from rwa_calc.data.schemas import DIRECT_BENEFICIARY_TYPES
 from rwa_calc.data.tables.eu_sovereign import (
     build_eu_domestic_currency_expr,
@@ -62,17 +63,15 @@ def apply_guarantees(
     Returns:
         Exposures with guarantee effects applied
     """
-    # Default protection_type to "guarantee" if not provided (backward compatibility)
-    guar_input_schema = guarantees.collect_schema()
-    if "protection_type" not in guar_input_schema.names():
-        guarantees = guarantees.with_columns(
-            pl.lit("guarantee").alias("protection_type"),
-        )
-    else:
-        # Fill nulls with "guarantee" (default for legacy data)
-        guarantees = guarantees.with_columns(
-            pl.col("protection_type").fill_null("guarantee").alias("protection_type"),
-        )
+    # Default protection_type to "guarantee" when absent, then fill nulls with
+    # the same default (backward compatibility for legacy data).
+    guarantees = ensure_columns(
+        guarantees,
+        {"protection_type": ColumnSpec(pl.String, default="guarantee", required=False)},
+    )
+    guarantees = guarantees.with_columns(
+        pl.col("protection_type").fill_null("guarantee").alias("protection_type"),
+    )
 
     guarantees = _resolve_guarantees_multi_level(guarantees, exposures)
 
@@ -294,7 +293,7 @@ def _resolve_guarantees_multi_level(
     """
     guar_schema = guarantees.collect_schema()
 
-    if "beneficiary_type" not in guar_schema.names():
+    if "beneficiary_type" not in guar_schema.names():  # arch-exempt: early-exit guard
         return guarantees
 
     bt_lower = pl.col("beneficiary_type").str.to_lowercase()

--- a/src/rwa_calc/engine/crm/haircuts.py
+++ b/src/rwa_calc/engine/crm/haircuts.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING
 
 import polars as pl
 
+from rwa_calc.data.column_spec import ColumnSpec, ensure_columns
 from rwa_calc.data.schemas import (
     REAL_ESTATE_COLLATERAL_TYPES,
     RECEIVABLE_COLLATERAL_TYPES,
@@ -254,10 +255,12 @@ class HaircutCalculator:
         H_c and H_fx are set to 0%.  The ``_is_zero_haircut`` flag is propagated so
         ``apply_haircuts`` can also zero the FX haircut.
         """
-        # Ensure issuer_type column exists for bond type normalization
+        # Ensure issuer_type column exists for bond type normalization.
+        collateral = ensure_columns(
+            collateral,
+            {"issuer_type": ColumnSpec(pl.String, required=False)},
+        )
         schema = collateral.collect_schema()
-        if "issuer_type" not in schema.names():
-            collateral = collateral.with_columns(pl.lit(None).cast(pl.String).alias("issuer_type"))
 
         # Art. 227: determine whether zero-haircut flag column is available
         has_zero_haircut_col = "qualifies_for_zero_haircut" in schema.names()

--- a/src/rwa_calc/engine/crm/processor.py
+++ b/src/rwa_calc/engine/crm/processor.py
@@ -163,7 +163,7 @@ def _join_collateral_to_lookups(
 
     coll_schema = collateral.collect_schema()
 
-    if "beneficiary_type" not in coll_schema.names():
+    if "beneficiary_type" not in coll_schema.names():  # arch-exempt: early-exit guard
         # Direct-only join — single pass with all columns
         return collateral.join(
             direct_lookup.select(
@@ -268,7 +268,7 @@ def _resolve_pledge_from_joined(collateral: pl.LazyFrame) -> pl.LazyFrame:
     and non-zero.
     """
     coll_schema = collateral.collect_schema()
-    if "pledge_percentage" not in coll_schema.names():
+    if "pledge_percentage" not in coll_schema.names():  # arch-exempt: early-exit guard
         return collateral.drop("_beneficiary_ead")
 
     needs_resolve = (

--- a/src/rwa_calc/engine/equity/calculator.py
+++ b/src/rwa_calc/engine/equity/calculator.py
@@ -43,6 +43,7 @@ from rwa_calc.contracts.errors import (
     ErrorSeverity,
     LazyFrameResult,
 )
+from rwa_calc.data.column_spec import ColumnSpec, ensure_columns
 from rwa_calc.data.tables.b31_equity_rw import B31_SA_EQUITY_RISK_WEIGHTS
 from rwa_calc.data.tables.crr_equity_rw import (
     IRB_SIMPLE_EQUITY_RISK_WEIGHTS,
@@ -69,6 +70,23 @@ _CIU_THIRD_PARTY_MULTIPLIER = 1.2
 
 # No multiplier for internally-managed CIU mandate calculations
 _CIU_INTERNAL_MULTIPLIER = 1.0
+
+
+# Equity input contract — defensive defaults for columns read by the equity
+# calculator. `ead_final` is derived (not defaulted) so is handled separately.
+_EQUITY_INPUT_CONTRACT: dict[str, ColumnSpec] = {
+    "equity_type": ColumnSpec(pl.String, default="other", required=False),
+    "is_diversified_portfolio": ColumnSpec(pl.Boolean, default=False, required=False),
+    "is_speculative": ColumnSpec(pl.Boolean, default=False, required=False),
+    "is_exchange_traded": ColumnSpec(pl.Boolean, default=False, required=False),
+    "is_government_supported": ColumnSpec(pl.Boolean, default=False, required=False),
+    "ciu_approach": ColumnSpec(pl.String, required=False),
+    "ciu_mandate_rw": ColumnSpec(pl.Float64, required=False),
+    "ciu_third_party_calc": ColumnSpec(pl.Boolean, required=False),
+    "fund_reference": ColumnSpec(pl.String, required=False),
+    "ciu_look_through_rw": ColumnSpec(pl.Float64, required=False),
+    "fund_nav": ColumnSpec(pl.Float64, required=False),
+}
 
 # Sentinel for null CQS in join operations (data processing convention)
 _NULL_CQS_SENTINEL = -1
@@ -321,86 +339,7 @@ class EquityCalculator:
                     ]
                 )
 
-        schema = exposures.collect_schema()
-
-        if "equity_type" not in schema.names():
-            exposures = exposures.with_columns(
-                [
-                    pl.lit("other").alias("equity_type"),
-                ]
-            )
-
-        if "is_diversified_portfolio" not in schema.names():
-            exposures = exposures.with_columns(
-                [
-                    pl.lit(False).alias("is_diversified_portfolio"),
-                ]
-            )
-
-        if "is_speculative" not in schema.names():
-            exposures = exposures.with_columns(
-                [
-                    pl.lit(False).alias("is_speculative"),
-                ]
-            )
-
-        if "is_exchange_traded" not in schema.names():
-            exposures = exposures.with_columns(
-                [
-                    pl.lit(False).alias("is_exchange_traded"),
-                ]
-            )
-
-        if "is_government_supported" not in schema.names():
-            exposures = exposures.with_columns(
-                [
-                    pl.lit(False).alias("is_government_supported"),
-                ]
-            )
-
-        if "ciu_approach" not in schema.names():
-            exposures = exposures.with_columns(
-                [
-                    pl.lit(None).cast(pl.Utf8).alias("ciu_approach"),
-                ]
-            )
-
-        if "ciu_mandate_rw" not in schema.names():
-            exposures = exposures.with_columns(
-                [
-                    pl.lit(None).cast(pl.Float64).alias("ciu_mandate_rw"),
-                ]
-            )
-
-        if "ciu_third_party_calc" not in schema.names():
-            exposures = exposures.with_columns(
-                [
-                    pl.lit(None).cast(pl.Boolean).alias("ciu_third_party_calc"),
-                ]
-            )
-
-        if "fund_reference" not in schema.names():
-            exposures = exposures.with_columns(
-                [
-                    pl.lit(None).cast(pl.Utf8).alias("fund_reference"),
-                ]
-            )
-
-        if "ciu_look_through_rw" not in schema.names():
-            exposures = exposures.with_columns(
-                [
-                    pl.lit(None).cast(pl.Float64).alias("ciu_look_through_rw"),
-                ]
-            )
-
-        if "fund_nav" not in schema.names():
-            exposures = exposures.with_columns(
-                [
-                    pl.lit(None).cast(pl.Float64).alias("fund_nav"),
-                ]
-            )
-
-        return exposures
+        return ensure_columns(exposures, _EQUITY_INPUT_CONTRACT)
 
     def _resolve_look_through_rw(
         self,

--- a/src/rwa_calc/engine/hierarchy.py
+++ b/src/rwa_calc/engine/hierarchy.py
@@ -34,6 +34,7 @@ from rwa_calc.contracts.bundles import (
     ResolvedHierarchyBundle,
 )
 from rwa_calc.contracts.errors import CalculationError
+from rwa_calc.data.column_spec import ColumnSpec, ensure_columns
 from rwa_calc.engine.fx_converter import FXConverter
 from rwa_calc.engine.utils import has_required_columns
 
@@ -294,8 +295,10 @@ class HierarchyResolver:
         sort_cols = ["rating_date", "rating_reference"]
 
         # Ensure model_id column exists on ratings (may be absent in legacy data)
-        if "model_id" not in ratings.collect_schema().names():
-            ratings = ratings.with_columns(pl.lit(None).cast(pl.String).alias("model_id"))
+        ratings = ensure_columns(
+            ratings,
+            {"model_id": ColumnSpec(pl.String, required=False)},
+        )
 
         # Best internal rating per counterparty (no CQS — that's external only)
         best_internal = (

--- a/src/rwa_calc/engine/irb/namespace.py
+++ b/src/rwa_calc/engine/irb/namespace.py
@@ -108,8 +108,6 @@ class IRBLazyFrame:
         Returns:
             LazyFrame with approach classification
         """
-        schema = self._lf.collect_schema()
-
         lf = ensure_columns(
             self._lf,
             {"approach": ColumnSpec(pl.String, default=ApproachType.FIRB.value, required=False)},

--- a/src/rwa_calc/engine/irb/namespace.py
+++ b/src/rwa_calc/engine/irb/namespace.py
@@ -34,6 +34,7 @@ from typing import TYPE_CHECKING
 
 import polars as pl
 
+from rwa_calc.data.column_spec import ColumnSpec, ensure_columns
 from rwa_calc.data.tables.firb_lgd import get_firb_lgd_table_for_framework
 from rwa_calc.domain.enums import ApproachType
 from rwa_calc.engine.irb.adjustments import (
@@ -109,14 +110,10 @@ class IRBLazyFrame:
         """
         schema = self._lf.collect_schema()
 
-        lf = self._lf
-        if "approach" not in schema.names():
-            lf = lf.with_columns(
-                [
-                    pl.lit(ApproachType.FIRB.value).alias("approach"),
-                ]
-            )
-
+        lf = ensure_columns(
+            self._lf,
+            {"approach": ColumnSpec(pl.String, default=ApproachType.FIRB.value, required=False)},
+        )
         return lf.with_columns(
             [
                 (pl.col("approach") == ApproachType.AIRB.value).alias("is_airb"),
@@ -412,11 +409,11 @@ class IRBLazyFrame:
         Returns:
             LazyFrame with correlation column
         """
-        # Ensure requires_fi_scalar column exists (defaults to False if not set by classifier)
-        schema = self._lf.collect_schema()
-        lf = self._lf
-        if "requires_fi_scalar" not in schema.names():
-            lf = lf.with_columns(pl.lit(False).alias("requires_fi_scalar"))
+        # requires_fi_scalar defaults to False if not set by classifier.
+        lf = ensure_columns(
+            self._lf,
+            {"requires_fi_scalar": ColumnSpec(pl.Boolean, default=False, required=False)},
+        )
 
         # B31 uses GBP-native thresholds (Art. 153(4)); CRR converts GBP→EUR via rate
         eur_gbp_rate = float(config.eur_gbp_rate)

--- a/src/rwa_calc/engine/loader.py
+++ b/src/rwa_calc/engine/loader.py
@@ -32,6 +32,7 @@ import polars as pl
 from rwa_calc.config.data_sources import DataSourceRegistry
 from rwa_calc.contracts.bundles import RawDataBundle
 from rwa_calc.contracts.errors import CalculationError
+from rwa_calc.data.column_spec import ColumnSpec, ensure_columns
 from rwa_calc.data.schemas import (
     CIU_HOLDINGS_SCHEMA,
     COLLATERAL_SCHEMA,
@@ -59,7 +60,7 @@ type ScanFn = Callable[[Path], pl.LazyFrame]
 
 def enforce_schema(
     lf: pl.LazyFrame,
-    schema: dict[str, pl.DataType],
+    schema: dict[str, pl.DataType] | dict[str, ColumnSpec],
     strict: bool = False,
 ) -> pl.LazyFrame:
     """
@@ -70,20 +71,29 @@ def enforce_schema(
 
     Args:
         lf: LazyFrame to enforce schema on
-        schema: Dictionary mapping column names to expected Polars types
+        schema: Dict mapping column names to expected Polars dtypes or
+            ColumnSpec entries. Raw dtype entries are treated as required.
         strict: If True, raise errors on invalid casts. If False (default),
                 invalid values become null.
 
     Returns:
         LazyFrame with columns cast to expected types
     """
+
+    def _dtype(entry: pl.DataType | ColumnSpec) -> pl.DataType:
+        return entry.dtype if isinstance(entry, ColumnSpec) else entry
+
+    is_column_spec_schema = any(isinstance(entry, ColumnSpec) for entry in schema.values())
+    if is_column_spec_schema:
+        lf = ensure_columns(lf, schema)  # type: ignore[arg-type]
+
     current_schema = lf.collect_schema()
     current_cols = set(current_schema.names())
 
     cast_exprs = [
-        pl.col(col_name).cast(expected_type, strict=strict).alias(col_name)
-        for col_name, expected_type in schema.items()
-        if col_name in current_cols and current_schema[col_name] != expected_type
+        pl.col(col_name).cast(_dtype(entry), strict=strict).alias(col_name)
+        for col_name, entry in schema.items()
+        if col_name in current_cols and current_schema[col_name] != _dtype(entry)
     ]
 
     if not cast_exprs:

--- a/src/rwa_calc/engine/sa/calculator.py
+++ b/src/rwa_calc/engine/sa/calculator.py
@@ -52,6 +52,12 @@ from rwa_calc.contracts.errors import (
     ErrorSeverity,
     LazyFrameResult,
 )
+from rwa_calc.data.column_spec import ColumnSpec, ensure_columns
+from rwa_calc.data.schemas import (
+    CLASSIFIER_OUTPUT_SCHEMA,
+    CRM_OUTPUT_SCHEMA,
+    HIERARCHY_OUTPUT_SCHEMA,
+)
 from rwa_calc.data.tables.b31_risk_weights import (
     B31_CORPORATE_INVESTMENT_GRADE_RW,
     B31_CORPORATE_NON_INVESTMENT_GRADE_RW,
@@ -108,6 +114,30 @@ from rwa_calc.engine.sa.supporting_factors import SupportingFactorCalculator
 
 if TYPE_CHECKING:
     from rwa_calc.contracts.config import CalculationConfig
+
+
+# SA input contract — defensive defaults for columns the SA calculator reads.
+# Composed of stage-output schemas (hierarchy / CRM / classifier) plus a small
+# set of input-schema columns that may be absent when calculators are invoked
+# directly from tests or ad-hoc pipelines.
+_SA_INPUT_CONTRACT: dict[str, ColumnSpec] = {
+    **HIERARCHY_OUTPUT_SCHEMA,
+    **CRM_OUTPUT_SCHEMA,
+    **CLASSIFIER_OUTPUT_SCHEMA,
+    "book_code": ColumnSpec(pl.String, default="", required=False),
+    "seniority": ColumnSpec(pl.String, default="senior", required=False),
+    "currency": ColumnSpec(pl.String, required=False),
+    "property_type": ColumnSpec(pl.String, required=False),
+    "residual_maturity_years": ColumnSpec(pl.Float64, required=False),
+    "is_adc": ColumnSpec(pl.Boolean, default=False, required=False),
+    "is_presold": ColumnSpec(pl.Boolean, default=False, required=False),
+    "is_qualifying_re": ColumnSpec(pl.Boolean, required=False),
+    "prior_charge_ltv": ColumnSpec(pl.Float64, default=0.0, required=False),
+    "is_short_term_trade_lc": ColumnSpec(pl.Boolean, default=False, required=False),
+    "is_payroll_loan": ColumnSpec(pl.Boolean, default=False, required=False),
+    "is_qrre_transactor": ColumnSpec(pl.Boolean, default=False, required=False),
+    "sl_type": ColumnSpec(pl.String, required=False),
+}
 
 
 def _crr_unrated_cb_rw_expr(use_uk_deviation: bool) -> pl.Expr:
@@ -477,88 +507,11 @@ class SACalculator:
         else:
             rw_table = get_combined_cqs_risk_weights(use_uk_deviation).lazy()
 
-        # Ensure required columns exist (single with_columns call)
+        # Fill any missing optional columns (counterparty attrs, CRM outputs,
+        # classifier flags, defensive input-schema fallbacks) from the
+        # declarative contract. See _SA_INPUT_CONTRACT at module level.
+        exposures = ensure_columns(exposures, _SA_INPUT_CONTRACT)
         schema = exposures.collect_schema()
-        missing_cols = []
-        if "ltv" not in schema.names():
-            missing_cols.append(pl.lit(None).cast(pl.Float64).alias("ltv"))
-        if "has_income_cover" not in schema.names():
-            missing_cols.append(pl.lit(False).alias("has_income_cover"))
-        if "book_code" not in schema.names():
-            missing_cols.append(pl.lit("").alias("book_code"))
-        if "cp_is_managed_as_retail" not in schema.names():
-            missing_cols.append(pl.lit(False).alias("cp_is_managed_as_retail"))
-        if "qualifies_as_retail" not in schema.names():
-            missing_cols.append(pl.lit(True).alias("qualifies_as_retail"))
-        if "property_type" not in schema.names():
-            missing_cols.append(pl.lit(None).cast(pl.Utf8).alias("property_type"))
-        if "is_adc" not in schema.names():
-            missing_cols.append(pl.lit(False).alias("is_adc"))
-        if "is_presold" not in schema.names():
-            missing_cols.append(pl.lit(False).alias("is_presold"))
-        if "seniority" not in schema.names():
-            missing_cols.append(pl.lit("senior").alias("seniority"))
-        if "cp_scra_grade" not in schema.names():
-            missing_cols.append(pl.lit(None).cast(pl.Utf8).alias("cp_scra_grade"))
-        if "cp_is_investment_grade" not in schema.names():
-            missing_cols.append(pl.lit(False).alias("cp_is_investment_grade"))
-        if "is_defaulted" not in schema.names():
-            missing_cols.append(pl.lit(False).alias("is_defaulted"))
-        if "provision_allocated" not in schema.names():
-            missing_cols.append(pl.lit(0.0).alias("provision_allocated"))
-        if "provision_deducted" not in schema.names():
-            missing_cols.append(pl.lit(0.0).alias("provision_deducted"))
-        if "currency" not in schema.names():
-            missing_cols.append(pl.lit(None).cast(pl.Utf8).alias("currency"))
-        if "cp_country_code" not in schema.names():
-            missing_cols.append(pl.lit(None).cast(pl.Utf8).alias("cp_country_code"))
-        if "cp_entity_type" not in schema.names():
-            missing_cols.append(pl.lit(None).cast(pl.Utf8).alias("cp_entity_type"))
-        if "cp_is_ccp_client_cleared" not in schema.names():
-            missing_cols.append(pl.lit(None).cast(pl.Boolean).alias("cp_is_ccp_client_cleared"))
-        if "sl_type" not in schema.names():
-            missing_cols.append(pl.lit(None).cast(pl.Utf8).alias("sl_type"))
-        if "sl_project_phase" not in schema.names():
-            missing_cols.append(pl.lit(None).cast(pl.Utf8).alias("sl_project_phase"))
-        if "is_qrre_transactor" not in schema.names():
-            missing_cols.append(pl.lit(False).alias("is_qrre_transactor"))
-        if "residual_maturity_years" not in schema.names():
-            missing_cols.append(pl.lit(None).cast(pl.Float64).alias("residual_maturity_years"))
-        if "is_short_term_trade_lc" not in schema.names():
-            missing_cols.append(pl.lit(False).alias("is_short_term_trade_lc"))
-        if "is_payroll_loan" not in schema.names():
-            missing_cols.append(pl.lit(False).alias("is_payroll_loan"))
-        # Art. 124H counterparty type for CRE general treatment routing
-        if "cp_is_natural_person" not in schema.names():
-            missing_cols.append(pl.lit(False).alias("cp_is_natural_person"))
-        if "is_sme" not in schema.names():
-            missing_cols.append(pl.lit(False).alias("is_sme"))
-        # Art. 124A qualifying RE flag for Other RE treatment (Art. 124J)
-        if "is_qualifying_re" not in schema.names():
-            missing_cols.append(pl.lit(None).cast(pl.Boolean).alias("is_qualifying_re"))
-        # Art. 124F(2) prior charge LTV for junior lien threshold reduction
-        if "prior_charge_ltv" not in schema.names():
-            missing_cols.append(pl.lit(0.0).alias("prior_charge_ltv"))
-        # Art. 124L social housing counterparty type for RRE residual RW
-        if "cp_is_social_housing" not in schema.names():
-            missing_cols.append(pl.lit(False).alias("cp_is_social_housing"))
-        # Art. 121(6) / CRE20.22: Sovereign floor for FX institution exposures
-        if "cp_sovereign_cqs" not in schema.names():
-            missing_cols.append(pl.lit(None).cast(pl.Int32).alias("cp_sovereign_cqs"))
-        if "cp_local_currency" not in schema.names():
-            missing_cols.append(pl.lit(None).cast(pl.Utf8).alias("cp_local_currency"))
-        # Art. 129(5): issuing institution CQS for unrated covered bond derivation
-        if "cp_institution_cqs" not in schema.names():
-            missing_cols.append(pl.lit(None).cast(pl.Int8).alias("cp_institution_cqs"))
-        # CRM collateral columns for Art. 127 secured/unsecured split
-        if "collateral_re_value" not in schema.names():
-            missing_cols.append(pl.lit(0.0).alias("collateral_re_value"))
-        if "collateral_receivables_value" not in schema.names():
-            missing_cols.append(pl.lit(0.0).alias("collateral_receivables_value"))
-        if "collateral_other_physical_value" not in schema.names():
-            missing_cols.append(pl.lit(0.0).alias("collateral_other_physical_value"))
-        if missing_cols:
-            exposures = exposures.with_columns(missing_cols)
 
         # CRR Art. 114(3)/(4): Domestic CGCB exposures → 0% RW
         # UK sovereign in GBP, or EU sovereign in that member state's domestic currency.
@@ -1369,7 +1322,7 @@ class SACalculator:
             return exposures
 
         schema = exposures.collect_schema()
-        if "fcsm_collateral_value" not in schema.names():
+        if "fcsm_collateral_value" not in schema.names():  # arch-exempt: early-exit guard
             return exposures
 
         ead_col = "ead_final" if "ead_final" in schema.names() else "ead"
@@ -1435,7 +1388,7 @@ class SACalculator:
             Exposures with blended risk weight for life-insurance-covered portion.
         """
         schema = exposures.collect_schema()
-        if "life_ins_collateral_value" not in schema.names():
+        if "life_ins_collateral_value" not in schema.names():  # arch-exempt: early-exit guard
             return exposures
 
         ead_col = "ead_final" if "ead_final" in schema.names() else "ead"
@@ -1910,7 +1863,7 @@ class SACalculator:
         which is set by the classifier for equity-class rows.
         """
         schema = exposures.collect_schema()
-        if "approach" not in schema.names():
+        if "approach" not in schema.names():  # arch-exempt: early-exit guard
             return
         # Approach == "equity" is only set for equity-class rows from the main
         # tables. We detect this via a lightweight one-row collect to avoid
@@ -1982,29 +1935,18 @@ class SACalculator:
         Returns:
             Exposures with supporting factors applied
         """
-        # Ensure required columns exist for supporting factor calculation
-        schema = exposures.collect_schema()
-
-        if "is_sme" not in schema.names():
-            exposures = exposures.with_columns(
-                [
-                    pl.lit(False).alias("is_sme"),
-                ]
-            )
-
-        if "is_infrastructure" not in schema.names():
-            exposures = exposures.with_columns(
-                [
-                    pl.lit(False).alias("is_infrastructure"),
-                ]
-            )
-
-        if "ead_final" not in schema.names():
-            exposures = exposures.with_columns(
-                [
-                    pl.col("ead").alias("ead_final"),
-                ]
-            )
+        # Ensure required columns exist for supporting factor calculation.
+        exposures = ensure_columns(
+            exposures,
+            {
+                "is_sme": ColumnSpec(pl.Boolean, default=False, required=False),
+                "is_infrastructure": ColumnSpec(pl.Boolean, default=False, required=False),
+            },
+        )
+        # ead_final is a multi-source derivation (fallback to ead), not a
+        # simple default — cannot use ensure_columns.
+        if "ead_final" not in exposures.collect_schema().names():  # arch-exempt: derivation
+            exposures = exposures.with_columns(pl.col("ead").alias("ead_final"))
 
         return self._supporting_factor_calc.apply_factors(exposures, config, errors=errors)
 

--- a/src/rwa_calc/engine/slotting/calculator.py
+++ b/src/rwa_calc/engine/slotting/calculator.py
@@ -43,6 +43,7 @@ import polars as pl
 
 from rwa_calc.contracts.bundles import CRMAdjustedBundle, SlottingResultBundle
 from rwa_calc.contracts.errors import CalculationError
+from rwa_calc.data.column_spec import ColumnSpec, ensure_columns
 from rwa_calc.engine.sa.supporting_factors import SupportingFactorCalculator
 
 if TYPE_CHECKING:
@@ -146,12 +147,14 @@ class SlottingCalculator:
         # Rename rwa to rwa_pre_factor for the SupportingFactorCalculator
         exposures = exposures.with_columns(pl.col("rwa").alias("rwa_pre_factor"))
 
-        # Ensure required columns exist
-        schema = exposures.collect_schema()
-        if "is_sme" not in schema.names():
-            exposures = exposures.with_columns(pl.lit(False).alias("is_sme"))
-        if "is_infrastructure" not in schema.names():
-            exposures = exposures.with_columns(pl.lit(False).alias("is_infrastructure"))
+        # Ensure supporting-factor flags exist (classifier may not have set them).
+        exposures = ensure_columns(
+            exposures,
+            {
+                "is_sme": ColumnSpec(pl.Boolean, default=False, required=False),
+                "is_infrastructure": ColumnSpec(pl.Boolean, default=False, required=False),
+            },
+        )
 
         sf_calc = SupportingFactorCalculator()
         exposures = sf_calc.apply_factors(exposures, config, errors=errors)

--- a/tests/acceptance/stress/conftest.py
+++ b/tests/acceptance/stress/conftest.py
@@ -20,6 +20,7 @@ from tests.fixtures.irb_test_helpers import (
 
 from rwa_calc.contracts.bundles import RawDataBundle
 from rwa_calc.contracts.config import CalculationConfig
+from rwa_calc.data.column_spec import dtypes_of
 from rwa_calc.data.schemas import (
     CONTINGENTS_SCHEMA,
     COUNTERPARTY_SCHEMA,
@@ -134,7 +135,7 @@ def generate_stress_counterparties(n: int, seed: int = 42) -> pl.LazyFrame:
                 "institution_cqs": pl.Series([None] * n, dtype=pl.Int8),
             }
         )
-        .cast(COUNTERPARTY_SCHEMA)
+        .cast(dtypes_of(COUNTERPARTY_SCHEMA))
         .lazy()
     )
 
@@ -222,7 +223,7 @@ def generate_stress_loans(
                 "due_diligence_override_rw": np.full(n_loans, None),
             }
         )
-        .cast(LOAN_SCHEMA)
+        .cast(dtypes_of(LOAN_SCHEMA))
         .lazy()
     )
 
@@ -275,7 +276,7 @@ def generate_stress_facilities(
                 "has_sufficient_collateral_data": np.full(n, None),
             }
         )
-        .cast(FACILITY_SCHEMA)
+        .cast(dtypes_of(FACILITY_SCHEMA))
         .lazy()
     )
 
@@ -317,7 +318,7 @@ def generate_stress_ratings(
                 "model_id": pl.Series([None] * n_rated, dtype=pl.String),
             }
         )
-        .cast(RATINGS_SCHEMA)
+        .cast(dtypes_of(RATINGS_SCHEMA))
         .lazy()
     )
 
@@ -343,7 +344,7 @@ def generate_stress_org_mappings(
     parent_pool = np.array([i for i in range(n) if i not in set(child_indices)])
 
     if len(parent_pool) == 0:
-        return pl.LazyFrame(schema=ORG_MAPPING_SCHEMA)
+        return pl.LazyFrame(schema=dtypes_of(ORG_MAPPING_SCHEMA))
 
     parent_indices = rng.choice(parent_pool, size=n_children)
 
@@ -354,7 +355,7 @@ def generate_stress_org_mappings(
                 "child_counterparty_reference": cp_refs[child_indices],
             }
         )
-        .cast(ORG_MAPPING_SCHEMA)
+        .cast(dtypes_of(ORG_MAPPING_SCHEMA))
         .lazy()
     )
 
@@ -372,7 +373,7 @@ def generate_stress_facility_mappings(
     loan_refs = loans.select("loan_reference").collect()["loan_reference"].to_numpy()
 
     if len(fac_refs) == 0 or len(loan_refs) == 0:
-        return pl.LazyFrame(schema=FACILITY_MAPPING_SCHEMA)
+        return pl.LazyFrame(schema=dtypes_of(FACILITY_MAPPING_SCHEMA))
 
     n_mapped = int(len(loan_refs) * mapping_pct)
     mapped_loans = rng.choice(loan_refs, size=n_mapped, replace=False)
@@ -386,7 +387,7 @@ def generate_stress_facility_mappings(
                 "child_type": ["loan"] * n_mapped,
             }
         )
-        .cast(FACILITY_MAPPING_SCHEMA)
+        .cast(dtypes_of(FACILITY_MAPPING_SCHEMA))
         .lazy()
     )
 
@@ -443,7 +444,7 @@ def generate_stress_contingents(
                 "due_diligence_override_rw": np.full(n_cont, None),
             }
         )
-        .cast(CONTINGENTS_SCHEMA)
+        .cast(dtypes_of(CONTINGENTS_SCHEMA))
         .lazy()
     )
 
@@ -506,7 +507,7 @@ def create_raw_bundle(
         ratings=ratings,
         facility_mappings=dataset["facility_mappings"],
         org_mappings=dataset["org_mappings"],
-        lending_mappings=pl.LazyFrame(schema=LENDING_MAPPING_SCHEMA),
+        lending_mappings=pl.LazyFrame(schema=dtypes_of(LENDING_MAPPING_SCHEMA)),
         model_permissions=model_permissions,
     )
 

--- a/tests/benchmarks/data_generators.py
+++ b/tests/benchmarks/data_generators.py
@@ -40,6 +40,7 @@ logger = logging.getLogger("rwa_calc.benchmarks")
 # Default directory for cached benchmark data
 BENCHMARK_DATA_DIR = Path(__file__).parent / "data"
 
+from rwa_calc.data.column_spec import dtypes_of  # noqa: E402
 from rwa_calc.data.schemas import (  # noqa: E402
     COLLATERAL_SCHEMA,
     CONTINGENTS_SCHEMA,
@@ -194,7 +195,7 @@ def generate_counterparties(config: BenchmarkDataConfig) -> pl.LazyFrame:
                 "institution_cqs": pl.Series([None] * n, dtype=pl.Int8),
             }
         )
-        .cast(COUNTERPARTY_SCHEMA)
+        .cast(dtypes_of(COUNTERPARTY_SCHEMA))
         .lazy()
     )
 
@@ -282,7 +283,7 @@ def generate_org_mappings(
                 "child_counterparty_reference": child_refs,
             }
         )
-        .cast(ORG_MAPPING_SCHEMA)
+        .cast(dtypes_of(ORG_MAPPING_SCHEMA))
         .lazy()
     )
 
@@ -411,7 +412,7 @@ def generate_facilities(
                 "has_sufficient_collateral_data": np.full(n_facilities, None),  # LGD modelling flag
             }
         )
-        .cast(FACILITY_SCHEMA)
+        .cast(dtypes_of(FACILITY_SCHEMA))
         .lazy()
     )
 
@@ -607,7 +608,7 @@ def generate_loans(
             "due_diligence_performed": np.full(n_loans, None),  # Art. 110A (B31 only)
             "due_diligence_override_rw": np.full(n_loans, None),  # Art. 110A override RW (B31 only)
         }
-    ).cast(LOAN_SCHEMA)
+    ).cast(dtypes_of(LOAN_SCHEMA))
 
     return df.lazy()
 
@@ -704,7 +705,7 @@ def generate_facility_mappings(
                 "child_type": all_types,
             }
         )
-        .cast(FACILITY_MAPPING_SCHEMA)
+        .cast(dtypes_of(FACILITY_MAPPING_SCHEMA))
         .lazy()
     )
 
@@ -845,7 +846,7 @@ def generate_ratings(
                 "model_id": pl.Series([None] * n_rated, dtype=pl.String),
             }
         )
-        .cast(RATINGS_SCHEMA)
+        .cast(dtypes_of(RATINGS_SCHEMA))
         .lazy()
     )
 
@@ -954,7 +955,7 @@ def generate_contingents(
                 ),  # Art. 110A override RW (B31 only)
             }
         )
-        .cast(CONTINGENTS_SCHEMA)
+        .cast(dtypes_of(CONTINGENTS_SCHEMA))
         .lazy()
     )
 
@@ -1145,7 +1146,7 @@ def generate_collateral(
                 .alias("property_ltv"),
             ]
         )
-        .cast(COLLATERAL_SCHEMA)
+        .cast(dtypes_of(COLLATERAL_SCHEMA))
         .lazy()
     )
 

--- a/tests/fixtures/collateral/collateral.py
+++ b/tests/fixtures/collateral/collateral.py
@@ -31,6 +31,7 @@ from pathlib import Path
 
 import polars as pl
 
+from rwa_calc.data.column_spec import dtypes_of
 from rwa_calc.data.schemas import COLLATERAL_SCHEMA
 
 
@@ -112,7 +113,7 @@ def create_collateral() -> pl.DataFrame:
         *_complex_scenario_collateral(),
     ]
 
-    return pl.DataFrame([c.to_dict() for c in collateral], schema=COLLATERAL_SCHEMA)
+    return pl.DataFrame([c.to_dict() for c in collateral], schema=dtypes_of(COLLATERAL_SCHEMA))
 
 
 def _cash_collateral() -> list[Collateral]:

--- a/tests/fixtures/counterparty/corporate.py
+++ b/tests/fixtures/counterparty/corporate.py
@@ -25,6 +25,7 @@ from pathlib import Path
 
 import polars as pl
 
+from rwa_calc.data.column_spec import dtypes_of
 from rwa_calc.data.schemas import COUNTERPARTY_SCHEMA
 
 
@@ -627,7 +628,7 @@ def create_corporate_counterparties() -> pl.DataFrame:
         },
     ]
 
-    return pl.DataFrame(corporates, schema=COUNTERPARTY_SCHEMA)
+    return pl.DataFrame(corporates, schema=dtypes_of(COUNTERPARTY_SCHEMA))
 
 
 def save_corporate_counterparties(output_dir: Path | None = None) -> Path:

--- a/tests/fixtures/counterparty/institution.py
+++ b/tests/fixtures/counterparty/institution.py
@@ -203,7 +203,7 @@ def create_institution_counterparties() -> pl.DataFrame:
         },
     ]
 
-    return pl.DataFrame(institutions, schema=COUNTERPARTY_SCHEMA)
+    return pl.DataFrame(institutions, schema=dtypes_of(COUNTERPARTY_SCHEMA))
 
 
 def save_institution_counterparties(output_dir: Path | None = None) -> Path:

--- a/tests/fixtures/counterparty/retail.py
+++ b/tests/fixtures/counterparty/retail.py
@@ -419,7 +419,7 @@ def create_retail_counterparties() -> pl.DataFrame:
         },
     ]
 
-    return pl.DataFrame(retail, schema=COUNTERPARTY_SCHEMA)
+    return pl.DataFrame(retail, schema=dtypes_of(COUNTERPARTY_SCHEMA))
 
 
 def save_retail_counterparties(output_dir: Path | None = None) -> Path:

--- a/tests/fixtures/counterparty/sovereign.py
+++ b/tests/fixtures/counterparty/sovereign.py
@@ -148,7 +148,7 @@ def create_sovereign_counterparties() -> pl.DataFrame:
         },
     ]
 
-    return pl.DataFrame(sovereigns, schema=COUNTERPARTY_SCHEMA)
+    return pl.DataFrame(sovereigns, schema=dtypes_of(COUNTERPARTY_SCHEMA))
 
 
 def save_sovereign_counterparties(output_dir: Path | None = None) -> Path:

--- a/tests/fixtures/counterparty/specialised_lending.py
+++ b/tests/fixtures/counterparty/specialised_lending.py
@@ -341,7 +341,7 @@ def create_specialised_lending_counterparties() -> pl.DataFrame:
         },
     ]
 
-    return pl.DataFrame(specialised_lending, schema=COUNTERPARTY_SCHEMA)
+    return pl.DataFrame(specialised_lending, schema=dtypes_of(COUNTERPARTY_SCHEMA))
 
 
 def save_specialised_lending_counterparties(output_dir: Path | None = None) -> Path:

--- a/tests/fixtures/exposures/contingents.py
+++ b/tests/fixtures/exposures/contingents.py
@@ -28,6 +28,7 @@ from pathlib import Path
 
 import polars as pl
 
+from rwa_calc.data.column_spec import dtypes_of
 from rwa_calc.data.schemas import CONTINGENTS_SCHEMA
 
 
@@ -96,7 +97,7 @@ def create_contingents() -> pl.DataFrame:
         *_ccf_test_contingents(),
     ]
 
-    return pl.DataFrame([c.to_dict() for c in contingents], schema=CONTINGENTS_SCHEMA)
+    return pl.DataFrame([c.to_dict() for c in contingents], schema=dtypes_of(CONTINGENTS_SCHEMA))
 
 
 def _trade_finance_contingents() -> list[Contingent]:

--- a/tests/fixtures/exposures/facilities.py
+++ b/tests/fixtures/exposures/facilities.py
@@ -23,6 +23,7 @@ from pathlib import Path
 
 import polars as pl
 
+from rwa_calc.data.column_spec import dtypes_of
 from rwa_calc.data.schemas import FACILITY_SCHEMA
 
 
@@ -100,7 +101,7 @@ def create_facilities() -> pl.DataFrame:
         *_complex_scenario_facilities(),
     ]
 
-    return pl.DataFrame([f.to_dict() for f in facilities], schema=FACILITY_SCHEMA)
+    return pl.DataFrame([f.to_dict() for f in facilities], schema=dtypes_of(FACILITY_SCHEMA))
 
 
 def _corporate_facilities() -> list[Facility]:

--- a/tests/fixtures/exposures/facility_mapping.py
+++ b/tests/fixtures/exposures/facility_mapping.py
@@ -24,6 +24,7 @@ from pathlib import Path
 
 import polars as pl
 
+from rwa_calc.data.column_spec import dtypes_of
 from rwa_calc.data.schemas import FACILITY_MAPPING_SCHEMA
 
 
@@ -62,7 +63,7 @@ def create_facility_mappings() -> pl.DataFrame:
         *_hierarchy_test_mappings(),
     ]
 
-    return pl.DataFrame([m.to_dict() for m in mappings], schema=FACILITY_MAPPING_SCHEMA)
+    return pl.DataFrame([m.to_dict() for m in mappings], schema=dtypes_of(FACILITY_MAPPING_SCHEMA))
 
 
 def _corporate_facility_mappings() -> list[FacilityMapping]:

--- a/tests/fixtures/exposures/loans.py
+++ b/tests/fixtures/exposures/loans.py
@@ -25,6 +25,7 @@ from pathlib import Path
 import polars as pl
 
 from rwa_calc.contracts.config import RegulatoryThresholds
+from rwa_calc.data.column_spec import dtypes_of
 from rwa_calc.data.schemas import LOAN_SCHEMA
 
 # SME exposure threshold in GBP (derived from EUR 2.5m using FX rate)
@@ -110,7 +111,7 @@ def create_loans() -> pl.DataFrame:
         *_dedicated_test_loans(),
     ]
 
-    return pl.DataFrame([ln.to_dict() for ln in loans], schema=LOAN_SCHEMA)
+    return pl.DataFrame([ln.to_dict() for ln in loans], schema=dtypes_of(LOAN_SCHEMA))
 
 
 def _sovereign_loans() -> list[Loan]:

--- a/tests/fixtures/fx_rates/fx_rates.py
+++ b/tests/fixtures/fx_rates/fx_rates.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 import polars as pl
 
+from rwa_calc.data.column_spec import dtypes_of
 from rwa_calc.data.schemas import FX_RATES_SCHEMA
 
 
@@ -76,7 +77,7 @@ def create_fx_rates() -> pl.DataFrame:
         FXRate("USD", "USD", 1.0),  # Identity rate
     ]
 
-    return pl.DataFrame([r.to_dict() for r in rates], schema=FX_RATES_SCHEMA)
+    return pl.DataFrame([r.to_dict() for r in rates], schema=dtypes_of(FX_RATES_SCHEMA))
 
 
 def save_fx_rates(output_dir: Path | None = None) -> Path:

--- a/tests/fixtures/guarantee/guarantee.py
+++ b/tests/fixtures/guarantee/guarantee.py
@@ -28,6 +28,7 @@ from pathlib import Path
 
 import polars as pl
 
+from rwa_calc.data.column_spec import dtypes_of
 from rwa_calc.data.schemas import GUARANTEE_SCHEMA
 
 
@@ -82,7 +83,7 @@ def create_guarantees() -> pl.DataFrame:
         *_crm_test_guarantees(),
     ]
 
-    return pl.DataFrame([g.to_dict() for g in guarantees], schema=GUARANTEE_SCHEMA)
+    return pl.DataFrame([g.to_dict() for g in guarantees], schema=dtypes_of(GUARANTEE_SCHEMA))
 
 
 def _sovereign_guarantees() -> list[Guarantee]:

--- a/tests/fixtures/mapping/lending_mapping.py
+++ b/tests/fixtures/mapping/lending_mapping.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 import polars as pl
 
+from rwa_calc.data.column_spec import dtypes_of
 from rwa_calc.data.schemas import LENDING_MAPPING_SCHEMA
 
 
@@ -55,7 +56,7 @@ def create_lending_mappings() -> pl.DataFrame:
             {"parent_counterparty_reference": r.parent, "child_counterparty_reference": r.child}
             for r in relationships
         ],
-        schema=LENDING_MAPPING_SCHEMA,
+        schema=dtypes_of(LENDING_MAPPING_SCHEMA),
     )
 
 

--- a/tests/fixtures/mapping/org_mapping.py
+++ b/tests/fixtures/mapping/org_mapping.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 import polars as pl
 
+from rwa_calc.data.column_spec import dtypes_of
 from rwa_calc.data.schemas import ORG_MAPPING_SCHEMA
 
 
@@ -54,7 +55,7 @@ def create_org_mappings() -> pl.DataFrame:
             {"parent_counterparty_reference": r.parent, "child_counterparty_reference": r.child}
             for r in relationships
         ],
-        schema=ORG_MAPPING_SCHEMA,
+        schema=dtypes_of(ORG_MAPPING_SCHEMA),
     )
 
 

--- a/tests/fixtures/model_permissions/model_permissions.py
+++ b/tests/fixtures/model_permissions/model_permissions.py
@@ -32,6 +32,7 @@ from pathlib import Path
 
 import polars as pl
 
+from rwa_calc.data.column_spec import dtypes_of
 from rwa_calc.data.schemas import MODEL_PERMISSIONS_SCHEMA
 
 
@@ -75,7 +76,9 @@ def create_model_permissions() -> pl.DataFrame:
         *_geography_restricted_permissions(),
     ]
 
-    return pl.DataFrame([p.to_dict() for p in permissions], schema=MODEL_PERMISSIONS_SCHEMA)
+    return pl.DataFrame(
+        [p.to_dict() for p in permissions], schema=dtypes_of(MODEL_PERMISSIONS_SCHEMA)
+    )
 
 
 def _corporate_permissions() -> list[ModelPermission]:

--- a/tests/fixtures/provision/provision.py
+++ b/tests/fixtures/provision/provision.py
@@ -80,7 +80,7 @@ def create_provisions() -> pl.DataFrame:
         *_provision_scenario_provisions(),
     ]
 
-    return pl.DataFrame([p.to_dict() for p in provisions], schema=PROVISION_SCHEMA)
+    return pl.DataFrame([p.to_dict() for p in provisions], schema=dtypes_of(PROVISION_SCHEMA))
 
 
 def _stage1_provisions() -> list[Provision]:

--- a/tests/fixtures/ratings/ratings.py
+++ b/tests/fixtures/ratings/ratings.py
@@ -88,7 +88,7 @@ def create_ratings() -> pl.DataFrame:
         *_complex_scenario_external_ratings(),
     ]
 
-    return pl.DataFrame([r.to_dict() for r in ratings], schema=RATINGS_SCHEMA)
+    return pl.DataFrame([r.to_dict() for r in ratings], schema=dtypes_of(RATINGS_SCHEMA))
 
 
 def _sovereign_external_ratings() -> list[Rating]:

--- a/tests/fixtures/ratings/specialised_lending.py
+++ b/tests/fixtures/ratings/specialised_lending.py
@@ -172,7 +172,7 @@ def create_specialised_lending_data() -> pl.DataFrame:
         },
     ]
 
-    return pl.DataFrame(rows, schema=SPECIALISED_LENDING_SCHEMA)
+    return pl.DataFrame(rows, schema=dtypes_of(SPECIALISED_LENDING_SCHEMA))
 
 
 def save_specialised_lending_data(output_dir: Path | None = None) -> Path:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -22,6 +22,7 @@ import pytest
 
 from rwa_calc.contracts.bundles import RawDataBundle
 from rwa_calc.contracts.config import CalculationConfig
+from rwa_calc.data.column_spec import ColumnSpec, dtypes_of
 from rwa_calc.data.schemas import (
     CONTINGENTS_SCHEMA,
     COUNTERPARTY_SCHEMA,
@@ -233,18 +234,27 @@ def make_rating(**overrides: Any) -> dict[str, Any]:
 
 
 def _rows_to_lazyframe(rows: list[dict[str, Any]], schema: dict[str, Any]) -> pl.LazyFrame:
-    """Convert row dicts to a LazyFrame, casting to the target schema."""
+    """Convert row dicts to a LazyFrame, casting to the target schema.
+
+    ``schema`` may be a plain ``{name: dtype}`` dict or a ``{name: ColumnSpec}``
+    schema from ``rwa_calc.data.schemas`` — ColumnSpec entries are unwrapped to
+    their dtype before casting.
+    """
+    dtype_schema = dtypes_of(schema) if _is_column_spec_schema(schema) else schema
     if not rows:
-        return pl.LazyFrame(schema=schema)
+        return pl.LazyFrame(schema=dtype_schema)
     df = pl.DataFrame(rows)
-    # Cast columns to match schema types, adding missing columns with nulls
     cast_exprs = []
-    for col_name, col_type in schema.items():
+    for col_name, col_type in dtype_schema.items():
         if col_name in df.columns:
             cast_exprs.append(pl.col(col_name).cast(col_type, strict=False))
         else:
             cast_exprs.append(pl.lit(None).cast(col_type).alias(col_name))
     return df.lazy().select(cast_exprs)
+
+
+def _is_column_spec_schema(schema: dict[str, Any]) -> bool:
+    return any(isinstance(v, ColumnSpec) for v in schema.values())
 
 
 def make_raw_data_bundle(

--- a/tests/integration/test_classifier_to_crm.py
+++ b/tests/integration/test_classifier_to_crm.py
@@ -26,6 +26,7 @@ import pytest
 
 from rwa_calc.contracts.bundles import CRMAdjustedBundle, RawDataBundle
 from rwa_calc.contracts.config import CalculationConfig
+from rwa_calc.data.column_spec import ColumnSpec, dtypes_of
 from rwa_calc.data.schemas import RATINGS_SCHEMA
 from rwa_calc.domain.enums import ApproachType
 from rwa_calc.engine.classifier import ExposureClassifier
@@ -74,12 +75,18 @@ def _make_internal_rating(
 
 
 def _rows_to_lazyframe(rows: list[dict[str, Any]], schema: dict[str, Any]) -> pl.LazyFrame:
-    """Convert row dicts to a LazyFrame, casting to the target schema."""
+    """Convert row dicts to a LazyFrame, casting to the target schema.
+
+    Accepts either a plain dtype dict or a ColumnSpec schema.
+    """
+    dtype_schema = (
+        dtypes_of(schema) if any(isinstance(v, ColumnSpec) for v in schema.values()) else schema
+    )
     if not rows:
-        return pl.LazyFrame(schema=schema)
+        return pl.LazyFrame(schema=dtype_schema)
     df = pl.DataFrame(rows)
     cast_exprs = []
-    for col_name, col_type in schema.items():
+    for col_name, col_type in dtype_schema.items():
         if col_name in df.columns:
             cast_exprs.append(pl.col(col_name).cast(col_type, strict=False))
         else:

--- a/tests/integration/test_loader_to_hierarchy.py
+++ b/tests/integration/test_loader_to_hierarchy.py
@@ -23,6 +23,7 @@ from typing import Any
 
 import polars as pl
 
+from rwa_calc.data.column_spec import dtypes_of
 from rwa_calc.data.schemas import (
     COUNTERPARTY_SCHEMA,
     FACILITY_MAPPING_SCHEMA,
@@ -67,7 +68,7 @@ def _make_counterparty_df(**overrides: Any) -> pl.DataFrame:
     defaults.update(overrides)
     df = pl.DataFrame([defaults])
     cast_exprs = []
-    for col_name, col_type in COUNTERPARTY_SCHEMA.items():
+    for col_name, col_type in dtypes_of(COUNTERPARTY_SCHEMA).items():
         if col_name in df.columns:
             cast_exprs.append(pl.col(col_name).cast(col_type, strict=False))
         else:
@@ -97,7 +98,7 @@ def _make_loan_df(**overrides: Any) -> pl.DataFrame:
     defaults.update(overrides)
     df = pl.DataFrame([defaults])
     cast_exprs = []
-    for col_name, col_type in LOAN_SCHEMA.items():
+    for col_name, col_type in dtypes_of(LOAN_SCHEMA).items():
         if col_name in df.columns:
             cast_exprs.append(pl.col(col_name).cast(col_type, strict=False))
         else:
@@ -130,7 +131,7 @@ def _make_facility_df(**overrides: Any) -> pl.DataFrame:
     defaults.update(overrides)
     df = pl.DataFrame([defaults])
     cast_exprs = []
-    for col_name, col_type in FACILITY_SCHEMA.items():
+    for col_name, col_type in dtypes_of(FACILITY_SCHEMA).items():
         if col_name in df.columns:
             cast_exprs.append(pl.col(col_name).cast(col_type, strict=False))
         else:
@@ -152,7 +153,7 @@ def _make_facility_mappings_df(
         ]
     df = pl.DataFrame(rows)
     cast_exprs = []
-    for col_name, col_type in FACILITY_MAPPING_SCHEMA.items():
+    for col_name, col_type in dtypes_of(FACILITY_MAPPING_SCHEMA).items():
         if col_name in df.columns:
             cast_exprs.append(pl.col(col_name).cast(col_type, strict=False))
         else:
@@ -165,10 +166,10 @@ def _make_lending_mappings_df(
 ) -> pl.DataFrame:
     """Build lending mappings DataFrame (empty by default)."""
     if not rows:
-        return pl.DataFrame(schema=LENDING_MAPPING_SCHEMA)
+        return pl.DataFrame(schema=dtypes_of(LENDING_MAPPING_SCHEMA))
     df = pl.DataFrame(rows)
     cast_exprs = []
-    for col_name, col_type in LENDING_MAPPING_SCHEMA.items():
+    for col_name, col_type in dtypes_of(LENDING_MAPPING_SCHEMA).items():
         if col_name in df.columns:
             cast_exprs.append(pl.col(col_name).cast(col_type, strict=False))
         else:
@@ -313,7 +314,7 @@ class TestDataIntegrity:
             ]
         )
         org_cast = []
-        for col_name, col_type in ORG_MAPPING_SCHEMA.items():
+        for col_name, col_type in dtypes_of(ORG_MAPPING_SCHEMA).items():
             if col_name in org_df.columns:
                 org_cast.append(pl.col(col_name).cast(col_type, strict=False))
             else:

--- a/tests/unit/crm/test_equity_main_index.py
+++ b/tests/unit/crm/test_equity_main_index.py
@@ -145,7 +145,7 @@ class TestIsMainIndexSchema:
     def test_field_type_is_boolean(self) -> None:
         from rwa_calc.data.schemas import COLLATERAL_SCHEMA
 
-        assert COLLATERAL_SCHEMA["is_main_index"] == pl.Boolean
+        assert COLLATERAL_SCHEMA["is_main_index"].dtype == pl.Boolean
 
     def test_field_distinct_from_eligibility(self) -> None:
         """is_main_index is a separate field from is_eligible_financial_collateral."""

--- a/tests/unit/test_column_spec.py
+++ b/tests/unit/test_column_spec.py
@@ -1,0 +1,152 @@
+"""Unit tests for ColumnSpec, ensure_columns, and dtypes_of."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import polars as pl
+import pytest
+
+from rwa_calc.data.column_spec import ColumnSpec, dtypes_of, ensure_columns
+
+# =============================================================================
+# ColumnSpec — frozen dataclass invariants
+# =============================================================================
+
+
+class TestColumnSpecFrozen:
+    def test_column_spec_is_frozen(self) -> None:
+        spec = ColumnSpec(pl.String)
+        with pytest.raises(FrozenInstanceError):
+            spec.dtype = pl.Int64  # type: ignore[misc]
+
+    def test_defaults_to_required_true_and_none_default(self) -> None:
+        spec = ColumnSpec(pl.String)
+        assert spec.required is True
+        assert spec.default is None
+
+    def test_accepts_explicit_default_and_required(self) -> None:
+        spec = ColumnSpec(pl.Float64, default=0.0, required=False)
+        assert spec.dtype == pl.Float64
+        assert spec.default == 0.0
+        assert spec.required is False
+
+
+# =============================================================================
+# ensure_columns — optional-only, idempotent, dtype-correct
+# =============================================================================
+
+
+class TestEnsureColumns:
+    def test_adds_missing_optional_column_with_declared_default(self) -> None:
+        lf = pl.LazyFrame({"a": [1, 2, 3]})
+        schema = {
+            "a": ColumnSpec(pl.Int64),
+            "b": ColumnSpec(pl.String, default="", required=False),
+        }
+
+        result = ensure_columns(lf, schema).collect()
+
+        assert result.columns == ["a", "b"]
+        assert result["b"].to_list() == ["", "", ""]
+        assert result.schema["b"] == pl.String
+
+    def test_preserves_declared_dtype_for_missing_column(self) -> None:
+        lf = pl.LazyFrame({"a": [1]})
+        schema = {
+            "a": ColumnSpec(pl.Int64),
+            "ltv": ColumnSpec(pl.Float64, default=None, required=False),
+            "flag": ColumnSpec(pl.Boolean, default=False, required=False),
+        }
+
+        result = ensure_columns(lf, schema).collect()
+
+        assert result.schema["ltv"] == pl.Float64
+        assert result.schema["flag"] == pl.Boolean
+        assert result["ltv"].to_list() == [None]
+        assert result["flag"].to_list() == [False]
+
+    def test_does_not_add_missing_required_column(self) -> None:
+        lf = pl.LazyFrame({"a": [1]})
+        schema = {
+            "a": ColumnSpec(pl.Int64),
+            "required_missing": ColumnSpec(pl.String, default="x", required=True),
+        }
+
+        result = ensure_columns(lf, schema).collect()
+
+        assert result.columns == ["a"]
+
+    def test_is_noop_when_all_optional_columns_present(self) -> None:
+        lf = pl.LazyFrame({"a": [1], "b": ["x"]})
+        schema = {
+            "a": ColumnSpec(pl.Int64),
+            "b": ColumnSpec(pl.String, default="", required=False),
+        }
+
+        result = ensure_columns(lf, schema).collect()
+
+        assert result.columns == ["a", "b"]
+        assert result["b"].to_list() == ["x"]
+
+    def test_does_not_recast_existing_column(self) -> None:
+        # Column exists but with a wider dtype than declared — ensure_columns
+        # must not interfere (loader is responsible for casting).
+        lf = pl.LazyFrame({"a": [1.5]}, schema={"a": pl.Float64})
+        schema = {"a": ColumnSpec(pl.Float32, default=0.0, required=False)}
+
+        result = ensure_columns(lf, schema).collect()
+
+        assert result.schema["a"] == pl.Float64
+        assert result["a"].to_list() == [1.5]
+
+    def test_empty_schema_is_noop(self) -> None:
+        lf = pl.LazyFrame({"a": [1]})
+        result = ensure_columns(lf, {}).collect()
+        assert result.columns == ["a"]
+
+    def test_adds_multiple_missing_optional_columns_in_single_pass(self) -> None:
+        lf = pl.LazyFrame({"a": [1]})
+        schema = {
+            "b": ColumnSpec(pl.String, default="", required=False),
+            "c": ColumnSpec(pl.Boolean, default=True, required=False),
+            "d": ColumnSpec(pl.Float64, default=0.0, required=False),
+        }
+
+        result = ensure_columns(lf, schema).collect()
+
+        assert set(result.columns) == {"a", "b", "c", "d"}
+        assert result["b"].to_list() == [""]
+        assert result["c"].to_list() == [True]
+        assert result["d"].to_list() == [0.0]
+
+
+# =============================================================================
+# dtypes_of — projection compatible with Polars constructors
+# =============================================================================
+
+
+class TestDtypesOf:
+    def test_returns_plain_dtype_dict(self) -> None:
+        schema = {
+            "a": ColumnSpec(pl.Int64),
+            "b": ColumnSpec(pl.String, default="", required=False),
+        }
+
+        dtypes = dtypes_of(schema)
+
+        assert dtypes == {"a": pl.Int64, "b": pl.String}
+
+    def test_result_is_accepted_by_polars_dataframe_constructor(self) -> None:
+        schema = {
+            "a": ColumnSpec(pl.Int64),
+            "b": ColumnSpec(pl.String, default="", required=False),
+        }
+
+        df = pl.DataFrame({"a": [1], "b": ["x"]}, schema=dtypes_of(schema))
+
+        assert df.schema["a"] == pl.Int64
+        assert df.schema["b"] == pl.String
+
+    def test_empty_schema_returns_empty_dict(self) -> None:
+        assert dtypes_of({}) == {}


### PR DESCRIPTION
## Summary

- Introduces `ColumnSpec(dtype, default, required)` as the declarative home for column metadata; replaces ~170 lines of hand-written `if \"col\" not in schema.names()` defaulting across engine calculators with single `ensure_columns(lf, <INPUT_CONTRACT>)` calls.
- Migrates 16 loader-consumed input schemas in `data/schemas.py` to `dict[str, ColumnSpec]`; adds stage-output schemas (`HIERARCHY_OUTPUT_SCHEMA`, `CRM_OUTPUT_SCHEMA`, `CLASSIFIER_OUTPUT_SCHEMA`) for calculator-derived columns.
- Adds `scripts/arch_check.py` rule #7 (`no inline 'not in schema.names()' in engine/**`) with per-file allowlist and per-line `# arch-exempt:` comment markers for intentional derivation / early-exit / combined warning+default cases.

## What moved where

- **New**: `src/rwa_calc/data/column_spec.py` — `ColumnSpec` frozen dataclass + `ensure_columns()` + `dtypes_of()` helpers (13 unit tests).
- **`data/schemas.py`**: 16 input schemas migrated; 3 new stage-output schemas; `MODEL_PERMISSIONS_OPTIONAL_COLUMNS` removed (now `required=False` on the relevant ColumnSpec entries).
- **`engine/loader.py`**: `enforce_schema` reads ColumnSpec dtypes and auto-fills optional defaults at load time.
- **`contracts/validation.py`**: validators accept either raw dtype dicts or ColumnSpec schemas.
- **Calculators**: SA (41 cols), Equity (11), IRB namespace (2), Slotting (2), CRM haircuts (1), Classifier (1), Hierarchy (1), CRM guarantees (1) migrated to `ensure_columns`.
- **Tests**: 30+ fixtures wrapped in `dtypes_of(...)`; integration `_rows_to_lazyframe` helpers unwrap ColumnSpec schemas.

## Design notes

- Scope: only the 16 loader-consumed input schemas + 3 new stage-output schemas are migrated to `ColumnSpec`. Output/reference/intermediate-documentation schemas (`CALCULATION_OUTPUT_SCHEMA`, risk-weight tables, `RAW_EXPOSURE_SCHEMA`, etc.) remain plain `dict[str, pl.DataType]` — they're not loader- or calculator-consumed, so `ColumnSpec` adds no value there.
- `ColumnSpec` lives in `data/column_spec.py` (not `data/schemas.py`) so it can be imported by schemas, loader, validators, and calculators without circulars.
- `IRB` calculator's PD/LGD defaulting blocks keep their `CalculationError` warning emission — they combine warning + default, which doesn't fit `ensure_columns` cleanly. Allowlisted in `SCHEMA_DEFAULTS_ALLOWLIST`.

## Test plan

- [x] `uv run pytest tests/` — 5,290 passed, 11 deselected
- [x] `uv run python scripts/arch_check.py` — all 7 rules pass
- [x] `uv run ty check src/` — clean
- [ ] Reviewer: spot-check that golden-file acceptance outputs are unchanged (they are — no regressions across 275 acceptance scenarios)

🤖 Generated with [Claude Code](https://claude.com/claude-code)