### PR TITLE
fix(guarantee): route guarantor rating by beneficiary's approach

### DIFF
--- a/src/rwa_calc/engine/crm/guarantees.py
+++ b/src/rwa_calc/engine/crm/guarantees.py
@@ -176,16 +176,28 @@ def apply_guarantees(
         ]
     )
 
-    # Determine guarantor approach from IRB permissions AND rating type.
+    # Determine guarantor approach from IRB permissions, rating type, AND
+    # the BENEFICIARY's approach.
     # A guarantor is treated under IRB only if:
-    # 1. The firm has IRB permission for the guarantor's exposure class, AND
-    # 2. The guarantor has an internal rating (PD) — indicating the firm
+    # 1. The beneficiary exposure is itself on FIRB/AIRB (CRR Art. 161 /
+    #    Basel 3.1 CRE22.70-85: parameter substitution applies only to IRB
+    #    beneficiaries; SA beneficiaries always substitute via guarantor's
+    #    SA risk weight regardless of the guarantor's internal rating), AND
+    # 2. The firm has IRB permission for the guarantor's exposure class, AND
+    # 3. The guarantor has an internal rating (PD) — indicating the firm
     #    actively rates this counterparty under its IRB model.
     # Counterparties with only external ratings (CQS) are treated under SA.
     irb_exposure_class_values = set()
     for ec, approaches in config.irb_permissions.permissions.items():
         if ApproachType.FIRB in approaches or ApproachType.AIRB in approaches:
             irb_exposure_class_values.add(ec.value)
+
+    irb_beneficiary_approaches = [ApproachType.FIRB.value, ApproachType.AIRB.value]
+    beneficiary_is_irb = (
+        pl.col("approach").fill_null("").is_in(irb_beneficiary_approaches)
+        if "approach" in exposures.collect_schema().names()
+        else pl.lit(False)
+    )
 
     # Art. 114(4)/(7): an EU/UK domestic-currency CGCB guarantor must receive 0% RW
     # via the SA short-circuit, even if the guarantor has an internal PD that would
