### PR TITLE
docs(homepage): new constellation landing page + stat/version fixes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,11 +21,13 @@ jobs:
           PYPROJECT_VERSION=$(grep -m1 'version = ' pyproject.toml | sed 's/.*"\(.*\)".*/\1/')
           INIT_VERSION=$(grep -m1 '__version__' src/rwa_calc/__init__.py | sed 's/.*"\(.*\)".*/\1/')
           DOC_VERSION=$(grep 'Calculator |' docs/overview.md | sed 's/.*| \([0-9.]*\) |.*/\1/')
+          MAIN_HTML_VERSION=$(grep -m1 '>v[0-9]' docs/overrides/main.html | sed 's/.*>v\([0-9.]*\) &middot;.*/\1/')
 
-          echo "Release tag:    $TAG_VERSION"
-          echo "pyproject.toml: $PYPROJECT_VERSION"
-          echo "__init__.py:    $INIT_VERSION"
-          echo "docs/overview.md: $DOC_VERSION"
+          echo "Release tag:              $TAG_VERSION"
+          echo "pyproject.toml:           $PYPROJECT_VERSION"
+          echo "__init__.py:              $INIT_VERSION"
+          echo "docs/overview.md:         $DOC_VERSION"
+          echo "docs/overrides/main.html: $MAIN_HTML_VERSION"
 
           ERRORS=0
           if [ "$TAG_VERSION" != "$PYPROJECT_VERSION" ]; then
@@ -38,6 +40,10 @@ jobs:
           fi
           if [ "$TAG_VERSION" != "$DOC_VERSION" ]; then
             echo "::error::Tag $TAG_VERSION != docs/overview.md $DOC_VERSION"
