### PR TITLE
refactor(logging): enhance stage_timer logging format

### DIFF
--- a/docs/specifications/observability.md
+++ b/docs/specifications/observability.md
@@ -23,7 +23,7 @@ do to stay inside it.
 | `bind_run_id(run_id)` | Bind an existing id (returns reset token). |
 | `clear_run_id(token)` | Release the binding using the token from `new_run_id` / `bind_run_id`. |
 | `current_run_id()` | Read the active id (or `None`). |
-| `stage_timer(logger, stage, **extra)` | Context manager emitting INFO entry/exit records with `elapsed_ms`. Emits WARNING on exception so timing is always recorded. |
+| `stage_timer(logger, stage, **extra)` | Context manager emitting a DEBUG entry record and an INFO exit record carrying `elapsed_ms`. Emits WARNING on exception so timing is always recorded. |
 | `RunIdFilter` | `logging.Filter` that injects `record.run_id` on every record. |
 | `TextFormatter` / `JsonFormatter` | The two supported output formats. |
 
@@ -32,8 +32,13 @@ do to stay inside it.
 **Text format** (default):
 
 ```
-2026-04-19T18:42:01 INFO    [a3f0c1b24e1c] rwa_calc.engine.classifier: stage completed
+2026-04-19T18:42:01 INFO    [a3f0c1b24e1c] rwa_calc.engine.pipeline: classifier completed in 12.3 ms
 ```
+
+The stage name and elapsed time are embedded in the message string so the
+default `%(message)s` formatter surfaces them without per-stage configuration.
+A companion DEBUG record (`"classifier started"`) bookends each stage and is
+suppressed at default `INFO` level.
 
 **JSON format** (audit ingestion), single line per record:
 
