### PR TITLE
fix(hierarchy): apply CRR Art. 138 multi-rating resolution

### DIFF
--- a/.claude/skills/crr/references/exposure-classification.md
+++ b/.claude/skills/crr/references/exposure-classification.md
@@ -38,6 +38,10 @@ If retail thresholds are breached, exposure reclassified as CORPORATE.
 - Child counterparties inherit ratings from parent when they lack their own
 - Traversed upward until a rated entity is found
 - Internal and external ratings resolved independently
+- External ratings are **not** inherited — each counterparty's own ECAI
+  assessments are resolved in place per **CRR Art. 138**: per-agency dedup to
+  most recent, then 1 → use it, 2 → higher RW (worse), ≥ 3 → higher of the
+  two lowest RWs (second-best)
 
 ## Lending Group Aggregation
 

--- a/docs/appendix/changelog.md
+++ b/docs/appendix/changelog.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **CRR Art. 138 multi-rating resolution now applied**: `HierarchyResolver._build_rating_inheritance_lazy` in `engine/hierarchy.py` previously collapsed multiple external ratings per counterparty to the single most recent one, silently ignoring assessments from additional nominated ECAIs. Replaced the "most recent wins" logic for external ratings with Art. 138: per-agency dedup (most recent per agency) followed by the 1-rating / 2-rating (higher RW) / ≥ 3-rating (second-best) selection rule. Resolution is performed on CQS rather than RW because within every SA exposure class the CQS → RW mapping is monotone non-decreasing. Internal-rating resolution, inheritance, and the external-rating non-inheritance rule are unchanged. New `TestArt138ExternalRatingResolution` class in `tests/unit/test_hierarchy.py` covers single/two/three/four-rating cases, ties at the two lowest CQS, same-agency repeats, and null-CQS rows. Existing fixture counterparties have ≤ 1 external agency each, so no acceptance-golden changes. Ref: CRR Art. 138.
+
 ## [0.1.202] — 2026-04-18
 
 ### Fixed

--- a/docs/specifications/common/hierarchy-classification.md
+++ b/docs/specifications/common/hierarchy-classification.md
@@ -13,6 +13,26 @@ The calculator resolves parent-child relationships between counterparties using 
 - Child counterparties inherit ratings from their parent when they lack their own
 - The hierarchy is traversed upward until a rated entity is found
 
+### Multi-Rating Resolution (CRR Art. 138)
+
+When a counterparty has more than one external rating from nominated ECAIs, the
+resolver applies CRR Art. 138 rather than picking the most recent:
+
+1. **Per-agency dedup** — multiple assessments from the same agency are first
+   reduced to the most recent (one assessment per agency).
+2. **Art. 138 selection** across the remaining distinct-agency assessments:
+    - 1 assessment → use it.
+    - 2 assessments → use the **higher risk weight** (worse of the two).
+    - ≥ 3 assessments → take the two assessments generating the two lowest
+      risk weights, then use the **higher** of those two (i.e. the
+      "second-best" rating).
+
+Resolution is performed on CQS rather than RW because the CQS → RW mapping is
+monotone non-decreasing within every SA exposure class, so ranking by CQS
+ascending gives the same outcome as ranking by RW. External ratings are **not**
+inherited from the parent — only the counterparty's own assessments participate
+in Art. 138 resolution.
+
 ### Lending Group Aggregation
 
 Lending groups aggregate exposure across related counterparties for threshold calculations (e.g., SME turnover, retail exposure limits).
@@ -404,6 +424,7 @@ All monetary values are converted to the base currency (GBP) using provided FX r
 | HIER-4 | Facility hierarchy — sub-facility undrawn amount aggregated to root facility |
 | HIER-5 | Duplicate membership — counterparty in multiple lending groups keeps first assignment |
 | HIER-6 | Negative drawn amount clamping — negative balances do not increase undrawn headroom |
+| HIER-7 | Multi-rating resolution — CRR Art. 138 applied when ≥ 2 external ratings present |
 
 ### Exposure Classification (CLASS)
 