+            ERRORS=1
+          fi
+          if [ "$TAG_VERSION" != "$MAIN_HTML_VERSION" ]; then
+            echo "::error::Tag $TAG_VERSION != docs/overrides/main.html $MAIN_HTML_VERSION"
             ERRORS=1
           fi
           if [ "$ERRORS" -ne 0 ]; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,10 +124,10 @@ References:
 ### Organisation
 ```
 tests/
-├── unit/          # Fast, isolated tests (~1,537 tests)
-├── acceptance/    # Scenario-based regulatory tests (~275 tests)
-├── contracts/     # Protocol/interface compliance tests (~125 tests)
-├── integration/   # Cross-component integration tests (~101 tests)
+├── unit/          # Fast, isolated tests (~4,500 tests)
+├── acceptance/    # Scenario-based regulatory tests (~500 tests)
+├── contracts/     # Protocol/interface compliance tests (~150 tests)
+├── integration/   # Cross-component integration tests (~130 tests)
 ├── benchmarks/    # Performance tests (marked @pytest.mark.benchmark)
 ├── bdd/           # BDD-style tests (step definitions)
 ├── fixtures/      # Shared test data builders

--- a/docs/assets/stylesheets/homepage.css
+++ b/docs/assets/stylesheets/homepage.css
@@ -72,7 +72,8 @@ body:has(.landing-hero) {
 /* ---------- Hero stage -------------------------------------- */
 .landing-hero {
   position: relative;
-  height: 100vh;
+  min-height: 100svh;
+  max-height: 1100px;
   width: 100%;
   overflow: hidden;
   color: var(--hero-fg);
@@ -130,7 +131,8 @@ body:has(.landing-hero) {
 .hero {
   position: relative;
   z-index: 2;
-  height: 100vh;
+  min-height: 100svh;
+  max-height: 1100px;
   display: grid;
   grid-template-rows: auto 1fr auto;
   padding: 28px 56px;
@@ -412,6 +414,13 @@ body:has(.landing-hero) {
   .meta-row { flex-wrap: wrap; gap: 16px 20px; }
   .meta-divider { display: none; }
   .hero-footer .footer-meta { display: none; }
+}
+
+@media (min-width: 1600px) {
+  body:has(.landing-hero) {
+    --hero-bg-gradient: radial-gradient(ellipse 65% 75% at 50% 30%, #1a1f2e 0%, var(--oah-slate-900) 75%);
+    --constellation-label-opacity: 0.78;
+  }
 }
 
 /* ---------- Reduced motion ---------------------------------- */

--- a/docs/assets/stylesheets/homepage.css
+++ b/docs/assets/stylesheets/homepage.css
@@ -1,283 +1,422 @@
-/* =========================================================================
-   Landing page — full-page hero with formula background
-   ========================================================================= */
+/* =============================================================
+   OpenAfterHours Docs — Landing page
+   Source of truth for the Zensical landing-page design system.
+   Single-screen constellation hero; adapts to Material's light/
+   dark colour scheme toggle.
+   ============================================================= */
 
-/* Hero container: fills viewport below the header */
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@300..700&family=JetBrains+Mono:wght@400;600;700&display=swap");
+
+/* ---------- Design tokens (brand) --------------------------- */
+:root {
+  --oah-orange:           #ff9100;
+  --oah-orange-bright:    #ffa724;
+  --oah-orange-hover:     #e68200;
+  --oah-orange-soft:      #ffb74d;
+  --oah-owl-body:         #c9442a;
+  --oah-owl-eye:          #ffc857;
+  --oah-terminal-green:   #3dd68c;
+
+  --oah-slate-900:        #0d0e11;
+  --oah-slate-850:        #11141a;
+  --oah-slate-800:        #161719;
+  --oah-slate-700:        #1f2430;
+  --oah-slate-600:        #2a3142;
+  --oah-slate-500:        #3b4356;
+  --oah-slate-400:        #64748b;
+  --oah-slate-300:        #a0a4ab;
+  --oah-slate-200:        #cbd0d8;
+  --oah-slate-100:        #e2e4e8;
+  --oah-slate-050:        #f1f5f9;
+
+  --font-sans:    "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI",
+                  Roboto, Helvetica, Arial, sans-serif;
+  --font-display: "Space Grotesk", "Inter", -apple-system, sans-serif;
+  --font-mono:    "JetBrains Mono", "Roboto Mono", "Fira Code",
+                  ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  --ease-std: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* ---------- Landing hero tokens (always dark) --------------- */
+/* Landing is fixed dark by design; it does not participate in
+   Material's light/dark toggle. Only docs pages respect the
+   user's palette choice. */
+body:has(.landing-hero) {
+  overflow: hidden;
+
+  --hero-bg-gradient: radial-gradient(ellipse at 50% 30%, #1a1f2e 0%, var(--oah-slate-900) 70%);
+  --hero-scrim:
+    radial-gradient(ellipse 70% 60% at 50% 45%, rgba(13,14,17,0.55) 0%, rgba(13,14,17,0) 70%),
+    linear-gradient(180deg,
+      rgba(13,14,17,0.45) 0%,
+      rgba(13,14,17,0.10) 30%,
+      rgba(13,14,17,0.10) 70%,
+      rgba(13,14,17,0.65) 100%);
+  --hero-fg:            var(--oah-slate-100);
+  --hero-fg-muted:      var(--oah-slate-200);
+  --hero-fg-faint:      var(--oah-slate-300);
+  --hero-fg-mute:       var(--oah-slate-400);
+  --hero-border:        rgba(216, 222, 233, 0.18);
+  --hero-border-soft:   rgba(216, 222, 233, 0.10);
+  --hero-border-strong: rgba(216, 222, 233, 0.30);
+  --hero-install-bg:    rgba(13, 14, 17, 0.50);
+  --hero-install-border: rgba(216, 222, 233, 0.14);
+  --constellation-star-warm: #ffc857;
+  --constellation-star-cool: #e2e4e8;
+  --constellation-line:      rgba(255, 145, 0, 0.18);
+  --constellation-label:     var(--oah-orange);
+  --constellation-label-opacity: 0.65;
+}
+
+/* ---------- Hero stage -------------------------------------- */
 .landing-hero {
   position: relative;
-  min-height: calc(100vh - 64px);
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  height: 100vh;
+  width: 100%;
   overflow: hidden;
+  color: var(--hero-fg);
+  font-family: var(--font-sans);
+  background: var(--hero-bg-gradient);
 }
 
-/* Formula background — fills the entire hero */
-.formula-background {
+/* ---------- Constellation background ------------------------ */
+.constellation-bg {
   position: absolute;
   inset: 0;
-  pointer-events: none;
-  user-select: none;
   z-index: 0;
+  overflow: hidden;
 }
-
-.formula-background__inner {
-  position: relative;
+.constellation-svg {
+  position: absolute;
+  inset: 0;
   width: 100%;
   height: 100%;
 }
+.constellation-spin {
+  transform-origin: 50% 50%;
+  animation: oah-constellation-rotate 240s linear infinite;
+}
+@keyframes oah-constellation-rotate {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}
+.constellation-line {
+  stroke: var(--constellation-line);
+  stroke-width: 0.08;
+}
+.constellation-star-warm { fill: var(--constellation-star-warm); }
+.constellation-star-cool { fill: var(--constellation-star-cool); }
+.constellation-svg-label {
+  font-family: var(--font-mono);
+  font-size: 1.6px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  fill: var(--constellation-label);
+  opacity: var(--constellation-label-opacity);
+  user-select: none;
+}
 
-.formula {
+/* ---------- Scrim (readability gradient) -------------------- */
+.landing-scrim {
   position: absolute;
-  font-family: "JetBrains Mono", "Roboto Mono", "Fira Code", monospace;
-  white-space: nowrap;
-  font-size: 0.85rem;
+  inset: 0;
+  z-index: 1;
+  background: var(--hero-scrim);
+  pointer-events: none;
+}
+
+/* ---------- Hero layout ------------------------------------- */
+.hero {
+  position: relative;
+  z-index: 2;
+  height: 100vh;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  padding: 28px 56px;
+  max-width: 1280px;
+  margin: 0 auto;
+}
+
+/* ---------- Nav --------------------------------------------- */
+.hero-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  text-decoration: none;
+  color: inherit;
+}
+.brand-icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 999px;
+  border: 1px solid var(--oah-orange);
+  background: var(--oah-slate-700);
+}
+.brand-text { line-height: 1; }
+.brand-name {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 17px;
+  letter-spacing: -0.01em;
+  color: var(--oah-orange);
   line-height: 1;
 }
-
-/* Light mode */
-[data-md-color-scheme="default"] .formula {
-  opacity: 0.06;
-  color: #000;
+.brand-tag {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.06em;
+  color: var(--hero-fg-faint);
+  margin-top: 4px;
+  text-transform: uppercase;
 }
-
-/* Dark mode */
-[data-md-color-scheme="slate"] .formula {
-  opacity: 0.10;
-  color: #fff;
-}
-
-/* Individual formula positions — scattered across the hero */
-.formula--1  { top: 12%; left: 3%;  font-size: 0.9rem;  transform: rotate(-2deg); }
-.formula--2  { top: 50%; left: 58%; font-size: 1.2rem;  transform: rotate(1deg); }
-.formula--3  { top: 75%; left: 2%;  font-size: 0.75rem; transform: rotate(-1deg); }
-.formula--4  { top: 28%; left: 42%; font-size: 0.85rem; transform: rotate(2deg); }
-.formula--5  { top: 8%;  left: 65%; font-size: 0.8rem;  transform: rotate(-3deg); }
-.formula--6  { top: 88%; left: 38%; font-size: 0.95rem; transform: rotate(1.5deg); }
-.formula--7  { top: 42%; left: 8%;  font-size: 1.0rem;  transform: rotate(-0.5deg); }
-.formula--8  { top: 5%;  left: 32%; font-size: 0.7rem;  transform: rotate(2.5deg); }
-.formula--9  { top: 62%; left: 78%; font-size: 0.75rem; transform: rotate(-1.5deg); }
-.formula--10 { top: 22%; left: 82%; font-size: 0.8rem;  transform: rotate(0.5deg); }
-.formula--11 { top: 82%; left: 72%; font-size: 1.2rem;  transform: rotate(-2.5deg); }
-.formula--12 { top: 38%; left: 55%; font-size: 0.7rem;  transform: rotate(1deg); }
-
-/* =========================================================================
-   Landing content — centered over the formula background
-   ========================================================================= */
-
-.landing-content {
-  position: relative;
-  z-index: 1;
-  text-align: center;
-  padding: 2rem 1.5rem;
-  max-width: 700px;
-}
-
-.landing-logo {
-  width: 96px;
-  height: 96px;
-  margin-bottom: 1.5rem;
-  border-radius: 16px;
-}
-
-.landing-title {
-  font-size: 2.4rem;
-  font-weight: 700;
-  margin: 0 0 1rem;
-  color: var(--md-default-fg-color);
-}
-
-.landing-tagline {
-  font-size: 1.15rem;
-  line-height: 1.6;
-  margin: 0 0 2.5rem;
-  opacity: 0.7;
-  color: var(--md-default-fg-color);
-}
-
-.landing-actions {
+.nav-links {
   display: flex;
-  gap: 1rem;
-  justify-content: center;
-  flex-wrap: wrap;
+  align-items: center;
+  gap: 28px;
+  font-size: 14px;
 }
-
-.landing-btn {
+.nav-links a {
+  color: var(--hero-fg-muted);
+  text-decoration: none;
+  transition: color 120ms ease;
+}
+.nav-links a:hover { color: var(--oah-orange); }
+.github-link {
   display: inline-flex;
   align-items: center;
-  padding: 0.75rem 1.75rem;
+  gap: 7px;
+  padding: 6px 12px;
+  border: 1px solid var(--hero-border);
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+.github-link:hover {
+  border-color: var(--oah-orange);
+  color: var(--oah-orange);
+}
+
+/* ---------- Hero body --------------------------------------- */
+.hero-body {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  max-width: 780px;
+  padding: 32px 0;
+}
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  color: var(--oah-orange);
+  margin-bottom: 28px;
+}
+.eyebrow .prompt {
+  color: var(--oah-terminal-green);
+  font-weight: 700;
+}
+.title {
+  font-family: var(--font-display);
+  font-size: clamp(40px, 5.4vw, 68px);
+  line-height: 1.04;
+  letter-spacing: -0.025em;
+  font-weight: 700;
+  margin: 0 0 24px;
+  color: var(--hero-fg);
+}
+.title-accent {
+  background: linear-gradient(90deg,
+    var(--oah-orange) 0%,
+    var(--oah-orange-bright) 60%,
+    var(--oah-owl-eye) 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  font-style: italic;
+  font-weight: 500;
+}
+.lede {
+  font-size: 17px;
+  line-height: 1.55;
+  color: var(--hero-fg-muted);
+  max-width: 620px;
+  margin: 0 0 36px;
+  text-wrap: pretty;
+}
+.lede .num {
+  color: var(--oah-orange);
+  font-family: var(--font-mono);
+  font-size: 15.5px;
+}
+
+/* ---------- Buttons ----------------------------------------- */
+.cta-row {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  margin-bottom: 28px;
+  flex-wrap: wrap;
+}
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 13px 22px;
   border-radius: 8px;
-  font-size: 0.95rem;
+  font-family: var(--font-sans);
+  font-size: 14.5px;
   font-weight: 600;
   text-decoration: none;
-  transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
+  transition: all 200ms var(--ease-std);
+  cursor: pointer;
+  border: none;
 }
-
-.landing-btn--primary {
-  background-color: #ff9100;
+.btn-primary {
+  background: var(--oah-orange);
+  color: #fff;
+  box-shadow: 0 4px 16px rgba(255, 145, 0, 0.22);
+}
+.btn-primary:hover {
+  background: var(--oah-orange-bright);
+  box-shadow: 0 6px 24px rgba(255, 145, 0, 0.36);
+  transform: translateY(-1px);
   color: #fff;
 }
-
-.landing-btn--primary:hover {
-  background-color: #e68200;
-  box-shadow: 0 4px 12px rgba(255, 145, 0, 0.3);
-}
-
-.landing-btn--secondary {
-  border: 2px solid var(--md-default-fg-color--lighter);
-  color: var(--md-default-fg-color);
+.btn-ghost {
   background: transparent;
+  color: var(--hero-fg);
+  border: 1.5px solid var(--hero-border-strong);
+}
+.btn-ghost:hover {
+  border-color: var(--oah-orange);
+  color: var(--oah-orange);
+}
+.btn-ghost .ext {
+  font-family: var(--font-mono);
+  margin-left: 2px;
 }
 
-.landing-btn--secondary:hover {
-  border-color: #ff9100;
-  color: #ff9100;
+/* ---------- Install snippet --------------------------------- */
+.install {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px 10px 16px;
+  background: var(--hero-install-bg);
+  border: 1px solid var(--hero-install-border);
+  border-radius: 8px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  margin-bottom: 40px;
+  width: fit-content;
+  backdrop-filter: blur(8px);
 }
-
-/* =========================================================================
-   Responsive
-   ========================================================================= */
-
-@media screen and (max-width: 76.25em) {
-  .landing-title {
-    font-size: 2rem;
-  }
-
-  .landing-tagline {
-    font-size: 1rem;
-  }
-}
-
-@media screen and (max-width: 600px) {
-  .landing-hero {
-    min-height: calc(100vh - 56px);
-  }
-
-  .landing-logo {
-    width: 72px;
-    height: 72px;
-  }
-
-  .landing-title {
-    font-size: 1.6rem;
-  }
-
-  .landing-tagline {
-    font-size: 0.9rem;
-  }
-
-  .landing-btn {
-    padding: 0.65rem 1.25rem;
-    font-size: 0.85rem;
-  }
-
-  /* Hide the longest formulas on small screens */
-  .formula--1,
-  .formula--3,
-  .formula--5 {
-    display: none;
-  }
-
-  .landing-features__grid {
-    grid-template-columns: 1fr !important;
-  }
-
-  .landing-cta-card {
-    padding: 1.5rem 1.25rem;
-  }
-
-  .landing-cta-card__title {
-    font-size: 1.2rem;
-  }
-}
-
-/* =========================================================================
-   Features section — card grid below the hero
-   ========================================================================= */
-
-.landing-features {
-  max-width: 960px;
-  margin: 0 auto;
-  padding: 3rem 1.5rem 2rem;
-}
-
-.landing-features__grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 1.25rem;
-}
-
-@media screen and (max-width: 76.25em) {
-  .landing-features__grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-}
-
-.feature-card {
-  padding: 1.75rem;
-  border-radius: 12px;
-  border: 1px solid var(--md-default-fg-color--lightest);
-  background: var(--md-default-bg-color);
-  transition: border-color 0.2s, box-shadow 0.2s, transform 0.15s;
-}
-
-.feature-card:hover {
-  border-color: #ff9100;
-  box-shadow: 0 4px 20px rgba(255, 145, 0, 0.12);
-  transform: translateY(-2px);
-}
-
-.feature-card__icon {
-  font-size: 2rem;
-  margin-bottom: 0.75rem;
-}
-
-.feature-card__title {
-  font-size: 1.05rem;
-  font-weight: 600;
-  margin: 0 0 0.5rem;
-  color: var(--md-default-fg-color);
-}
-
-.feature-card__desc {
-  font-size: 0.88rem;
-  line-height: 1.6;
-  margin: 0;
-  opacity: 0.7;
-  color: var(--md-default-fg-color);
-}
-
-/* =========================================================================
-   Interactive UI CTA card — contained card below features
-   ========================================================================= */
-
-.landing-cta-card {
-  grid-column: 1 / -1;
-  padding: 2rem 2.5rem;
-  border-radius: 12px;
-  border: 1px solid rgba(255, 145, 0, 0.2);
-  border-left: 3px solid #ff9100;
-  background: rgba(255, 145, 0, 0.04);
-  text-align: center;
-}
-
-[data-md-color-scheme="slate"] .landing-cta-card {
-  background: rgba(255, 145, 0, 0.06);
-  border-color: rgba(255, 145, 0, 0.25);
-  border-left-color: #ff9100;
-}
-
-.landing-cta-card__title {
-  font-size: 1.4rem;
+.install .prompt {
+  color: var(--oah-terminal-green);
   font-weight: 700;
-  margin: 0 0 0.5rem;
-  color: var(--md-default-fg-color);
+}
+.install code {
+  background: none;
+  padding: 0;
+  color: var(--hero-fg);
+  font-family: var(--font-mono);
+}
+.copy-btn {
+  background: none;
+  border: none;
+  padding: 4px;
+  color: var(--hero-fg-faint);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  border-radius: 4px;
+  transition: color 120ms ease, background 120ms ease;
+}
+.copy-btn:hover {
+  color: var(--oah-orange);
+  background: rgba(255, 145, 0, 0.10);
+}
+.copy-btn.is-copied { color: var(--oah-terminal-green); }
+
+/* ---------- Meta row (stats) -------------------------------- */
+.meta-row {
+  display: flex;
+  align-items: center;
+  gap: 28px;
+  padding-top: 24px;
+  border-top: 1px solid var(--hero-border-soft);
+}
+.meta { min-width: 0; }
+.meta-num {
+  font-family: var(--font-display);
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--hero-fg);
+  letter-spacing: -0.01em;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.meta-lbl {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.06em;
+  color: var(--hero-fg-mute);
+  text-transform: uppercase;
+  margin-top: 4px;
+}
+.meta-divider {
+  width: 1px;
+  height: 32px;
+  background: var(--hero-border-soft);
+}
+.status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--oah-terminal-green);
+  box-shadow: 0 0 0 3px rgba(61, 214, 140, 0.15);
+  animation: oah-pulse 2.4s ease-in-out infinite;
+}
+@keyframes oah-pulse {
+  50% { box-shadow: 0 0 0 7px rgba(61, 214, 140, 0); }
 }
 
-.landing-cta-card__desc {
-  font-size: 0.95rem;
-  line-height: 1.6;
-  margin: 0 0 1.5rem;
-  opacity: 0.7;
-  color: var(--md-default-fg-color);
+/* ---------- Footer ------------------------------------------ */
+.hero-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  color: var(--hero-fg-mute);
+  padding-top: 12px;
+}
+.footer-meta { color: var(--hero-fg-mute); }
+
+/* ---------- Responsive -------------------------------------- */
+@media (max-width: 880px) {
+  .hero { padding: 20px 24px; }
+  .nav-links a:not(.github-link) { display: none; }
+  .meta-row { flex-wrap: wrap; gap: 16px 20px; }
+  .meta-divider { display: none; }
+  .hero-footer .footer-meta { display: none; }
+}
+
+/* ---------- Reduced motion ---------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  .constellation-spin,
+  .status-dot { animation: none; }
+  .btn, .nav-links a, .copy-btn { transition: none; }
 }

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -24,64 +24,122 @@
   {% if not page.url %}
     <section class="landing-hero" data-screen-label="01 Hero">
       <div class="constellation-bg" aria-hidden="true">
-        <svg class="constellation-svg" viewBox="0 0 100 100" preserveAspectRatio="none">
+        <svg class="constellation-svg" viewBox="0 0 200 100" preserveAspectRatio="xMidYMid slice">
           <g class="constellation-spin">
-            <line class="constellation-line" x1="12" y1="22" x2="18" y2="18" />
-            <line class="constellation-line" x1="18" y1="18" x2="22" y2="26" />
-            <line class="constellation-line" x1="22" y1="26" x2="28" y2="20" />
-            <line class="constellation-line" x1="22" y1="26" x2="24" y2="32" />
-            <line class="constellation-line" x1="18" y1="18" x2="24" y2="32" />
-            <line class="constellation-line" x1="62" y1="30" x2="70" y2="26" />
-            <line class="constellation-line" x1="70" y1="26" x2="76" y2="34" />
-            <line class="constellation-line" x1="76" y1="34" x2="68" y2="38" />
-            <line class="constellation-line" x1="62" y1="30" x2="68" y2="38" />
-            <line class="constellation-line" x1="70" y1="26" x2="80" y2="28" />
-            <line class="constellation-line" x1="42" y1="70" x2="50" y2="64" />
-            <line class="constellation-line" x1="50" y1="64" x2="56" y2="72" />
-            <line class="constellation-line" x1="56" y1="72" x2="48" y2="78" />
-            <line class="constellation-line" x1="48" y1="78" x2="38" y2="76" />
-            <line class="constellation-line" x1="42" y1="70" x2="38" y2="76" />
+            {# Cluster A — left bleed (visible on wider screens) #}
+            <line class="constellation-line" x1="22" y1="36" x2="30" y2="28" />
+            <line class="constellation-line" x1="30" y1="28" x2="40" y2="30" />
+            <line class="constellation-line" x1="40" y1="30" x2="44" y2="42" />
+            <line class="constellation-line" x1="44" y1="42" x2="28" y2="46" />
+            <line class="constellation-line" x1="28" y1="46" x2="22" y2="36" />
+            <line class="constellation-line" x1="30" y1="28" x2="28" y2="46" />
 
-            <circle class="constellation-star-warm" cx="12" cy="22" r="0.432"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="3s" repeatCount="indefinite" /></circle>
-            <circle class="constellation-star-warm" cx="18" cy="18" r="0.324"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="4s" repeatCount="indefinite" /></circle>
-            <circle class="constellation-star-warm" cx="22" cy="26" r="0.360"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="5s" repeatCount="indefinite" /></circle>
-            <circle class="constellation-star-warm" cx="28" cy="20" r="0.288"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="6s" repeatCount="indefinite" /></circle>
-            <circle class="constellation-star-warm" cx="24" cy="32" r="0.396"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="7s" repeatCount="indefinite" /></circle>
-            <circle class="constellation-star-warm" cx="62" cy="30" r="0.468"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="3s" repeatCount="indefinite" /></circle>
-            <circle class="constellation-star-warm" cx="70" cy="26" r="0.324"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="4s" repeatCount="indefinite" /></circle>
-            <circle class="constellation-star-warm" cx="76" cy="34" r="0.360"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="5s" repeatCount="indefinite" /></circle>
-            <circle class="constellation-star-warm" cx="68" cy="38" r="0.396"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="6s" repeatCount="indefinite" /></circle>
-            <circle class="constellation-star-warm" cx="80" cy="28" r="0.288"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="7s" repeatCount="indefinite" /></circle>
-            <circle class="constellation-star-warm" cx="42" cy="70" r="0.432"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="3s" repeatCount="indefinite" /></circle>
-            <circle class="constellation-star-warm" cx="50" cy="64" r="0.360"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="4s" repeatCount="indefinite" /></circle>
-            <circle class="constellation-star-warm" cx="56" cy="72" r="0.324"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="5s" repeatCount="indefinite" /></circle>
-            <circle class="constellation-star-warm" cx="48" cy="78" r="0.396"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="6s" repeatCount="indefinite" /></circle>
-            <circle class="constellation-star-warm" cx="38" cy="76" r="0.288"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="7s" repeatCount="indefinite" /></circle>
+            {# Cluster B — Standardised Approach (safe zone) #}
+            <line class="constellation-line" x1="80" y1="28" x2="86" y2="22" />
+            <line class="constellation-line" x1="86" y1="22" x2="94" y2="26" />
+            <line class="constellation-line" x1="94" y1="26" x2="96" y2="36" />
+            <line class="constellation-line" x1="96" y1="36" x2="84" y2="38" />
+            <line class="constellation-line" x1="84" y1="38" x2="80" y2="28" />
+            <line class="constellation-line" x1="86" y1="22" x2="84" y2="38" />
 
-            <circle class="constellation-star-cool" cx="8"  cy="60" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="3s" repeatCount="indefinite" /></circle>
-            <circle class="constellation-star-cool" cx="15" cy="45" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="4s" repeatCount="indefinite" /></circle>
-            <circle class="constellation-star-cool" cx="33" cy="50" r="0.252"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="5s" repeatCount="indefinite" /></circle>
-            <circle class="constellation-star-cool" cx="44" cy="18" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="6s" repeatCount="indefinite" /></circle>
-            <circle class="constellation-star-cool" cx="55" cy="14" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="7s" repeatCount="indefinite" /></circle>
-            <circle class="constellation-star-cool" cx="88" cy="60" r="0.252"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="3s" repeatCount="indefinite" /></circle>
-            <circle class="constellation-star-cool" cx="92" cy="45" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="4s" repeatCount="indefinite" /></circle>
-            <circle class="constellation-star-cool" cx="85" cy="80" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="5s" repeatCount="indefinite" /></circle>
-            <circle class="constellation-star-cool" cx="25" cy="88" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="6s" repeatCount="indefinite" /></circle>
-            <circle class="constellation-star-cool" cx="65" cy="90" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="7s" repeatCount="indefinite" /></circle>
-            <circle class="constellation-star-cool" cx="5"  cy="12" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="3s" repeatCount="indefinite" /></circle>
-            <circle class="constellation-star-cool" cx="95" cy="12" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="4s" repeatCount="indefinite" /></circle>
-            <circle class="constellation-star-cool" cx="70" cy="8"  r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="5s" repeatCount="indefinite" /></circle>
-            <circle class="constellation-star-cool" cx="30" cy="8"  r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="6s" repeatCount="indefinite" /></circle>
-            <circle class="constellation-star-cool" cx="50" cy="38" r="0.252"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="7s" repeatCount="indefinite" /></circle>
-            <circle class="constellation-star-cool" cx="78" cy="70" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="3s" repeatCount="indefinite" /></circle>
-            <circle class="constellation-star-cool" cx="12" cy="78" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="4s" repeatCount="indefinite" /></circle>
-            <circle class="constellation-star-cool" cx="42" cy="92" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="5s" repeatCount="indefinite" /></circle>
-            <circle class="constellation-star-cool" cx="88" cy="92" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="6s" repeatCount="indefinite" /></circle>
-            <circle class="constellation-star-cool" cx="60" cy="50" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="7s" repeatCount="indefinite" /></circle>
+            {# Cluster C — Foundation IRB (safe zone) #}
+            <line class="constellation-line" x1="108" y1="58" x2="116" y2="54" />
+            <line class="constellation-line" x1="116" y1="54" x2="124" y2="58" />
+            <line class="constellation-line" x1="124" y1="58" x2="122" y2="68" />
+            <line class="constellation-line" x1="122" y1="68" x2="110" y2="70" />
+            <line class="constellation-line" x1="110" y1="70" x2="108" y2="58" />
+            <line class="constellation-line" x1="116" y1="54" x2="110" y2="70" />
 
-            <text class="constellation-svg-label" x="20.8" y="31.6" text-anchor="middle">Standardised Approach</text>
-            <text class="constellation-svg-label" x="71.2" y="39.2" text-anchor="middle">Foundation IRB</text>
-            <text class="constellation-svg-label" x="46.8" y="80"   text-anchor="middle">CRR &middot; Basel 3.1</text>
+            {# Cluster D — right bleed (visible on wider screens) #}
+            <line class="constellation-line" x1="158" y1="34" x2="166" y2="28" />
+            <line class="constellation-line" x1="166" y1="28" x2="176" y2="32" />
+            <line class="constellation-line" x1="176" y1="32" x2="178" y2="44" />
+            <line class="constellation-line" x1="178" y1="44" x2="164" y2="46" />
+            <line class="constellation-line" x1="164" y1="46" x2="158" y2="34" />
+            <line class="constellation-line" x1="158" y1="34" x2="176" y2="32" />
+
+            {# Cluster E — CRR · Basel 3.1 anchor (safe zone) #}
+            <line class="constellation-line" x1="90" y1="82" x2="98" y2="78" />
+            <line class="constellation-line" x1="98" y1="78" x2="106" y2="82" />
+            <line class="constellation-line" x1="106" y1="82" x2="100" y2="88" />
+            <line class="constellation-line" x1="100" y1="88" x2="90" y2="82" />
+            <line class="constellation-line" x1="98" y1="78" x2="100" y2="88" />
+
+            {# Warm cluster stars #}
+            <circle class="constellation-star-warm" cx="22"  cy="36" r="0.432"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="3s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-warm" cx="30"  cy="28" r="0.360"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="4s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-warm" cx="40"  cy="30" r="0.396"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="5s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-warm" cx="44"  cy="42" r="0.324"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="6s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-warm" cx="28"  cy="46" r="0.396"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="7s" repeatCount="indefinite" /></circle>
+
+            <circle class="constellation-star-warm" cx="80"  cy="28" r="0.468"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="3s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-warm" cx="86"  cy="22" r="0.360"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="4s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-warm" cx="94"  cy="26" r="0.324"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="5s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-warm" cx="96"  cy="36" r="0.396"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="6s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-warm" cx="84"  cy="38" r="0.288"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="7s" repeatCount="indefinite" /></circle>
+
+            <circle class="constellation-star-warm" cx="108" cy="58" r="0.432"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="3s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-warm" cx="116" cy="54" r="0.324"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="4s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-warm" cx="124" cy="58" r="0.396"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="5s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-warm" cx="122" cy="68" r="0.360"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="6s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-warm" cx="110" cy="70" r="0.288"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="7s" repeatCount="indefinite" /></circle>
+
+            <circle class="constellation-star-warm" cx="158" cy="34" r="0.396"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="3s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-warm" cx="166" cy="28" r="0.468"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="4s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-warm" cx="176" cy="32" r="0.324"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="5s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-warm" cx="178" cy="44" r="0.360"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="6s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-warm" cx="164" cy="46" r="0.288"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="7s" repeatCount="indefinite" /></circle>
+
+            <circle class="constellation-star-warm" cx="90"  cy="82" r="0.396"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="3s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-warm" cx="98"  cy="78" r="0.324"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="4s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-warm" cx="106" cy="82" r="0.432"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="5s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-warm" cx="100" cy="88" r="0.360"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="6s" repeatCount="indefinite" /></circle>
+
+            {# Cool filler stars — left bleed #}
+            <circle class="constellation-star-cool" cx="5"   cy="18" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="3s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="12"  cy="60" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="4s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="18"  cy="72" r="0.252"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="5s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="50"  cy="12" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="6s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="8"   cy="88" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="7s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="55"  cy="88" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="3s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="15"  cy="8"  r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="4s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="65"  cy="50" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="5s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="48"  cy="60" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="6s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="40"  cy="80" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="7s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="35"  cy="14" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="3s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="60"  cy="70" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="4s" repeatCount="indefinite" /></circle>
+
+            {# Cool filler stars — safe zone (mobile-visible) #}
+            <circle class="constellation-star-cool" cx="75"  cy="12" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="5s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="92"  cy="10" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="6s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="108" cy="8"  r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="7s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="125" cy="14" r="0.252"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="3s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="78"  cy="50" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="4s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="85"  cy="66" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="5s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="120" cy="32" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="6s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="104" cy="48" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="7s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="118" cy="78" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="3s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="82"  cy="76" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="4s" repeatCount="indefinite" /></circle>
+
+            {# Cool filler stars — right bleed #}
+            <circle class="constellation-star-cool" cx="140" cy="12" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="5s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="150" cy="74" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="6s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="190" cy="22" r="0.252"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="7s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="195" cy="62" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="3s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="145" cy="88" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="4s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="182" cy="82" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="5s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="140" cy="50" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="6s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="190" cy="92" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="7s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="155" cy="18" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="3s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="170" cy="16" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="4s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="168" cy="90" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="5s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="175" cy="55" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="6s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="135" cy="60" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="7s" repeatCount="indefinite" /></circle>
+
+            {# Labels — kept within safe zone so they remain visible on mobile #}
+            <text class="constellation-svg-label" x="88"  y="44" text-anchor="middle">Standardised Approach</text>
+            <text class="constellation-svg-label" x="116" y="76" text-anchor="middle">Foundation IRB</text>
+            <text class="constellation-svg-label" x="100" y="94" text-anchor="middle">CRR &middot; Basel 3.1</text>
           </g>
         </svg>
       </div>

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,71 +1,182 @@
 {% extends "base.html" %}
 
+{#
+  OpenAfterHours — Zensical landing page override.
+  On "/" (page.url empty) we render a full-viewport constellation hero
+  and hide Material's header, sidebar, main container, and footer so the
+  hero owns the screen. Every other page gets the stock Material layout.
+#}
+
+{% block extrahead %}
+  {{ super() }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+{% endblock %}
+
+{% block header %}
+  {% if not page.url %}
+  {% else %}
+    {{ super() }}
+  {% endif %}
+{% endblock %}
+
 {% block hero %}
   {% if not page.url %}
-    <div class="landing-hero">
-      <div class="formula-background" aria-hidden="true">
-        <div class="formula-background__inner">
-          <span class="formula formula--1">K = LGD &times; &Phi;[&radic;(1&minus;R)&sup1; &times; &Phi;&sup1;(PD) + &radic;(R/(1&minus;R)) &times; &Phi;&sup1;(0.999)] &minus; PD &times; LGD</span>
-          <span class="formula formula--2">RWA = K &times; 12.5 &times; EAD</span>
-          <span class="formula formula--3">R = 0.12 &times; (1 &minus; e<sup>&minus;50&middot;PD</sup>) / (1 &minus; e<sup>&minus;50</sup>) + 0.24 &times; [1 &minus; (1 &minus; e<sup>&minus;50&middot;PD</sup>) / (1 &minus; e<sup>&minus;50</sup>)]</span>
-          <span class="formula formula--4">b = (0.11852 &minus; 0.05478 &times; ln(PD))&sup2;</span>
-          <span class="formula formula--5">MA = (1 + (M &minus; 2.5) &times; b) / (1 &minus; 1.5 &times; b)</span>
-          <span class="formula formula--6">&Phi;(x) = &frac12;[1 + erf(x/&radic;2)]</span>
-          <span class="formula formula--7">EL = PD &times; LGD</span>
-          <span class="formula formula--8">RW = K &times; 12.5 &times; MA</span>
-          <span class="formula formula--9">CCF &times; Off-Balance = EAD</span>
-          <span class="formula formula--10">SA: RWA = EAD &times; RW%</span>
-          <span class="formula formula--11">&Phi;&sup1;(PD)</span>
-          <span class="formula formula--12">N[(1&minus;R)<sup>&minus;0.5</sup> &times; G(PD)]</span>
-        </div>
-      </div>
-      <div class="landing-content">
-        <img src="assets/openafterhours_icon_512.png" alt="" class="landing-logo">
-        <h1 class="landing-title">UK Credit Risk RWA Calculator</h1>
-        <p class="landing-tagline">High-performance Risk-Weighted Assets calculation<br>for Basel 3.1 and CRR frameworks</p>
-        <div class="landing-actions">
-          <a href="overview/" class="landing-btn landing-btn--primary">Explore Documentation</a>
-          <a href="getting-started/quickstart/" class="landing-btn landing-btn--secondary">Quick Start</a>
-        </div>
-      </div>
-    </div>
+    <section class="landing-hero" data-screen-label="01 Hero">
+      <div class="constellation-bg" aria-hidden="true">
+        <svg class="constellation-svg" viewBox="0 0 100 100" preserveAspectRatio="none">
+          <g class="constellation-spin">
+            <line class="constellation-line" x1="12" y1="22" x2="18" y2="18" />
+            <line class="constellation-line" x1="18" y1="18" x2="22" y2="26" />
+            <line class="constellation-line" x1="22" y1="26" x2="28" y2="20" />
+            <line class="constellation-line" x1="22" y1="26" x2="24" y2="32" />
+            <line class="constellation-line" x1="18" y1="18" x2="24" y2="32" />
+            <line class="constellation-line" x1="62" y1="30" x2="70" y2="26" />
+            <line class="constellation-line" x1="70" y1="26" x2="76" y2="34" />
+            <line class="constellation-line" x1="76" y1="34" x2="68" y2="38" />
+            <line class="constellation-line" x1="62" y1="30" x2="68" y2="38" />
+            <line class="constellation-line" x1="70" y1="26" x2="80" y2="28" />
+            <line class="constellation-line" x1="42" y1="70" x2="50" y2="64" />
+            <line class="constellation-line" x1="50" y1="64" x2="56" y2="72" />
+            <line class="constellation-line" x1="56" y1="72" x2="48" y2="78" />
+            <line class="constellation-line" x1="48" y1="78" x2="38" y2="76" />
+            <line class="constellation-line" x1="42" y1="70" x2="38" y2="76" />
 
-    <!-- Features section -->
-    <div class="landing-features">
-      <div class="landing-features__grid">
-        <div class="feature-card">
-          <div class="feature-card__icon">&#x1f9ee;</div>
-          <h3 class="feature-card__title">SA &amp; IRB Approaches</h3>
-          <p class="feature-card__desc">Full Standardised Approach and Internal Ratings-Based calculation with PRA-compliant risk weights, LGD floors, and maturity adjustments.</p>
-        </div>
-        <div class="feature-card">
-          <div class="feature-card__icon">&#x2696;&#xfe0f;</div>
-          <h3 class="feature-card__title">CRR vs Basel 3.1</h3>
-          <p class="feature-card__desc">Side-by-side framework comparison with waterfall analysis, exposure-level deltas, and output floor impact assessment.</p>
-        </div>
-        <div class="feature-card">
-          <div class="feature-card__icon">&#x26a1;</div>
-          <h3 class="feature-card__title">Polars-Powered Engine</h3>
-          <p class="feature-card__desc">Built on Polars LazyFrames for high-performance columnar processing. Handles millions of exposures with minimal memory.</p>
-        </div>
-        <div class="feature-card">
-          <div class="feature-card__icon">&#x1f4cb;</div>
-          <h3 class="feature-card__title">Regulatory Reporting</h3>
-          <p class="feature-card__desc">COREP-aligned output templates and Pillar III disclosure support. Export results ready for regulatory submission.</p>
-        </div>
-      </div>
-    </div>
+            <circle class="constellation-star-warm" cx="12" cy="22" r="0.432"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="3s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-warm" cx="18" cy="18" r="0.324"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="4s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-warm" cx="22" cy="26" r="0.360"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="5s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-warm" cx="28" cy="20" r="0.288"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="6s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-warm" cx="24" cy="32" r="0.396"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="7s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-warm" cx="62" cy="30" r="0.468"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="3s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-warm" cx="70" cy="26" r="0.324"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="4s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-warm" cx="76" cy="34" r="0.360"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="5s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-warm" cx="68" cy="38" r="0.396"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="6s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-warm" cx="80" cy="28" r="0.288"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="7s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-warm" cx="42" cy="70" r="0.432"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="3s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-warm" cx="50" cy="64" r="0.360"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="4s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-warm" cx="56" cy="72" r="0.324"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="5s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-warm" cx="48" cy="78" r="0.396"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="6s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-warm" cx="38" cy="76" r="0.288"><animate attributeName="opacity" values="0.4;0.95;0.4" dur="7s" repeatCount="indefinite" /></circle>
 
-      <!-- Interactive UI CTA card -->
-      <div class="landing-cta-card">
-        <h2 class="landing-cta-card__title">Interactive Calculator</h2>
-        <p class="landing-cta-card__desc">Launch the browser-based UI to run calculations, explore results, and compare frameworks &mdash; no code required.</p>
-        <div class="landing-actions">
-          <a href="user-guide/interactive-ui/" class="landing-btn landing-btn--primary">Learn More</a>
-          <a href="getting-started/installation/" class="landing-btn landing-btn--secondary">Install Guide</a>
-        </div>
+            <circle class="constellation-star-cool" cx="8"  cy="60" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="3s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="15" cy="45" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="4s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="33" cy="50" r="0.252"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="5s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="44" cy="18" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="6s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="55" cy="14" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="7s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="88" cy="60" r="0.252"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="3s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="92" cy="45" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="4s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="85" cy="80" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="5s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="25" cy="88" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="6s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="65" cy="90" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="7s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="5"  cy="12" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="3s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="95" cy="12" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="4s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="70" cy="8"  r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="5s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="30" cy="8"  r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="6s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="50" cy="38" r="0.252"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="7s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="78" cy="70" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="3s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="12" cy="78" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="4s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="42" cy="92" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="5s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="88" cy="92" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="6s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="60" cy="50" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4"  dur="7s" repeatCount="indefinite" /></circle>
+
+            <text class="constellation-svg-label" x="20.8" y="31.6" text-anchor="middle">Standardised Approach</text>
+            <text class="constellation-svg-label" x="71.2" y="39.2" text-anchor="middle">Foundation IRB</text>
+            <text class="constellation-svg-label" x="46.8" y="80"   text-anchor="middle">CRR &middot; Basel 3.1</text>
+          </g>
+        </svg>
       </div>
-    </div>
+
+      <div class="landing-scrim" aria-hidden="true"></div>
+
+      <div class="hero">
+        <header class="hero-nav">
+          <a class="brand" href="./">
+            <img src="assets/openafterhours_icon_512.png" alt="" class="brand-icon">
+            <div class="brand-text">
+              <div class="brand-name">OpenAfterHours</div>
+              <div class="brand-tag">UK Credit Risk RWA Calculator</div>
+            </div>
+          </a>
+          <nav class="nav-links">
+            <a href="overview/">Docs</a>
+            <a href="user-guide/interactive-ui/">Calculator</a>
+            <a href="framework-comparison/technical-reference/">Reference</a>
+            <a href="https://github.com/OpenAfterHours/rwa_calculator" class="github-link" target="_blank" rel="noopener">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.1.79-.25.79-.55v-2.13c-3.2.7-3.87-1.36-3.87-1.36-.52-1.32-1.27-1.67-1.27-1.67-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.75 2.69 1.24 3.34.95.1-.74.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.18a10.93 10.93 0 0 1 5.74 0c2.19-1.49 3.15-1.18 3.15-1.18.62 1.58.23 2.75.11 3.04.74.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.39-5.26 5.68.41.36.78 1.06.78 2.15v3.18c0 .31.21.66.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5Z"/></svg>
+              <span>GitHub</span>
+            </a>
+          </nav>
+        </header>
+
+        <div class="hero-body">
+          <div class="eyebrow">
+            <span class="prompt">$</span>
+            <span>OPEN SOURCE &middot; BUILT AFTER HOURS</span>
+          </div>
+
+          <h1 class="title">
+            Risk-Weighted Assets,<br>
+            <span class="title-accent">computed at the speed of polars.</span>
+          </h1>
+
+          <p class="lede">
+            A high-performance Python engine for CRR (Basel 3.0) and Basel 3.1
+            (PRA PS1/26) &mdash; Standardised, F-IRB and A-IRB approaches.
+            Millions of exposures in seconds, audited across
+            <span class="num">~1,934 tests</span>.
+          </p>
+
+          <div class="cta-row">
+            <a href="overview/" class="btn btn-primary">
+              Read the Docs
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+            </a>
+            <a href="user-guide/interactive-ui/" class="btn btn-ghost">
+              Open Calculator <span class="ext">&#8599;</span>
+            </a>
+          </div>
+
+          <div class="install">
+            <span class="prompt">$</span>
+            <code>pip install rwa-calculator</code>
+            <button
+              class="copy-btn"
+              type="button"
+              aria-label="Copy install command"
+              onclick="var b=this;navigator.clipboard&amp;&amp;navigator.clipboard.writeText('pip install rwa-calculator').then(function(){b.classList.add('is-copied');setTimeout(function(){b.classList.remove('is-copied');},1400);});">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+            </button>
+          </div>
+
+          <div class="meta-row">
+            <div class="meta">
+              <div class="meta-num">50&ndash;100&times;</div>
+              <div class="meta-lbl">Faster than reference impl.</div>
+            </div>
+            <div class="meta-divider"></div>
+            <div class="meta">
+              <div class="meta-num">~1,934</div>
+              <div class="meta-lbl">Regulatory test cases</div>
+            </div>
+            <div class="meta-divider"></div>
+            <div class="meta">
+              <div class="meta-num">3 frameworks</div>
+              <div class="meta-lbl">CRR &middot; Basel 3.1 &middot; IRB</div>
+            </div>
+            <div class="meta-divider"></div>
+            <div class="meta status">
+              <div class="meta-num"><span class="status-dot"></span> Active dev</div>
+              <div class="meta-lbl">Pre-1.0 &middot; not production-ready</div>
+            </div>
+          </div>
+        </div>
+
+        <footer class="hero-footer">
+          <div>OpenAfterHours &middot; Open source regulatory tools</div>
+          <div class="footer-meta">v0.1.62 &middot; MIT licensed &middot; github.com/OpenAfterHours</div>
+        </footer>
+      </div>
+    </section>
   {% endif %}
 {% endblock %}
 
@@ -77,6 +188,13 @@
 {% endblock %}
 
 {% block container %}
+  {% if not page.url %}
+  {% else %}
+    {{ super() }}
+  {% endif %}
+{% endblock %}
+
+{% block footer %}
   {% if not page.url %}
   {% else %}
     {{ super() }}

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -136,6 +136,50 @@
             <circle class="constellation-star-cool" cx="175" cy="55" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="6s" repeatCount="indefinite" /></circle>
             <circle class="constellation-star-cool" cx="135" cy="60" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="7s" repeatCount="indefinite" /></circle>
 
+            {# Envelope stars — placed outside the 200×100 viewBox so rotation never leaves the sides bare #}
+            <circle class="constellation-star-cool" cx="-8"  cy="30"  r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="5s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="0"   cy="70"  r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="6s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="15"  cy="-10" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="7s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="40"  cy="-25" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="3s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="75"  cy="-15" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="4s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="100" cy="-40" r="0.252"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="5s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="125" cy="-20" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="6s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="160" cy="-25" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="7s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="195" cy="-15" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="3s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="208" cy="20"  r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="4s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="210" cy="55"  r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="5s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="205" cy="80"  r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="6s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="198" cy="108" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="7s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="170" cy="120" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="3s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="135" cy="135" r="0.252"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="4s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="100" cy="130" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="5s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="65"  cy="138" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="6s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="30"  cy="125" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="7s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="2"   cy="110" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="3s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="-5"  cy="85"  r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="4s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="-10" cy="20"  r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="5s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="215" cy="30"  r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="6s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="218" cy="75"  r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="7s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="88"  cy="-45" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="3s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="105" cy="148" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="4s" repeatCount="indefinite" /></circle>
+
+            {# Densifying feeder strips (x=50..150, y<0 or y>100) — these swing into the L/R bands at 90°/270° rotation #}
+            <circle class="constellation-star-cool" cx="55"  cy="-8"  r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="5s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="70"  cy="-30" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="6s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="85"  cy="-12" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="7s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="112" cy="-30" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="3s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="130" cy="-8"  r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="4s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="145" cy="-32" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="5s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="58"  cy="-32" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="6s" repeatCount="indefinite" /></circle>
+
+            <circle class="constellation-star-cool" cx="55"  cy="112" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="7s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="72"  cy="128" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="3s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="88"  cy="115" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="4s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="115" cy="118" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="5s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="125" cy="132" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="6s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="148" cy="115" r="0.180"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="7s" repeatCount="indefinite" /></circle>
+            <circle class="constellation-star-cool" cx="80"  cy="110" r="0.216"><animate attributeName="opacity" values="0.4;0.7;0.4" dur="3s" repeatCount="indefinite" /></circle>
+
             {# Labels — kept within safe zone so they remain visible on mobile #}
             <text class="constellation-svg-label" x="88"  y="44" text-anchor="middle">Standardised Approach</text>
             <text class="constellation-svg-label" x="116" y="76" text-anchor="middle">Foundation IRB</text>

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -181,7 +181,7 @@
             A high-performance Python engine for CRR (Basel 3.0) and Basel 3.1
             (PRA PS1/26) &mdash; Standardised, F-IRB and A-IRB approaches.
             Millions of exposures in seconds, audited across
-            <span class="num">~1,934 tests</span>.
+            <span class="num">~5,300 tests</span>.
           </p>
 
           <div class="cta-row">
@@ -213,13 +213,13 @@
             </div>
             <div class="meta-divider"></div>
             <div class="meta">
-              <div class="meta-num">~1,934</div>
+              <div class="meta-num">~5,300</div>
               <div class="meta-lbl">Regulatory test cases</div>
             </div>
             <div class="meta-divider"></div>
             <div class="meta">
-              <div class="meta-num">3 frameworks</div>
-              <div class="meta-lbl">CRR &middot; Basel 3.1 &middot; IRB</div>
+              <div class="meta-num">2 frameworks</div>
+              <div class="meta-lbl">CRR &middot; Basel 3.1</div>
             </div>
             <div class="meta-divider"></div>
             <div class="meta status">
@@ -231,7 +231,7 @@
 
         <footer class="hero-footer">
           <div>OpenAfterHours &middot; Open source regulatory tools</div>
-          <div class="footer-meta">v0.1.62 &middot; MIT licensed &middot; github.com/OpenAfterHours</div>
+          <div class="footer-meta">v0.1.62 &middot; Apache-2.0 licensed &middot; github.com/OpenAfterHours</div>
         </footer>
       </div>
     </section>

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -33,6 +33,7 @@ VERSION_FILES = {
     "pyproject.toml": r'version = "(\d+\.\d+\.\d+)"',
     "src/rwa_calc/__init__.py": r'__version__ = "(\d+\.\d+\.\d+)"',
     "docs/overview.md": r"\| Calculator \| (\d+\.\d+\.\d+) \|",
+    "docs/overrides/main.html": r">v(\d+\.\d+\.\d+) &middot;",
 }
 
 CHANGELOG_PATH = PROJECT_ROOT / "docs" / "appendix" / "changelog.md"

--- a/zensical.toml
+++ b/zensical.toml
@@ -170,18 +170,18 @@ features = [
 repo = "fontawesome/brands/github"
 
 [[project.theme.palette]]
-scheme = "default"
-primary = "orange"
-accent = "orange"
-toggle.icon = "material/brightness-7"
-toggle.name = "Switch to dark mode"
-
-[[project.theme.palette]]
 scheme = "slate"
 primary = "orange"
 accent = "orange"
 toggle.icon = "material/brightness-4"
 toggle.name = "Switch to light mode"
+
+[[project.theme.palette]]
+scheme = "default"
+primary = "orange"
+accent = "orange"
+toggle.icon = "material/brightness-7"
+toggle.name = "Switch to dark mode"
 
 # -- Plugins ----------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- **New constellation landing page** on `/`: dark hero with an animated SVG star field, content hierarchy (nav → title → CTAs → install → stats → footer), and a Material-theme bypass so only the home page runs the override. Background uses a 2:1 viewBox with `preserveAspectRatio="xMidYMid slice"` and `min-height: 100svh; max-height: 1100px` — stars stay circular at every aspect ratio, and the layout neither stretches on ultrawide/4K nor jitters with mobile URL-bar chrome. Outer-envelope stars (radii 90–115) keep the sides populated during the slow rotation, so 90°/270° no longer exposes empty bands.
- **Stat corrections** on the landing page and in contributor docs: footer license `MIT` → `Apache-2.0` (matches `LICENSE` and `pyproject.toml`), meta row `3 frameworks · CRR · Basel 3.1 · IRB` → `2 frameworks · CRR · Basel 3.1` (IRB is an approach within both frameworks, not a separate framework), and test counts `~1,934` → `~5,300` (lede + meta row + `CLAUDE.md` + memory).
- **Version auto-sync for the landing page footer**: `docs/overrides/main.html` is now registered in `scripts/deploy.py:VERSION_FILES` so any `deploy.py` bump updates the footer alongside `pyproject.toml`, `__init__.py`, and `docs/overview.md`. A matching check in `.github/workflows/publish.yml` fails the release if the footer ever drifts from the release tag — so the version on GitHub Pages cannot lag the actual release.
- **Docs default to dark theme** (`zensical.toml` palette order swapped) to match the hero aesthetic.

## Test plan

- [ ] `uv run zensical serve` — landing page renders with constellation hero at `/`; other pages keep Material layout.
- [ ] Resize viewport across mobile portrait (≤400w), tablet, laptop, 1920×1080, 2560×1440, and 3840×1600 — stars stay circular, content stays centered, no horizontal scrollbars, no empty bands during rotation.
- [ ] Let the full 4-minute rotation cycle complete on a wide screen — sides stay populated throughout.
- [ ] Check `prefers-reduced-motion: reduce` — rotation and pulse animations stop; layout unchanged.
- [ ] Footer reads `v0.1.62 · Apache-2.0 licensed · …`; meta row reads `2 frameworks / CRR · Basel 3.1`; lede and meta show `~5,300 tests`.
- [ ] `uv run python scripts/deploy.py 0.1.62 --dry-run` lists `docs/overrides/main.html` in the update set.
- [ ] Next release publishes through `publish.yml` without the new version-consistency check firing `::error::`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)