@@ -41,9 +46,9 @@ do to stay inside it.
 {
   "timestamp": "2026-04-19T18:42:01.123456+00:00",
   "level": "INFO",
-  "logger": "rwa_calc.engine.classifier",
+  "logger": "rwa_calc.engine.pipeline",
   "run_id": "a3f0c1b24e1c",
-  "message": "stage completed",
+  "message": "classifier completed in 12.3 ms",
   "module": "pipeline",
   "line": 399,
   "stage": "classifier",
@@ -60,8 +65,8 @@ Only a whitelisted set of `extra` keys is propagated to JSON: `stage`,
 
 | Level | When |
 |---|---|
-| DEBUG | Branch decisions (IRB-vs-SA routing, CRM method selection, RE-splitter no-op skip). Guard expensive formatting with `logger.isEnabledFor(logging.DEBUG)`. |
-| INFO | Stage entry/exit (via `stage_timer`); pipeline start/finish; config echo (framework, permission_mode — never regulatory scalars); a single `"collected N calculation errors"` line when errors are appended. |
+| DEBUG | Stage entry records (via `stage_timer`); branch decisions (IRB-vs-SA routing, CRM method selection, RE-splitter no-op skip). Guard expensive formatting with `logger.isEnabledFor(logging.DEBUG)`. |
+| INFO | Stage exit lines with embedded `elapsed_ms` (via `stage_timer`); pipeline start/finish (with total elapsed + error count); stage-level row/row-count summaries (e.g. `"calculators materialised N rows"`); config echo (framework, permission_mode — never regulatory scalars); a single `"collected N calculation errors"` line when errors are appended. |
 | WARNING | Missing optional inputs (e.g., IRB selected without `model_permissions`); fallback risk weights; stage failures (emitted by `stage_timer` on exception). |
 | ERROR | Reserved for truly unexpected exceptions. Regulatory issues remain `CalculationError`. |
 

--- a/src/rwa_calc/engine/pipeline.py
+++ b/src/rwa_calc/engine/pipeline.py
@@ -27,6 +27,7 @@ Usage:
 from __future__ import annotations
 
 import logging
+import time
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -229,9 +230,12 @@ class PipelineOrchestrator:
         self._errors = []
 
         run_id, run_id_token = new_run_id()
+        run_start = time.perf_counter()
         try:
             logger.info(
-                "pipeline run starting",
+                "pipeline run starting (framework=%s, permission_mode=%s)",
+                config.framework.value,
+                config.permission_mode.value,
                 extra={
                     "stage": "pipeline",
                     "framework": config.framework.value,
@@ -299,9 +303,16 @@ class PipelineOrchestrator:
                 all_errors = list(result.errors) + extra_errors
                 result = replace(result, errors=all_errors)
 
+            total_ms = round((time.perf_counter() - run_start) * 1000.0, 2)
             logger.info(
-                "pipeline run finished",
-                extra={"stage": "pipeline", "error_count": len(result.errors)},
+                "pipeline run finished in %.1f ms (%d errors)",
+                total_ms,
+                len(result.errors),
+                extra={
+                    "stage": "pipeline",
+                    "elapsed_ms": total_ms,
+                    "error_count": len(result.errors),
+                },
             )
             return result
         finally:
@@ -576,6 +587,20 @@ class PipelineOrchestrator:
                     [sa_result, irb_result, slotting_result],
                     config,
                     ["sa_branch", "irb_branch", "slotting_branch"],
+                )
+                sa_rows = sa_df.height
+                irb_rows = irb_df.height
+                slotting_rows = slotting_df.height
+                logger.info(
+                    "calculators materialised %d rows (sa=%d, irb=%d, slotting=%d)",
+                    sa_rows + irb_rows + slotting_rows,
+                    sa_rows,
+                    irb_rows,
+                    slotting_rows,
+                    extra={
+                        "stage": "calculators",
+                        "row_count": sa_rows + irb_rows + slotting_rows,
+                    },
                 )
 
                 # Equity — separate path (not in unified frame)

--- a/src/rwa_calc/observability/context.py
+++ b/src/rwa_calc/observability/context.py
@@ -71,16 +71,21 @@ def stage_timer(
     stage: str,
     **extra: Any,
 ) -> Iterator[None]:
-    """Emit INFO entry/exit records bracketing a pipeline stage.
+    """Emit DEBUG entry / INFO exit records bracketing a pipeline stage.
 
-    Entry record: "stage entered" with `extra={"stage": stage, **extra}`.
-    Exit record:  "stage completed" with `extra={..., "elapsed_ms": <float>}`.
+    Entry record (DEBUG): ``"<stage> started"``.
+    Exit record (INFO):   ``"<stage> completed in <elapsed> ms"``.
+    Failure record (WARNING): ``"<stage> failed after <elapsed> ms"``.
+
+    The stage name and elapsed time are embedded in the message so the text
+    formatter surfaces them without additional configuration. The same values
+    remain on ``extra={"stage": ..., "elapsed_ms": ...}`` for JSON consumers.
 
     Exceptions propagate unchanged; the exit record is still emitted so
-    timing is visible even for failed stages, at WARNING level.
+    timing is visible even for failed stages.
     """
     base_extra = {"stage": stage, **extra}
-    logger.info("stage entered", extra=base_extra)
+    logger.debug("%s started", stage, extra=base_extra)
     start = time.perf_counter()
     failed = False
     try:
@@ -92,6 +97,6 @@ def stage_timer(
         elapsed_ms = round((time.perf_counter() - start) * 1000.0, 2)
         exit_extra = {**base_extra, "elapsed_ms": elapsed_ms}
         if failed:
-            logger.warning("stage failed", extra=exit_extra)
+            logger.warning("%s failed after %.1f ms", stage, elapsed_ms, extra=exit_extra)
         else:
-            logger.info("stage completed", extra=exit_extra)
+            logger.info("%s completed in %.1f ms", stage, elapsed_ms, extra=exit_extra)

--- a/tests/integration/test_logging_pipeline.py
+++ b/tests/integration/test_logging_pipeline.py
@@ -96,10 +96,16 @@ class TestPipelineLoggingInstrumentation:
         _, records = _run_pipeline_capturing_records(minimal_bundle, crr_config, caplog)
 
         stages_with_entries = {
-            r.stage for r in records if r.message == "stage entered" and hasattr(r, "stage")
+            r.stage
+            for r in records
+            if r.levelname == "DEBUG" and hasattr(r, "stage") and r.message == f"{r.stage} started"
         }
         stages_with_exits = {
-            r.stage for r in records if r.message == "stage completed" and hasattr(r, "stage")
+            r.stage
+            for r in records
+            if r.levelname == "INFO"
+            and hasattr(r, "stage")
+            and r.message.startswith(f"{r.stage} completed in ")
         }
 
         expected_stages = {
@@ -123,7 +129,13 @@ class TestPipelineLoggingInstrumentation:
     ) -> None:
         _, records = _run_pipeline_capturing_records(minimal_bundle, crr_config, caplog)
 
-        exit_records = [r for r in records if r.message == "stage completed"]
+        exit_records = [
+            r
+            for r in records
+            if r.levelname == "INFO"
+            and hasattr(r, "stage")
+            and r.message.startswith(f"{r.stage} completed in ")
+        ]
         assert exit_records, "no stage exit records captured"
         for record in exit_records:
             elapsed = getattr(record, "elapsed_ms", None)

--- a/tests/unit/observability/test_logging.py
+++ b/tests/unit/observability/test_logging.py
@@ -247,32 +247,47 @@ class TestConfigureLogging:
 class TestStageTimer:
     def test_emits_entry_and_exit_records(self, caplog: pytest.LogCaptureFixture) -> None:
         logger = logging.getLogger("rwa_calc.test.stage")
-        caplog.set_level(logging.INFO, logger=logger.name)
+        caplog.set_level(logging.DEBUG, logger=logger.name)
 
         with stage_timer(logger, "loader", framework="CRR"):
             pass
 
-        messages = [(r.levelname, r.message, getattr(r, "stage", None)) for r in caplog.records]
-        assert ("INFO", "stage entered", "loader") in messages
-        assert any(
-            level == "INFO" and msg == "stage completed" and stage == "loader"
-            for level, msg, stage in messages
-        )
-        exit_record = next(r for r in caplog.records if r.message == "stage completed")
+        entry_records = [
+            r
+            for r in caplog.records
+            if r.levelname == "DEBUG" and getattr(r, "stage", None) == "loader"
+        ]
+        exit_records = [
+            r
+            for r in caplog.records
+            if r.levelname == "INFO" and getattr(r, "stage", None) == "loader"
+        ]
+        assert len(entry_records) == 1, "expected a single DEBUG entry record"
+        assert entry_records[0].message == "loader started"
+        assert len(exit_records) == 1, "expected a single INFO exit record"
+        exit_record = exit_records[0]
+        assert exit_record.message.startswith("loader completed in ")
+        assert exit_record.message.endswith(" ms")
         assert getattr(exit_record, "elapsed_ms", None) is not None
         assert getattr(exit_record, "framework", None) == "CRR"
 
     def test_emits_warning_on_exception(self, caplog: pytest.LogCaptureFixture) -> None:
         logger = logging.getLogger("rwa_calc.test.stage")
-        caplog.set_level(logging.INFO, logger=logger.name)
+        caplog.set_level(logging.DEBUG, logger=logger.name)
 
         with pytest.raises(RuntimeError), stage_timer(logger, "classifier"):
             raise RuntimeError("boom")
 
-        failures = [r for r in caplog.records if r.message == "stage failed"]
+        failures = [
+            r
+            for r in caplog.records
+            if r.levelname == "WARNING" and getattr(r, "stage", None) == "classifier"
+        ]
         assert len(failures) == 1
-        assert failures[0].levelname == "WARNING"
-        assert getattr(failures[0], "elapsed_ms", None) is not None
+        failure = failures[0]
+        assert failure.message.startswith("classifier failed after ")
+        assert failure.message.endswith(" ms")
+        assert getattr(failure, "elapsed_ms", None) is not None
 
 
 class TestCalculationConfigLogFields:


### PR DESCRIPTION
* Change entry log level to DEBUG with message format "<stage> started".
* Update exit log level to INFO with message format "<stage> completed in <elapsed> ms".
* Add WARNING level for failure logs with message format "<stage> failed after <elapsed> ms".
* Update documentation to reflect new logging behavior.