--- a/src/rwa_calc/engine/hierarchy.py
+++ b/src/rwa_calc/engine/hierarchy.py
@@ -273,26 +273,27 @@ class HierarchyResolver:
         """
         Build rating lookup with dual per-type resolution and inheritance.
 
-        Internal ratings: most recent per counterparty, with inheritance from
-        the ultimate parent when the entity has no own internal rating.
-
-        External ratings: resolved per CRR Art. 138 across nominated ECAIs.
-        Repeated assessments from the same agency are first reduced to the
-        most recent (one assessment per agency), then:
+        Resolves the best internal and best external rating separately per
+        counterparty, then inherits internal ratings from the ultimate parent
+        when the entity has no own internal rating. External ratings are NOT
+        inherited — they apply only to the counterparty explicitly rated by
+        the agency, and when more than one ECAI has rated the counterparty
+        they are combined per CRR Art. 138:
 
           - 1 assessment  -> use it
           - 2 assessments -> use the higher risk weight (worse CQS)
           - >= 3          -> use the higher of the two lowest risk weights
                              (i.e. the second-best rating)
 
+        Repeated assessments from the same agency are first reduced to the
+        most recent (one assessment per agency) before Art. 138 is applied.
         Resolution is performed on CQS rather than RW because within every
         SA exposure class the CQS -> RW mapping is monotone non-decreasing,
         so ranking by CQS ascending yields the same outcome as ranking by RW.
-        External ratings are NOT inherited from the parent.
 
         Returns LazyFrame with columns:
         - counterparty_reference: The entity
-        - internal_pd: Most recent internal PD (own or inherited from parent)
+        - internal_pd: Best internal PD (own or inherited from parent)
         - internal_model_id: Model ID for the internal rating
         - external_cqs: Art. 138-resolved external CQS (own only — not inherited)
         - cqs: Alias of external_cqs
@@ -306,7 +307,7 @@ class HierarchyResolver:
             {"model_id": ColumnSpec(pl.String, required=False)},
         )
 
-        # Most recent internal rating per counterparty (no CQS — that's external only)
+        # Best internal rating per counterparty (no CQS — that's external only)
         best_internal = (
             ratings.filter(pl.col("rating_type") == "internal")
             .sort(sort_cols, descending=[True, True])

--- a/src/rwa_calc/engine/hierarchy.py
+++ b/src/rwa_calc/engine/hierarchy.py
@@ -273,17 +273,28 @@ class HierarchyResolver:
         """
         Build rating lookup with dual per-type resolution and inheritance.
 
-        Resolves the best internal and best external rating separately per
-        counterparty, then inherits internal ratings from the ultimate parent
-        when the entity has no own internal rating. External ratings are NOT
-        inherited — they apply only to the counterparty explicitly rated by
-        the agency.
+        Internal ratings: most recent per counterparty, with inheritance from
+        the ultimate parent when the entity has no own internal rating.
+
+        External ratings: resolved per CRR Art. 138 across nominated ECAIs.
+        Repeated assessments from the same agency are first reduced to the
+        most recent (one assessment per agency), then:
+
+          - 1 assessment  -> use it
+          - 2 assessments -> use the higher risk weight (worse CQS)
+          - >= 3          -> use the higher of the two lowest risk weights
+                             (i.e. the second-best rating)
+
+        Resolution is performed on CQS rather than RW because within every
+        SA exposure class the CQS -> RW mapping is monotone non-decreasing,
+        so ranking by CQS ascending yields the same outcome as ranking by RW.
+        External ratings are NOT inherited from the parent.
 
         Returns LazyFrame with columns:
         - counterparty_reference: The entity
-        - internal_pd: Best internal PD (own or inherited from parent)
+        - internal_pd: Most recent internal PD (own or inherited from parent)
         - internal_model_id: Model ID for the internal rating