@@ -218,7 +230,8 @@ def apply_guarantees(
             pl.when(is_domestic_cgcb_guarantor)
             .then(pl.lit("sa"))
             .when(
-                (pl.col("guarantor_exposure_class") != "")
+                beneficiary_is_irb
+                & (pl.col("guarantor_exposure_class") != "")
                 & pl.col("guarantor_exposure_class").is_in(list(irb_exposure_class_values))
                 & pl.col("guarantor_internal_pd").is_not_null()
             )

--- a/src/rwa_calc/engine/irb/guarantee.py
+++ b/src/rwa_calc/engine/irb/guarantee.py
@@ -82,7 +82,12 @@ def apply_guarantee_substitution(lf: pl.LazyFrame, config: CalculationConfig) ->
 
     has_expected_loss = "expected_loss" in cols
     has_guarantor_pd = "guarantor_pd" in cols
-    use_parameter_substitution = config.is_basel_3_1 and has_guarantor_pd
+    # PD substitution applies whenever the guarantor has an internal PD.
+    # Per-row routing (IRB-derived RW vs SA-derived RW) is decided inside
+    # _apply_parameter_substitution by guarantor_approach, which is itself
+    # beneficiary-aware (set in engine/crm/guarantees.py). This covers both
+    # CRR Art. 161(3) and Basel 3.1 CRE22.70-85 — only the F-IRB LGD differs.
+    use_parameter_substitution = has_guarantor_pd
 
     # Store original IRB values before substitution (pre-CRM values)
     store_originals = [
@@ -286,12 +291,14 @@ def _apply_parameter_substitution(
     config: CalculationConfig,
     use_parameter_substitution: bool,
 ) -> pl.LazyFrame:
-    """Apply Basel 3.1 parameter substitution for IRB guarantors (CRE22.70-85)."""
+    """Apply parameter substitution for IRB guarantors (CRR Art. 161(3) /
+    Basel 3.1 CRE22.70-85). The F-IRB supervisory LGD differs by framework:
+    0.45 under CRR, 0.40 under Basel 3.1."""
     if use_parameter_substitution:
         from rwa_calc.data.tables.firb_lgd import get_firb_lgd_table_for_framework
 
-        firb_lgd_table = get_firb_lgd_table_for_framework(is_basel_3_1=True)
-        firb_lgd_senior = float(firb_lgd_table["unsecured_senior"])  # 0.40
+        firb_lgd_table = get_firb_lgd_table_for_framework(is_basel_3_1=config.is_basel_3_1)
+        firb_lgd_senior = float(firb_lgd_table["unsecured_senior"])
 
         # Ensure columns required by _parametric_irb_risk_weight_expr exist
         ensure_cols: list[pl.Expr] = []
@@ -428,12 +435,12 @@ def _apply_double_default(
             .then(pl.col("lgd_floored") if "lgd_floored" in cols else pl.col("lgd"))
             .otherwise(pl.lit(None).cast(pl.Float64))
             .alias("irb_lgd_double_default"),
-            # Track DD method
+            # Track DD method — True only when actual double-default treatment is
+            # applied (eligible AND beneficial vs. plain substitution). PD substitution
+            # is tracked independently via _is_pd_substitution.
             pl.when(_is_dd_eligible & (rw_dd_floored < pl.col("guarantor_rw")))
             .then(pl.lit(True))
-            .otherwise(
-                pl.col("_is_pd_substitution") if use_parameter_substitution else pl.lit(False)
-            )
+            .otherwise(pl.lit(False))
             .alias("_is_dd_applied"),
         ]
     )
@@ -445,49 +452,15 @@ def _adjust_expected_loss(
     ead_col: str,
     use_parameter_substitution: bool,
 ) -> pl.LazyFrame:
-    """Adjust expected loss for guaranteed portion."""
-    # SA guarantor: no EL concept -- only unguaranteed portion retains IRB EL
-    # IRB guarantor (parameter sub): EL = guarantor_pd x firb_lgd x guaranteed_portion
-    if use_parameter_substitution:
-        from rwa_calc.data.tables.firb_lgd import get_firb_lgd_table_for_framework
+    """Adjust expected loss for guaranteed portion.
 
-        firb_lgd_table = get_firb_lgd_table_for_framework(is_basel_3_1=True)
-        firb_lgd_senior = float(firb_lgd_table["unsecured_senior"])
-
-        has_transactor = "is_qrre_transactor" in lf.collect_schema().names()
-        pd_floor_expr = _pd_floor_expression(config, has_transactor_col=has_transactor)
-        guarantor_pd_floored = pl.max_horizontal(pl.col("guarantor_pd"), pd_floor_expr)
-
-        return lf.with_columns(
-            [
-                pl.when(
-                    (pl.col("guaranteed_portion").fill_null(0) > 0)
-                    & (pl.col("guarantor_rw").is_not_null())
-                    & (pl.col("is_guarantee_beneficial"))
-                )
-                .then(
-                    pl.when(pl.col("_is_pd_substitution"))
-                    .then(
-                        # IRB guarantor: blend IRB EL for unguaranteed +
-                        # substituted EL for guaranteed
-                        pl.col("expected_loss_irb_original")
-                        * (pl.col("unguaranteed_portion") / pl.col(ead_col)).fill_null(1.0)
-                        + guarantor_pd_floored * firb_lgd_senior * pl.col("guaranteed_portion")
-                    )
-                    .otherwise(
-                        # SA guarantor: SA has no EL -- only unguaranteed retains EL
-                        pl.col("expected_loss_irb_original")
-                        * (pl.col("unguaranteed_portion") / pl.col(ead_col)).fill_null(1.0)
-                    )
-                )
-                .otherwise(pl.col("expected_loss_irb_original"))
-                .alias("expected_loss"),
-            ]
-        )
-
-    # CRR: SA guarantors -> reduce EL for guaranteed portion (SA has no EL concept)
-    # CRR: IRB guarantors (non-DD, with PD) -> PD substitution for EL (Art. 161(3))
-    # Double default exposures retain full obligor EL (DD modifies K, not EL)
+    SA guarantor: SA has no EL concept; only the unguaranteed portion retains EL.
+    IRB guarantor: blend borrower EL (unguaranteed) + guarantor EL (guaranteed)
+        per CRR Art. 161(3) / Basel 3.1 CRE22.70-85, using the framework's
+        F-IRB supervisory LGD (0.45 CRR / 0.40 Basel 3.1).
+    Double-default exposures (CRR Art. 153(3)) retain the full obligor EL —
+        DD modifies K, not EL.
+    """
     _base_el = (
         (pl.col("guaranteed_portion").fill_null(0) > 0)
         & (pl.col("guarantor_rw").is_not_null())
@@ -497,34 +470,27 @@ def _adjust_expected_loss(
         pl.col("unguaranteed_portion") / pl.col(ead_col)
     ).fill_null(1.0)
 
-    has_guarantor_pd = "guarantor_pd" in lf.collect_schema().names()
-    if has_guarantor_pd:
+    if use_parameter_substitution:
         from rwa_calc.data.tables.firb_lgd import get_firb_lgd_table_for_framework
 
         firb_lgd_table = get_firb_lgd_table_for_framework(is_basel_3_1=config.is_basel_3_1)
-        firb_lgd_senior = float(firb_lgd_table["unsecured_senior"])  # 0.45 CRR
+        firb_lgd_senior = float(firb_lgd_table["unsecured_senior"])
 
         has_transactor = "is_qrre_transactor" in lf.collect_schema().names()
         pd_floor_expr = _pd_floor_expression(config, has_transactor_col=has_transactor)
         guarantor_pd_floored = pl.max_horizontal(pl.col("guarantor_pd"), pd_floor_expr)
 
-        _is_irb_non_dd = (
-            (pl.col("guarantor_approach").fill_null("") == "irb")
-            & pl.col("guarantor_pd").is_not_null()
-            & ~pl.col("_is_dd_applied")
-        )
+        _is_irb_non_dd = pl.col("_is_pd_substitution") & ~pl.col("_is_dd_applied")
 
         return lf.with_columns(
             [
-                pl.when(_base_el & (pl.col("guarantor_approach").fill_null("") == "sa"))
-                .then(_el_unguaranteed)
-                .when(_base_el & _is_irb_non_dd)
+                pl.when(_base_el & _is_irb_non_dd)
                 .then(
-                    # IRB guarantor: blend borrower EL (unguaranteed) +
-                    # guarantor EL (guaranteed) per Art. 161(3)
                     _el_unguaranteed
                     + guarantor_pd_floored * firb_lgd_senior * pl.col("guaranteed_portion")
                 )
+                .when(_base_el & (pl.col("guarantor_approach").fill_null("") == "sa"))
+                .then(_el_unguaranteed)
                 .otherwise(pl.col("expected_loss_irb_original"))
                 .alias("expected_loss"),
             ]

--- a/tests/acceptance/basel31/test_scenario_b31_d7_parameter_substitution.py
+++ b/tests/acceptance/basel31/test_scenario_b31_d7_parameter_substitution.py
@@ -248,17 +248,16 @@ class TestB31D7_ParameterSubstitution:
         assert row["guarantee_method_used"] == "SA_RW_SUBSTITUTION"
         assert row["guarantor_rw"] == pytest.approx(0.0)
 
-    def test_b31_d7_crr_irb_guarantor_uses_sa_rw_substitution(
+    def test_b31_d7_crr_irb_guarantor_uses_pd_parameter_substitution(
         self,
         crr_firb_config: CalculationConfig,
     ) -> None:
         """
-        B31-D7c: Under CRR, even IRB guarantors use SA RW substitution.
+        B31-D7c: Under CRR, IRB guarantors with internal PD use PD parameter
+        substitution per CRR Art. 161(3).
 
-        CRR does not support parameter substitution. All guarantee methods
-        fall back to SA risk weight substitution.
-
-        Expected: SA_RW_SUBSTITUTION even though guarantor has IRB PD.
+        Expected: PD_PARAMETER_SUBSTITUTION when the guarantor has an internal PD
+        and the firm has IRB permission for the guarantor's exposure class.
         """
         result_df = _create_crm_and_irb_result(
             config=crr_firb_config,
@@ -272,8 +271,7 @@ class TestB31D7_ParameterSubstitution:
         assert len(result_df) > 0
         row = result_df.row(0, named=True)
 
-        # CRR: always SA RW substitution
-        assert row["guarantee_method_used"] == "SA_RW_SUBSTITUTION"
+        assert row["guarantee_method_used"] == "PD_PARAMETER_SUBSTITUTION"
 
     def test_b31_d7_partial_guarantee_blends_correctly(
         self,

--- a/tests/unit/crm/test_guarantor_rating_type.py
+++ b/tests/unit/crm/test_guarantor_rating_type.py
@@ -476,7 +476,7 @@ def _sovereign_exposure(currency: str, original_currency: str | None = None) -> 
         "exposure_reference": ["EXP001"],
         "counterparty_reference": ["CP001"],
         "exposure_class": ["corporate"],
-        "approach": ["IRB"],
+        "approach": ["foundation_irb"],
         "ead_pre_crm": [1_000_000.0],
         "lgd": [0.45],
         "cqs": [3],
@@ -646,6 +646,129 @@ class TestDomesticSovereignGuarantorForcedToSA:
             _sovereign_counterparty_lookup("DE"),
             b31_irb_config,
             rating_inheritance=_rating_inheritance(cqs=2, internal_pd=0.001),
+        ).collect()
+
+        assert result["guarantor_approach"][0] == "sa"
+
+
+# ---------------------------------------------------------------------------
+# Beneficiary-aware routing: institution beneficiary + institution guarantor
+# ---------------------------------------------------------------------------
+
+
+def _institution_exposure(approach: str) -> pl.LazyFrame:
+    """Institution-class exposure where `approach` is the BENEFICIARY's approach."""
+    return pl.LazyFrame(
+        {
+            "exposure_reference": ["EXP001"],
+            "counterparty_reference": ["CP001"],
+            "exposure_class": ["institution"],
+            "approach": [approach],
+            "ead_pre_crm": [1_000_000.0],
+            "lgd": [0.45],
+            "cqs": [3],
+            "product_type": ["LOAN"],
+            "drawn_amount": [1_000_000.0],
+            "undrawn_amount": [0.0],
+            "nominal_amount": [0.0],
+            "risk_type": [None],
+            "interest": [0.0],
+            "maturity_date": [date(2029, 12, 31)],
+            "ead_after_collateral": [1_000_000.0],
+            "ead_from_ccf": [0.0],
+            "ccf": [1.0],
+            "collateral_adjusted_value": [0.0],
+            "lgd_pre_crm": [0.45],
+            "lgd_post_crm": [0.45],
+        }
+    )
+
+
+def _institution_counterparty_lookup() -> pl.LazyFrame:
+    """Counterparty lookup for an institution guarantor."""
+    return pl.LazyFrame(
+        {
+            "counterparty_reference": ["GUAR001"],
+            "entity_type": ["institution"],
+            "country_code": ["GB"],
+        }
+    )
+
+
+class TestInstitutionGuarantorBeneficiaryAware:
+    """Beneficiary-aware guarantor routing for an institution-on-institution
+    guarantee where both parties have internal AND external ratings.
+
+    Expected (CRR Art. 161 / Basel 3.1 CRE22.70-85):
+    - Beneficiary on IRB → guarantor_approach == "irb" (use internal PD)
+    - Beneficiary on SA  → guarantor_approach == "sa"  (use external CQS)
+    """
+
+    def test_crr_irb_beneficiary_routes_guarantor_to_irb(
+        self, crr_irb_config: CalculationConfig
+    ) -> None:
+        result = apply_guarantees(
+            _institution_exposure(approach="foundation_irb"),
+            _guarantee(),
+            _institution_counterparty_lookup(),
+            crr_irb_config,
+            rating_inheritance=_rating_inheritance(cqs=2, internal_pd=0.005),
+        ).collect()
+
+        assert result["guarantor_approach"][0] == "irb"
+
+    def test_crr_sa_beneficiary_routes_guarantor_to_sa(
+        self, crr_irb_config: CalculationConfig
+    ) -> None:
+        """SA beneficiary always uses guarantor's external CQS, even if guarantor
+        has an internal PD that would otherwise route to IRB."""
+        result = apply_guarantees(
+            _institution_exposure(approach="standardised"),
+            _guarantee(),
+            _institution_counterparty_lookup(),
+            crr_irb_config,
+            rating_inheritance=_rating_inheritance(cqs=2, internal_pd=0.005),
+        ).collect()
+
+        assert result["guarantor_approach"][0] == "sa"
+
+    def test_b31_irb_beneficiary_routes_guarantor_to_irb(
+        self, b31_irb_config: CalculationConfig
+    ) -> None:
+        result = apply_guarantees(
+            _institution_exposure(approach="foundation_irb"),
+            _guarantee(),
+            _institution_counterparty_lookup(),
+            b31_irb_config,
+            rating_inheritance=_rating_inheritance(cqs=2, internal_pd=0.005),
+        ).collect()
+
+        assert result["guarantor_approach"][0] == "irb"
+
+    def test_b31_sa_beneficiary_routes_guarantor_to_sa(
+        self, b31_irb_config: CalculationConfig
+    ) -> None:
+        result = apply_guarantees(
+            _institution_exposure(approach="standardised"),
+            _guarantee(),
+            _institution_counterparty_lookup(),
+            b31_irb_config,
+            rating_inheritance=_rating_inheritance(cqs=2, internal_pd=0.005),
+        ).collect()
+
+        assert result["guarantor_approach"][0] == "sa"
+
+    def test_irb_beneficiary_without_firm_irb_permission_falls_back_to_sa(
+        self, crr_config: CalculationConfig
+    ) -> None:
+        """If the firm lacks IRB permission for the guarantor's exposure class,
+        the guarantor is routed to SA even when the beneficiary is IRB."""
+        result = apply_guarantees(
+            _institution_exposure(approach="foundation_irb"),
+            _guarantee(),
+            _institution_counterparty_lookup(),
+            crr_config,  # default permissions (SA-only)
+            rating_inheritance=_rating_inheritance(cqs=2, internal_pd=0.005),
         ).collect()
 
         assert result["guarantor_approach"][0] == "sa"

--- a/tests/unit/irb/test_irb_el_guarantee.py
+++ b/tests/unit/irb/test_irb_el_guarantee.py
@@ -136,7 +136,11 @@ class TestELGuaranteeAdjustment:
         assert result["expected_loss"][0] == pytest.approx(450.0)
 
     def test_irb_guarantor_el_substituted_with_pd(self, crr_config: CalculationConfig) -> None:
-        """IRB guarantor with PD should substitute guarantor PD for EL (Art. 161(3))."""
+        """IRB guarantor with PD should substitute guarantor PD for EL (Art. 161(3)).
+
+        Borrower RW is set to 100% so the IRB-derived guarantor RW (computed from
+        PD=0.005 with the CRR FIRB LGD of 45%) is unambiguously beneficial.
+        """
         lf = pl.LazyFrame(
             {
                 "exposure_reference": ["EXP001"],
@@ -145,8 +149,8 @@ class TestELGuaranteeAdjustment:
                 "ead_final": [1_000_000.0],
                 "maturity": [2.5],
                 "exposure_class": ["CORPORATE"],
-                "rwa": [500_000.0],
-                "risk_weight": [0.50],
+                "rwa": [1_000_000.0],
+                "risk_weight": [1.00],
                 "expected_loss": [4_500.0],  # PD * LGD * EAD = 0.01 * 0.45 * 1M
                 "guaranteed_portion": [1_000_000.0],
                 "unguaranteed_portion": [0.0],
@@ -159,7 +163,7 @@ class TestELGuaranteeAdjustment:
 
         result = lf.irb.apply_guarantee_substitution(crr_config).collect()
 
-        # EL = guarantor_PD(0.005) × LGD_senior(0.45) × guaranteed(1M) + 0 (no unguaranteed)
+        # EL = guarantor_PD(0.005) × LGD_senior(0.45 CRR) × guaranteed(1M) + 0
         # = 2,250.0
         assert result["expected_loss_irb_original"][0] == pytest.approx(4_500.0)
         assert result["expected_loss"][0] == pytest.approx(2_250.0)

--- a/tests/unit/irb/test_irb_parameter_substitution.py
+++ b/tests/unit/irb/test_irb_parameter_substitution.py
@@ -157,10 +157,13 @@ class TestParameterSubstitutionMethod:
         assert result["rwa"][0] == pytest.approx(0.0)
         assert result["guarantor_rw"][0] == pytest.approx(0.0)
 
-    def test_crr_always_uses_sa_rw_substitution(self, crr_config: CalculationConfig) -> None:
-        """CRR should always use SA RW substitution, even for IRB guarantors."""
+    def test_crr_uses_pd_substitution_for_irb_guarantor(
+        self, crr_config: CalculationConfig
+    ) -> None:
+        """CRR with an IRB guarantor (internal PD) uses PD parameter substitution
+        per Art. 161(3). SA RW substitution is reserved for SA guarantors."""
         ead = 1_000_000.0
-        borrower_rw = 0.80  # Higher than guarantor's SA RW (20%) → beneficial
+        borrower_rw = 1.00  # high enough that PD-derived IRB RW is beneficial
         borrower_rwa = borrower_rw * ead
 
         lf = pl.LazyFrame(
@@ -176,19 +179,52 @@ class TestParameterSubstitutionMethod:
                 "guaranteed_portion": [ead],
                 "unguaranteed_portion": [0.0],
                 "guarantor_entity_type": ["corporate"],
-                "guarantor_cqs": [1],  # Corporate CQS 1 = 20% RW under SA
+                "guarantor_cqs": [1],
                 "guarantor_approach": ["irb"],
-                "guarantor_pd": [0.005],  # IRB guarantor with PD
+                "guarantor_pd": [0.005],
             }
         )
 
         result = lf.irb.apply_guarantee_substitution(crr_config).collect()
 
-        # CRR: always SA RW substitution regardless of guarantor approach
+        assert result["guarantee_method_used"][0] == "PD_PARAMETER_SUBSTITUTION"
+        assert result["guarantee_status"][0] == "PD_PARAMETER_SUBSTITUTION"
+        # IRB-derived RW from PD=0.005 under CRR LGD=0.45 must be lower than
+        # the 100% borrower RW to be beneficial; the exact value depends on the
+        # parametric IRB formula.
+        assert result["guarantor_rw"][0] < borrower_rw
+
+    def test_crr_uses_sa_rw_substitution_for_sa_guarantor(
+        self, crr_config: CalculationConfig
+    ) -> None:
+        """CRR with an SA guarantor (external CQS only) uses SA RW substitution."""
+        ead = 1_000_000.0
+        borrower_rw = 0.80
+        borrower_rwa = borrower_rw * ead
+
+        lf = pl.LazyFrame(
+            {
+                "exposure_reference": ["EXP001"],
+                "pd": [0.05],
+                "lgd": [0.45],
+                "ead_final": [ead],
+                "maturity": [2.5],
+                "exposure_class": ["CORPORATE"],
+                "rwa": [borrower_rwa],
+                "risk_weight": [borrower_rw],
+                "guaranteed_portion": [ead],
+                "unguaranteed_portion": [0.0],
+                "guarantor_entity_type": ["corporate"],
+                "guarantor_cqs": [1],
+                "guarantor_approach": ["sa"],
+                "guarantor_pd": [None],
+            }
+        )
+
+        result = lf.irb.apply_guarantee_substitution(crr_config).collect()
+
         assert result["guarantee_method_used"][0] == "SA_RW_SUBSTITUTION"
         assert result["guarantee_status"][0] == "SA_RW_SUBSTITUTION"
-
-        # SA RW for corporate CQS 1 = 20%
         assert result["guarantor_rw"][0] == pytest.approx(0.20)
 
     def test_partial_guarantee_blends_irb_and_parameter_sub(

--- a/tests/unit/test_irb_double_default.py
+++ b/tests/unit/test_irb_double_default.py
@@ -254,11 +254,13 @@ class TestDoubleDefaultRWA:
         lf = _make_guaranteed_frame(guarantor_pd=0.0003, guarantor_cqs=1)
         result = lf.irb.apply_guarantee_substitution(_crr_dd_config()).collect()
 
-        # DD should be applied (low guarantor PD → DD RW < SA substitution RW)
+        # DD eligibility allows DD treatment OR plain substitution (SA RW for SA
+        # guarantors, PD-parameter substitution for IRB guarantors per Art. 161(3))
         if result["is_double_default_eligible"][0]:
             assert result["guarantee_method_used"][0] in (
                 "DOUBLE_DEFAULT",
                 "SA_RW_SUBSTITUTION",
+                "PD_PARAMETER_SUBSTITUTION",
             )
 
     def test_dd_unfunded_protection_tracked(self):


### PR DESCRIPTION
## Summary
- Make `guarantor_approach` beneficiary-aware in `engine/crm/guarantees.py`: a guarantor is treated under IRB only when the beneficiary is itself FIRB/AIRB (in addition to the existing checks on firm IRB permissions and guarantor internal PD).
- Drop the `config.is_basel_3_1` gate on `use_parameter_substitution` in `engine/irb/guarantee.py`; PD substitution now applies under CRR Art. 161(3) as well as Basel 3.1 CRE22.70-85, with per-row routing decided by `guarantor_approach`.
- F-IRB supervisory LGD used in PD substitution (`_apply_parameter_substitution`) and EL blending (`_adjust_expected_loss`) now reads from the framework table (0.45 CRR / 0.40 Basel 3.1) instead of being hard-coded to 0.40.
- Consolidate the two duplicated EL-blending branches in `_adjust_expected_loss` into a single framework-agnostic path with an explicit double-default carve-out.
- Stop `_apply_double_default` piggy-backing `_is_dd_applied` on `_is_pd_substitution` — `_is_dd_applied` is now true only when actual DD treatment is applied.

### Why
When an institution guaranteed another institution and both had internal AND external ratings, the engine substituted the guarantor's external CQS even when the beneficiary was IRB and the guarantor had a more favourable internal PD. The desired CRR / Basel 3.1 behaviour is:

- Beneficiary on **IRB** → substitute the guarantor's **internal PD** (CRR Art. 161(3) / CRE22.70-85)
- Beneficiary on **SA**  → substitute via the guarantor's **external CQS** → SA risk weight (CRR Art. 215 / 235, CRE22.91-92)

## Test plan
- [x] `uv run pytest tests/unit/crm/test_guarantor_rating_type.py` — added `TestInstitutionGuarantorBeneficiaryAware` covering institution-on-institution under CRR + Basel 3.1, both SA and IRB beneficiary, plus a no-IRB-permission fallback case.
- [x] `uv run pytest tests/unit/irb/test_irb_el_guarantee.py tests/unit/irb/test_irb_parameter_substitution.py` — updated `test_crr_uses_pd_substitution_for_irb_guarantor` (was `test_crr_always_uses_sa_rw_substitution`) and added `test_crr_uses_sa_rw_substitution_for_sa_guarantor`. EL test fixture bumped to 100% borrower RW so PD substitution is unambiguously beneficial.
- [x] `uv run pytest tests/unit/test_irb_double_default.py` — `test_dd_method_tracked` now also accepts `PD_PARAMETER_SUBSTITUTION` as a valid outcome under CRR.
- [x] `uv run pytest tests/acceptance/basel31/test_scenario_b31_d7_parameter_substitution.py` — renamed the CRR scenario to `test_b31_d7_crr_irb_guarantor_uses_pd_parameter_substitution` reflecting the new CRR behaviour.
- [x] `uv run pytest tests/` — full suite, 5,491 passed.
- [x] `uv run python scripts/arch_check.py` — passed.
