### PR TITLE
fix(classifier): require modelled LGD for SL A-IRB approach

### DIFF
--- a/src/rwa_calc/engine/classifier.py
+++ b/src/rwa_calc/engine/classifier.py
@@ -1014,10 +1014,13 @@ class ExposureClassifier:
             .when(_b31_ipre_hvcre_forced_slotting)
             .then(pl.lit(ApproachType.SLOTTING.value))
             # SL A-IRB takes precedence over slotting (non-IPRE/HVCRE under B31)
+            # Requires both PD and modelled LGD — without LGD, fall through to slotting
+            # (CRR Art. 153(1)-(4) vs Art. 153(5))
             .when(
                 (pl.col("exposure_class") == ExposureClass.SPECIALISED_LENDING.value)
                 & sl_airb
                 & has_internal_rating
+                & has_modelled_lgd
             )
             .then(pl.lit(ApproachType.AIRB.value))
             # SL slotting fallback (slotting does not require internal rating)

--- a/tests/unit/test_sa_sl_classification.py
+++ b/tests/unit/test_sa_sl_classification.py
@@ -358,6 +358,35 @@ class TestSLApproachRoutingUnchanged:
         df = _classify(specialised_lending=sl, framework="b31")
         assert df["approach"][0] == ApproachType.AIRB.value
 
+    def test_pf_with_pd_but_no_lgd_gets_slotting_b31(self) -> None:
+        """SL with internal_pd but no modelled LGD → SLOTTING, not AIRB.
+
+        A-IRB requires both PD and LGD estimates (CRR Art. 153(1)-(4)).
+        Without modelled LGD, the supervisory slotting approach applies
+        (Art. 153(5)).
+        """
+        sl = _make_sl_table("project_finance")
+        df = _classify(specialised_lending=sl, framework="b31", lgd=None, internal_pd=0.005)
+        assert df["approach"][0] == ApproachType.SLOTTING.value
+
+    def test_pf_with_pd_and_lgd_gets_airb_b31(self) -> None:
+        """SL with both internal_pd and modelled LGD → AIRB (unchanged)."""
+        sl = _make_sl_table("project_finance")
+        df = _classify(specialised_lending=sl, framework="b31", lgd=0.45, internal_pd=0.005)
+        assert df["approach"][0] == ApproachType.AIRB.value
+
+    def test_pf_without_pd_gets_slotting_b31(self) -> None:
+        """SL without internal_pd → SLOTTING (slotting needs no PD)."""
+        sl = _make_sl_table("project_finance")
+        df = _classify(specialised_lending=sl, framework="b31", lgd=None, internal_pd=None)
+        assert df["approach"][0] == ApproachType.SLOTTING.value
+
+    def test_pf_with_pd_but_no_lgd_gets_slotting_crr(self) -> None:
+        """CRR: SL with internal_pd but no modelled LGD → SLOTTING."""
+        sl = _make_sl_table("project_finance")
+        df = _classify(specialised_lending=sl, framework="crr", lgd=None, internal_pd=0.005)
+        assert df["approach"][0] == ApproachType.SLOTTING.value
+
     def test_sl_entity_type_without_sl_table_gets_sa(self) -> None:
         """entity_type='specialised_lending' without SL table → SA fallback."""
         df = _classify(entity_type="specialised_lending", lgd=None, internal_pd=None)


### PR DESCRIPTION
## Summary
- SL A-IRB condition in classifier checked `has_internal_rating` but was missing `has_modelled_lgd`, causing SL exposures with a PD but no bank-estimated LGD to be incorrectly routed to AIRB instead of supervisory slotting
- Added `& has_modelled_lgd` to the SL A-IRB gate (CRR Art. 153(1)-(4) vs Art. 153(5)), matching the pattern already used by the general AIRB condition
- Added 4 unit tests covering SL+PD+LGD→AIRB, SL+PD−LGD→SLOTTING, SL−PD→SLOTTING, and the CRR equivalent

## Test plan
- [x] New unit tests pass: `uv run pytest tests/unit/test_sa_sl_classification.py -v` (31 passed)
- [x] Full suite regression: `uv run pytest tests/` (5,284 passed, 0 failures)