-        - external_cqs: Best external CQS (own only — not inherited)
+        - external_cqs: Art. 138-resolved external CQS (own only — not inherited)
         - cqs: Alias of external_cqs
         - pd: Alias of internal_pd
         """
@@ -295,7 +306,7 @@ class HierarchyResolver:
             {"model_id": ColumnSpec(pl.String, required=False)},
         )
 
-        # Best internal rating per counterparty (no CQS — that's external only)
+        # Most recent internal rating per counterparty (no CQS — that's external only)
         best_internal = (
             ratings.filter(pl.col("rating_type") == "internal")
             .sort(sort_cols, descending=[True, True])
@@ -310,18 +321,34 @@ class HierarchyResolver:
             )
         )
 
-        # Best external rating per counterparty
-        best_external = (
-            ratings.filter(pl.col("rating_type") == "external")
+        # Art. 138: per-agency dedup to most recent, then resolve across agencies.
+        # Rows without a CQS are ignored (only rated assessments count).
+        per_agency_latest = (
+            ratings.filter((pl.col("rating_type") == "external") & pl.col("cqs").is_not_null())
             .sort(sort_cols, descending=[True, True])
-            .group_by("counterparty_reference")
+            .group_by(["counterparty_reference", "rating_agency"])
             .first()
-            .select(
-                [
-                    pl.col("counterparty_reference").alias("_ext_cp"),
-                    pl.col("cqs").alias("external_cqs"),
-                ]
-            )
+            .select(["counterparty_reference", "cqs"])
+        )
+
+        # Rank CQS ascending per counterparty (lowest CQS == best rating == lowest RW).
+        # For 1 assessment: pick rank 1. For >= 2: pick rank 2 -- this yields the
+        # higher-RW side of the two lowest RWs, i.e. "worse of two" / "second-best".
+        ranked_external = per_agency_latest.with_columns(
+            [
+                pl.col("cqs").rank(method="ordinal").over("counterparty_reference").alias("_rank"),
+                pl.len().over("counterparty_reference").alias("_n"),
+            ]
+        )
+
+        best_external = ranked_external.filter(
+            ((pl.col("_n") == 1) & (pl.col("_rank") == 1))
+            | ((pl.col("_n") >= 2) & (pl.col("_rank") == 2))
+        ).select(
+            [
+                pl.col("counterparty_reference").alias("_ext_cp"),
+                pl.col("cqs").alias("external_cqs"),
+            ]
         )
 
         # Materialise the per-counterparty best-rating aggregates before joining.

--- a/tests/benchmarks/data_generators.py
+++ b/tests/benchmarks/data_generators.py
@@ -406,6 +406,7 @@ def generate_facilities(
                 "is_payroll_loan": np.full(n_facilities, None),  # Payroll loan flag
                 "is_buy_to_let": np.full(n_facilities, None),  # BTL flag for SME supporting factor
                 "has_one_day_maturity_floor": np.full(n_facilities, None),  # Repo/SFT 1-day floor
+                "is_sft": np.full(n_facilities, False),  # CRR Art. 162(1) repo-style SFT flag
                 "facility_termination_date": pl.Series([None] * n_facilities, dtype=pl.Date),
                 "underlying_risk_type": pl.Series([None] * n_facilities, dtype=pl.String),
                 "lgd_unsecured": np.full(n_facilities, None),  # A-IRB unsecured LGD
@@ -603,6 +604,7 @@ def generate_loans(
             "is_payroll_loan": np.full(n_loans, None),  # Payroll loan flag
             "is_buy_to_let": np.full(n_loans, None),  # BTL flag for SME supporting factor
             "has_one_day_maturity_floor": np.full(n_loans, None),  # Repo/SFT 1-day floor
+            "is_sft": np.full(n_loans, False),  # CRR Art. 162(1) repo-style SFT flag
             "has_netting_agreement": np.full(n_loans, None),  # Netting flag (CRR Art. 195)
             "netting_facility_reference": np.full(n_loans, None),  # Facility for netting agreement
             "due_diligence_performed": np.full(n_loans, None),  # Art. 110A (B31 only)
@@ -948,6 +950,7 @@ def generate_contingents(
                 "ead_modelled": np.full(n_contingents, None),  # No modelled EAD for benchmarks
                 "is_short_term_trade_lc": is_short_term_trade_lc,  # True for LCs
                 "has_one_day_maturity_floor": np.full(n_contingents, None),  # Repo/SFT 1-day floor
+                "is_sft": np.full(n_contingents, False),  # CRR Art. 162(1) repo-style SFT flag
                 "bs_type": np.full(n_contingents, "OFB"),  # Off-balance-sheet by default
                 "due_diligence_performed": np.full(n_contingents, None),  # Art. 110A (B31 only)
                 "due_diligence_override_rw": np.full(

--- a/tests/unit/test_hierarchy.py
+++ b/tests/unit/test_hierarchy.py
@@ -615,6 +615,171 @@ class TestDualRatingResolution:
         assert cp["pd"][0] is None
 
 
+class TestArt138ExternalRatingResolution:
+    """CRR Art. 138 multi-rating resolution across nominated ECAIs.
+
+    - 1 rating  -> use it
+    - 2 ratings -> higher RW (worse CQS)
+    - >=3       -> higher of the two lowest RWs (second-best CQS)
+
+    Same-agency repeats first reduce to the most recent before Art. 138 runs.
+    """
+
+    @staticmethod
+    def _run(resolver: HierarchyResolver, ratings: pl.LazyFrame) -> pl.DataFrame:
+        counterparties = pl.DataFrame({"counterparty_reference": ["CP"]}).lazy()
+        ultimate_parents = pl.LazyFrame(
+            schema={
+                "counterparty_reference": pl.String,
+                "ultimate_parent_reference": pl.String,
+                "hierarchy_depth": pl.Int32,
+            }
+        )
+        return resolver._build_rating_inheritance_lazy(
+            counterparties, ratings, ultimate_parents
+        ).collect()
+
+    @staticmethod
+    def _ratings(cqs_by_agency: list[tuple[str, int, date]]) -> pl.LazyFrame:
+        return pl.DataFrame(
+            {
+                "rating_reference": [f"R{i}" for i in range(len(cqs_by_agency))],
+                "counterparty_reference": ["CP"] * len(cqs_by_agency),
+                "rating_type": ["external"] * len(cqs_by_agency),
+                "rating_agency": [a for a, _, _ in cqs_by_agency],
+                "rating_value": ["x"] * len(cqs_by_agency),
+                "cqs": [c for _, c, _ in cqs_by_agency],
+                "pd": [None] * len(cqs_by_agency),
+                "rating_date": [d for _, _, d in cqs_by_agency],
+            }
+        ).lazy()
+
+    def test_single_rating_used_as_is(self, resolver: HierarchyResolver) -> None:
+        ratings = self._ratings([("MOODYS", 3, date(2024, 6, 1))])
+        result = self._run(resolver, ratings)
+        assert result["external_cqs"][0] == 3
+
+    def test_two_ratings_picks_worse(self, resolver: HierarchyResolver) -> None:
+        # CQS 2 (better, lower RW) vs CQS 4 (worse) -> worse wins
+        ratings = self._ratings(
+            [
+                ("MOODYS", 2, date(2024, 6, 1)),
+                ("SP", 4, date(2024, 6, 1)),
+            ]
+        )
+        result = self._run(resolver, ratings)
+        assert result["external_cqs"][0] == 4
+
+    def test_two_ratings_same_cqs(self, resolver: HierarchyResolver) -> None:
+        ratings = self._ratings(
+            [
+                ("MOODYS", 3, date(2024, 6, 1)),
+                ("SP", 3, date(2024, 6, 1)),
+            ]
+        )
+        result = self._run(resolver, ratings)
+        assert result["external_cqs"][0] == 3
+
+    def test_three_ratings_picks_second_best(self, resolver: HierarchyResolver) -> None:
+        # CQS 1, 3, 5 -> two lowest are 1 and 3 -> higher = 3
+        ratings = self._ratings(
+            [
+                ("MOODYS", 1, date(2024, 6, 1)),
+                ("SP", 3, date(2024, 6, 1)),
+                ("FITCH", 5, date(2024, 6, 1)),
+            ]
+        )
+        result = self._run(resolver, ratings)
+        assert result["external_cqs"][0] == 3
+
+    def test_four_ratings_second_best(self, resolver: HierarchyResolver) -> None:
+        # CQS 1, 3, 4, 6 -> second-best = 3
+        ratings = self._ratings(
+            [
+                ("MOODYS", 1, date(2024, 6, 1)),
+                ("SP", 3, date(2024, 6, 1)),
+                ("FITCH", 4, date(2024, 6, 1)),
+                ("DBRS", 6, date(2024, 6, 1)),
+            ]
+        )
+        result = self._run(resolver, ratings)
+        assert result["external_cqs"][0] == 3
+
+    def test_ties_at_best_cqs(self, resolver: HierarchyResolver) -> None:
+        # CQS 2, 2, 3, 5 -> two lowest are 2 and 2 -> second-best = 2
+        ratings = self._ratings(
+            [
+                ("MOODYS", 2, date(2024, 6, 1)),
+                ("SP", 2, date(2024, 6, 1)),
+                ("FITCH", 3, date(2024, 6, 1)),
+                ("DBRS", 5, date(2024, 6, 1)),
+            ]
+        )
+        result = self._run(resolver, ratings)
+        assert result["external_cqs"][0] == 2
+
+    def test_ties_at_second_and_third(self, resolver: HierarchyResolver) -> None:
+        # CQS 1, 3, 3, 5 -> second-best = 3
+        ratings = self._ratings(
+            [
+                ("MOODYS", 1, date(2024, 6, 1)),
+                ("SP", 3, date(2024, 6, 1)),
+                ("FITCH", 3, date(2024, 6, 1)),
+                ("DBRS", 5, date(2024, 6, 1)),
+            ]
+        )
+        result = self._run(resolver, ratings)
+        assert result["external_cqs"][0] == 3
+
+    def test_same_agency_repeated_reduces_to_most_recent(self, resolver: HierarchyResolver) -> None:
+        # Two agencies, each with two assessments. Moody's newest is CQS 2,
+        # S&P newest is CQS 4. Art. 138 on [2, 4] -> worse = 4.
+        ratings = self._ratings(
+            [
+                ("MOODYS", 5, date(2022, 1, 1)),
+                ("MOODYS", 2, date(2024, 6, 1)),
+                ("SP", 6, date(2022, 1, 1)),
+                ("SP", 4, date(2024, 6, 1)),
+            ]
+        )
+        result = self._run(resolver, ratings)
+        assert result["external_cqs"][0] == 4
+
+    def test_null_cqs_ignored(self, resolver: HierarchyResolver) -> None:
+        # One valid rating (CQS 3) and one null-CQS row; null is dropped
+        # so n==1 -> use the valid one.
+        ratings = pl.DataFrame(
+            {
+                "rating_reference": ["R0", "R1"],
+                "counterparty_reference": ["CP", "CP"],
+                "rating_type": ["external", "external"],
+                "rating_agency": ["MOODYS", "SP"],
+                "rating_value": ["Baa1", "NR"],
+                "cqs": [3, None],
+                "pd": [None, None],
+                "rating_date": [date(2024, 6, 1), date(2024, 6, 1)],
+            }
+        ).lazy()
+        result = self._run(resolver, ratings)
+        assert result["external_cqs"][0] == 3
+
+    def test_no_external_ratings(self, resolver: HierarchyResolver) -> None:
+        ratings = pl.DataFrame(
+            {
+                "rating_reference": ["R0"],
+                "counterparty_reference": ["CP"],
+                "rating_type": ["internal"],
+                "rating_agency": ["INT"],
+                "rating_value": ["INT_A"],
+                "cqs": [None],
+                "pd": [0.01],
+                "rating_date": [date(2024, 6, 1)],
+            }
+        ).lazy()
+        result = self._run(resolver, ratings)
+        assert result["external_cqs"][0] is None
+
+
 # =============================================================================
 # Exposure Unification Tests
 # =============================================================================


### PR DESCRIPTION
External ratings were collapsed to the single most recent assessment per
counterparty, silently ignoring additional nominated ECAIs. Replace the
"most recent wins" logic with Art. 138:

- per-agency dedup to most recent assessment
- 1 rating  -> use it
- 2 ratings -> higher RW (worse CQS)
- >= 3      -> higher of the two lowest RWs (second-best)

Resolution is performed on CQS rather than RW because the CQS -> RW
mapping is monotone non-decreasing within every SA exposure class.
Internal-rating handling and the external-rating non-inheritance rule
are unchanged.

New TestArt138ExternalRatingResolution class covers single / two / three /
four-rating cases, ties at the two lowest CQS, same-agency repeats, and
null-CQS rows. No fixture counterparty has >= 2 external agencies so
acceptance goldens are unaffected.

Ref: CRR Art. 138.

https://claude.ai/code/session_01JX7jdWQ4yioj5SdYUkP4Mc