### PR TITLE
Agent teams: role-based subagents + parallel batch orchestrators

### DIFF
--- a/.claude/commands/next-docs.md
+++ b/.claude/commands/next-docs.md
@@ -1,0 +1,102 @@
+---
+description: Pick top N non-conflicting items from DOCS_IMPLEMENTATION_PLAN.md and dispatch N doc-writer agents in parallel. Default N=3, capped at 5.
+argument-hint: [N]
+---
+
+You are draining `DOCS_IMPLEMENTATION_PLAN.md` in batches.
+
+Parse `$ARGUMENTS` as integer **N** (default 3, cap 5). If `$ARGUMENTS`
+is empty or not an integer, use 3.
+
+## Step 1 — pick a non-conflicting batch
+
+Read `DOCS_IMPLEMENTATION_PLAN.md` (root of the repo). Walk the
+priority buckets in order:
+
+1. Priority 1: Critical Gaps
+2. Priority 2: Basel 3.1 Specification Parity
+3. Priority 3: Code-Docs Alignment
+4. Priority 4: Minor Fixes
+
+Select up to N items where each item's **canonical docs target page
+is unique within the batch** — two writers on the same `.md` file is
+the only collision worth blocking. To resolve the target page, scan
+the bullet for an explicit path; if absent, infer from the bullet's
+section heading and any cited spec.
+
+If two top items share a target page, take the higher-priority one
+into the batch and skip the other this round (it will be eligible
+next batch).
+
+If the queue is empty, report "nothing to do" and stop without
+dispatching anything.
+
+## Step 2 — confirm before dispatch
+
+State to the operator: the picked item IDs, their priority
+buckets, and the distinct target docs page for each. One line per
+item. Stop here if the operator hasn't seen the list before — for
+headless `loop.sh` runs, proceed automatically.
+
+## Step 3 — parallel dispatch
+
+In a **single message with N Agent tool blocks**, invoke the
+`doc-writer` agent N times. Each invocation gets its own item's
+bullet text verbatim. Prompt template per dispatch:
+
+> Update the documentation per the attached
+> `DOCS_IMPLEMENTATION_PLAN.md` item. Stay strictly within `docs/`,
+> and stay strictly within the canonical target page named below.
+> Do **not** run `uv run zensical build` from within the agent —
+> the orchestrator will run it once at the end.
+>
+> --- target page ---
+> {{absolute path}}
+>
+> --- plan item ---
+> {{exact bullet text including ID and citation}}
+
+Wait for all N to return.
+
+## Step 4 — single global build
+
+Run `uv run zensical build` exactly once. If it fails, surface the
+error and the implicated item IDs (any item whose target page is
+mentioned in the build error), then stop **without committing**.
+Operator decides whether to squash, drop, or fix forward.
+
+## Step 5 — sequential commits
+
+For each returned item, in priority order:
+
+1. `git add` the files reported by that item's `doc-writer`.
+2. Commit with `docs(<area>): <one-line summary> [batch <ID>]`
+   where `<batch ID>` is a short hash like `b<unix-timestamp>` or
+   the first 6 chars of `git rev-parse HEAD`.
+
+The `pre_commit_gate.sh` PreToolUse hook fires per commit — that's
+intentional.
+
+## Step 6 — tick the plan and final commit
+
+Use the Edit tool at the top level (no agent needed) to toggle each
+batched item from `[ ]` to `[x]` in `DOCS_IMPLEMENTATION_PLAN.md`.
+One Edit per item, then a single commit:
+
+```
+chore(plan): tick N docs items [batch <ID>]
+```
+
+Push to the current branch.
+
+## Constraints
+
+- Cap N at 5 even if the user asks for more — context cost is
+  super-linear past that.
+- Never commit if the global build is red.
+- Do not rerun `uv run zensical build` per agent — N agents × per-item
+  builds is the failure mode this command exists to avoid.
+- If a `doc-writer` returns "this item is actually a code bug",
+  exclude its files from the commit and surface the finding so
+  the operator can refile it under `IMPLEMENTATION_PLAN.md`. The
+  remaining batched items still commit.

--- a/.claude/commands/next-items.md
+++ b/.claude/commands/next-items.md
@@ -1,0 +1,170 @@
+---
+description: Pick top N non-conflicting items from IMPLEMENTATION_PLAN.md and run the four-stage agent pipeline as parallel waves. Default N=3, capped at 5. Hard-excludes items that touch shared engine files.
+argument-hint: [N]
+---
+
+You are draining `IMPLEMENTATION_PLAN.md` in batches.
+
+Parse `$ARGUMENTS` as integer **N** (default 3, cap 5). If
+`$ARGUMENTS` is empty or not an integer, use 3.
+
+This command is more delicate than `/next-docs` because the
+validation gate is global and several files in `src/rwa_calc/` are
+touched by many items. Read the collision rules carefully.
+
+## Step 1 — pick a non-conflicting batch
+
+Read `IMPLEMENTATION_PLAN.md`. Walk tiers in order:
+
+1. Tier 1: Calculation Correctness
+2. Tier 2: Test Coverage Gaps
+3. Tier 3: COREP Reporting Completeness
+4. Tier 4: Pillar III Disclosure Gaps
+5. (skip Tier 5: Documentation — that's `/next-docs` territory)
+6. Tier 6: Code Quality
+7. (skip Tier 7: Future / v2.0)
+
+For each candidate item, infer its expected change footprint by
+reading the bullet's `Ref:` field, the cited file paths, and the
+named test. Apply these collision-prevention rules; any violation
+disqualifies the candidate from this batch (it remains eligible
+next batch):
+
+1. **Distinct engine sub-package**: each batched item touches a
+   different top-level under `src/rwa_calc/engine/` (e.g.
+   `engine/sa/`, `engine/irb/`, `engine/crm/`,
+   `engine/slotting/`, `engine/equity/`,
+   `engine/re_splitter.py`, `engine/hierarchy.py`,
+   `engine/classifier.py`). Two SA fixes in one batch is a
+   collision.
+2. **Distinct data table**: each item touches a different file in
+   `src/rwa_calc/data/tables/`. Two items both editing the same
+   risk-weight or LGD table is a collision.
+3. **Distinct new test file**: each item produces a different
+   new test path under `tests/`. Two writers on the same module
+   is a collision.
+
+**Hard exclusions** — any candidate that requires changes to:
+
+- `src/rwa_calc/engine/pipeline.py`
+- `src/rwa_calc/contracts/protocols.py`
+- `src/rwa_calc/contracts/bundles.py`
+- `src/rwa_calc/engine/aggregator/aggregator.py`
+
+is forced single-stream. Pick it alone, even if N>1 was
+requested, and report the downgrade ("Picked P-code only;
+touches pipeline.py — single-stream").
+
+If the queue is empty, report "nothing to do" and stop.
+
+## Step 2 — confirm before dispatch
+
+State to the operator, one line per item:
+`<P-code> | Tier <n> | engine: <subpkg> | table: <file or none> | test: <path>`
+
+If any candidate was downgraded to single-stream, say so.
+
+## Step 3 — four parallel waves
+
+Run the agent pipeline as **four sequential waves**, each wave
+parallel across the N items.
+
+### Wave 1 — scenario-architect (parallel)
+
+In a single message, dispatch N `scenario-architect` calls, one per
+item. Each gets the item's bullet verbatim. Prompt template:
+
+> Design the work needed for **<P-CODE>**. Read the bullet from
+> `IMPLEMENTATION_PLAN.md` below and the cited spec.
+> Produce the structured proposal per your system prompt.
+>
+> --- plan item ---
+> {{exact bullet text}}
+
+Wait for all N proposals.
+
+### Wave 2 — fixture-builder (parallel, may include skips)
+
+For each item whose proposal calls for new fixtures, dispatch
+`fixture-builder` with that item's proposal. Items needing no
+fixture changes are skipped (pass an empty fixture report into
+Wave 3 for those).
+
+Run all needed fixture-builder calls in one parallel message. Wait
+for all to return.
+
+### Wave 3 — test-writer (parallel)
+
+In one parallel message, dispatch N `test-writer` calls. Each gets
+its item's proposal plus its fixture report (or "no new
+fixtures"). Each writer must leave its test failing for the right
+reason before returning.
+
+### Wave 4 — engine-implementer (parallel)
+
+In one parallel message, dispatch N `engine-implementer` calls.
+Each gets its item's proposal + failing test report.
+
+**Important**: instruct each engine-implementer to run only its
+own item's pytest target — **not** the global validation gate —
+because the orchestrator runs the global gate once at the end of
+this wave. Per-agent global runs would be N× redundant and could
+churn ruff/format on each other's edits.
+
+## Step 4 — single global validation gate
+
+Run once, in this order:
+
+```
+uv run python scripts/arch_check.py
+uv run ruff check src/ && uv run ruff format --check src/
+uv run ty src/
+uv run pytest tests/contracts/ --benchmark-skip -q
+uv run pytest <union of all batched items' new test paths> -x --benchmark-skip
+```
+
+If anything fails, surface:
+- the gate command that failed,
+- the failing test names or arch_check messages,
+- a best-effort attribution of which batched item is implicated
+  (match failing file paths to the engine sub-packages picked in
+  Step 1).
+
+**Do not commit if the gate is red.** Operator decides whether to
+squash, drop, or fix forward.
+
+## Step 5 — sequential commits
+
+For each item in tier-priority order:
+
+1. `git add` only the files reported by that item's
+   engine-implementer (plus its fixture-builder and test-writer if
+   they ran).
+2. Commit with `feat(<P-code>): <one-line summary> [batch <ID>]`.
+
+The `pre_commit_gate.sh` PreToolUse hook fires per commit.
+
+## Step 6 — tick the plan and final commit
+
+Edit `IMPLEMENTATION_PLAN.md` at the top level: toggle each batched
+item from `[ ]` to `[x] FIXED v<x.y.z>` with a one-line summary.
+One Edit per item, then a single commit:
+
+```
+chore(plan): tick N code items [batch <ID>]
+```
+
+Push to the current branch.
+
+## Constraints
+
+- Cap N at 5 even if the user asks for more.
+- Never commit if the global gate is red.
+- Do not rerun the gate inside any engine-implementer — global gate
+  runs once at the end of Wave 4.
+- If a stage fails for any single item (e.g. test-writer can't
+  produce a clean failure), drop that item from the batch and
+  continue with the rest. Surface the dropped item to the
+  operator.
+- Hard-excluded items never appear in a multi-item batch — they
+  always run alone with the same wave structure.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,14 +177,16 @@ Project subagents in `.claude/agents/` (role-based, not domain-based — regulat
 - **`plan-curator`** — owns the two work-queue files at the repo root: `IMPLEMENTATION_PLAN.md` and `DOCS_IMPLEMENTATION_PLAN.md`. Audits code/specs/PDFs against each other and writes prioritised bullet items.
 - **`doc-writer`** — owns `docs/`. Writes or updates one canonical docs page per `DOCS_IMPLEMENTATION_PLAN.md` item; runs `uv run zensical build` before returning.
 
-Orchestration lives in slash commands, not in agents. Each `loop.sh` mode maps to one slash command, and each slash command commits once at the end:
+Orchestration lives in slash commands, not in agents. Each `loop.sh` mode maps to one slash command. The default build / docs_build commands are the **parallel batch** orchestrators (`/next-items`, `/next-docs`); the strict-serial single-item commands (`/next-scenario`, `/next-doc`) remain available for one-off / debugging use.
 
-| `loop.sh` mode | Prompt file | Slash command | Owns |
+| `loop.sh` mode | Prompt file | Default command | Strict-serial alternative |
 |---|---|---|---|
-| `loop.sh` (build) | `PROMPT_build.md` | `/next-scenario` | code/test backlog → implementation |
-| `loop.sh plan` | `PROMPT_plan.md` | `/refresh-plan` | refresh `IMPLEMENTATION_PLAN.md` |
-| `loop.sh docs_build` | `PROMPT_docs_build.md` | `/next-doc` | docs backlog → docs page edit |
-| `loop.sh docs_plan` | `PROMPT_docs_plan.md` | `/refresh-docs-plan` | refresh `DOCS_IMPLEMENTATION_PLAN.md` |
+| `loop.sh` (build) | `PROMPT_build.md` | `/next-items 3` | `/next-scenario` |
+| `loop.sh plan` | `PROMPT_plan.md` | `/refresh-plan` | — |
+| `loop.sh docs_build` | `PROMPT_docs_build.md` | `/next-docs 3` | `/next-doc` |
+| `loop.sh docs_plan` | `PROMPT_docs_plan.md` | `/refresh-docs-plan` | — |
+
+The batch commands pick N non-conflicting items, dispatch the agent pipeline as parallel waves, and run the validation gate (or `uv run zensical build`) **once at the end** — not per agent. Items that touch shared engine files (`engine/pipeline.py`, `contracts/protocols.py`, `contracts/bundles.py`, `engine/aggregator/aggregator.py`) are forced single-stream by `/next-items` even when N>1 was requested.
 
 Plus `/implement-scenario <ID>` for ad-hoc one-off work on a specific P-code or scenario ID.
 

--- a/PROMPT_build.md
+++ b/PROMPT_build.md
@@ -1,19 +1,33 @@
-Run `/next-scenario`.
+Run `/next-items 3`.
 
-That single slash command drives the whole `loop.sh` build iteration:
+That single slash command drives the whole `loop.sh` build
+iteration as a parallel batch:
 
-- it picks the highest-priority unfixed P-coded item from
-  `IMPLEMENTATION_PLAN.md` (root of the repo — the project's code/test
-  work queue),
-- delegates to `/implement-scenario <P-CODE>`, which runs
-  scenario-architect, fixture-builder, test-writer, and
-  engine-implementer in sequence with strict file ownership,
-- runs the validation gate (`uv run python scripts/arch_check.py && uv run ruff check src/ && uv run ruff format --check src/ && uv run ty src/ && uv run pytest tests/contracts/ --benchmark-skip -q`) inside engine-implementer,
-- ticks the item off `IMPLEMENTATION_PLAN.md` at the top level
-  (single-line Edit; no agent needed for a checkbox toggle), then
-  commits and pushes once at the end.
+- it picks up to 3 non-conflicting P-coded items from
+  `IMPLEMENTATION_PLAN.md` (each touching a distinct engine
+  sub-package, distinct `data/tables/` file, and distinct new
+  test path),
+- runs the four agent stages as four parallel waves
+  (scenario-architect → fixture-builder → test-writer →
+  engine-implementer), with N items in flight per wave,
+- runs the global validation gate
+  (`uv run python scripts/arch_check.py && uv run ruff check src/ && uv run ruff format --check src/ && uv run ty src/ && uv run pytest tests/contracts/ --benchmark-skip -q`)
+  exactly once at the end of the engine-implementer wave —
+  per-agent gate runs are forbidden because they would
+  N×-redundantly churn ruff/format on each other's edits,
+- on green: commits each item separately, then ticks the items off
+  `IMPLEMENTATION_PLAN.md` in one final
+  `chore(plan): tick N code items` commit and pushes.
 
-After `/next-scenario` returns, do these housekeeping items in the
+Items that touch shared files (`engine/pipeline.py`,
+`contracts/protocols.py`, `contracts/bundles.py`,
+`engine/aggregator/aggregator.py`) are forced single-stream by
+the orchestrator — that's deliberate and not a bug.
+
+If you want strict-serial behaviour (one item per iteration), run
+`/next-scenario` instead — both commands remain available.
+
+After `/next-items` returns, do these housekeeping items in the
 top-level session (not via a sub-agent):
 
 1. If the change is user-facing, append a one-line entry to
@@ -22,10 +36,15 @@ top-level session (not via a sub-agent):
 2. If the validation gate is green and the new test passes, create a
    git tag. If no tag exists yet start at `0.0.0`; otherwise bump the
    patch version (`0.0.0` → `0.0.1`).
-3. If `/next-scenario` reported the backlog is empty across Tiers 1–4
-   and 6, stop the loop and surface that to the operator. Do not invent
-   work, and do not silently promote Tier 5 (docs) or Tier 7 (v2.0)
-   items — Tier 5 belongs in the `loop.sh docs_build` mode.
+3. If `/next-items` reported the backlog is empty across Tiers 1–4
+   and 6, stop the loop and surface that to the operator. Do not
+   invent work, and do not silently promote Tier 5 (docs) or
+   Tier 7 (v2.0) items — Tier 5 belongs in the `loop.sh docs_build`
+   mode.
+4. If `/next-items` reported the global validation gate was red,
+   **no commits will have been made**. Do not retry blindly;
+   inspect the failure attribution, fix forward in the next
+   iteration, and rerun the loop manually.
 
 ## Hard constraints
 

--- a/PROMPT_docs_build.md
+++ b/PROMPT_docs_build.md
@@ -1,19 +1,23 @@
-Run `/next-doc`.
+Run `/next-docs 3`.
 
 That single slash command drives the whole `loop.sh docs_build`
-iteration:
+iteration as a parallel batch:
 
-- it picks the highest-priority unresolved item from
-  `DOCS_IMPLEMENTATION_PLAN.md`,
-- delegates to the `doc-writer` agent, which owns `docs/` and
-  edits only the canonical page for that regulatory concept,
-- runs `uv run zensical build` to confirm the docs site still
-  builds with no broken internal links,
-- updates `DOCS_IMPLEMENTATION_PLAN.md` via `plan-curator` to mark
-  the item `[x]`, and
-- commits and pushes once at the end of the iteration.
+- it picks the top 3 non-conflicting items from
+  `DOCS_IMPLEMENTATION_PLAN.md` (each touching a distinct
+  canonical docs page),
+- dispatches 3 `doc-writer` agents in one parallel message, each
+  scoped to its own page,
+- runs `uv run zensical build` once at the end of the batch (not
+  per agent) to confirm the docs site still builds,
+- commits each item separately, then ticks the 3 items off
+  `DOCS_IMPLEMENTATION_PLAN.md` in one final
+  `chore(plan): tick 3 docs items` commit and pushes.
 
-After `/next-doc` returns, do this housekeeping in the top-level
+If you want strict-serial behaviour (one item per iteration), run
+`/next-doc` instead — both commands remain available.
+
+After `/next-docs` returns, do this housekeeping in the top-level
 session:
 
 1. If the change is user-facing, append a one-line entry to
@@ -26,6 +30,11 @@ session:
    `src/` from this loop.
 3. If `DOCS_IMPLEMENTATION_PLAN.md` is empty across all four
    priority buckets, surface that and stop — do not invent work.
+4. If `/next-docs` reported the global `uv run zensical build` was
+   red, **no commits will have been made**. Do not retry blindly;
+   inspect the build error, fix the offending docs page (or
+   surface the item as needing operator review), and rerun the
+   loop manually.
 
 ## Hard constraints
 


### PR DESCRIPTION
## Summary

Stands up the project's agent-team infrastructure end-to-end. Replaces the ad-hoc "spawn up to 10 Sonnet subagents" pattern with role-based subagents, file-ownership boundaries, and slash-command orchestrators wired into all four `loop.sh` modes.

### What's in this branch

- **6 role-based subagents** under `.claude/agents/` (each scoped to one directory):
  - `scenario-architect` — read-only proposal designer
  - `fixture-builder` — owns `tests/fixtures/`
  - `test-writer` — owns `tests/{unit,acceptance,contracts,integration}/`
  - `engine-implementer` — owns `src/rwa_calc/`, runs the validation gate
  - `plan-curator` — owns `IMPLEMENTATION_PLAN.md` and `DOCS_IMPLEMENTATION_PLAN.md`
  - `doc-writer` — owns `docs/`, runs `uv run zensical build`

- **7 slash commands** under `.claude/commands/`:
  - `/implement-scenario <ID>` — one-off four-stage pipeline on a named P-code
  - `/next-scenario` — strict-serial code/test backlog drain (single item)
  - `/next-items <N>` — **parallel batch** code/test drain (default 3, cap 5)
  - `/next-doc` — strict-serial docs drain (single item)
  - `/next-docs <N>` — **parallel batch** docs drain (default 3, cap 5)
  - `/refresh-plan` — plan-curator audit of `IMPLEMENTATION_PLAN.md`
  - `/refresh-docs-plan` — plan-curator audit of `DOCS_IMPLEMENTATION_PLAN.md`

- **`PROMPT_*.md` rewrites** so all four `loop.sh` modes (`build`, `plan`, `docs_build`, `docs_plan`) call exactly one slash command and stay debuggable from the JSONL stream.

- **`CLAUDE.md`** gains an `## Agents and Slash Commands` section documenting the role map, ownership boundaries, and the `loop.sh` mode → slash-command table.

### Design properties worth flagging for review

- **One-level call graph**: agents do not invoke other agents. Orchestration lives in slash commands; `pre_commit_gate.sh` fires once per scenario with full context.
- **No commit/push permissions** on any agent — top-level session commits.
- **Skills (`basel31`, `crr`) stay as skills**, not agents. Each agent prompt instructs: "for any regulatory scalar, invoke the relevant Skill — do not infer from training data."
- **Parallel batches run the validation gate / `zensical build` once at the end**, not per agent. Per-agent global runs would be N×-redundant and would churn ruff/format on each other's edits.
- **Hard-excluded files** (`engine/pipeline.py`, `contracts/protocols.py`, `contracts/bundles.py`, `engine/aggregator/aggregator.py`) force `/next-items` to single-stream even when N>1 was requested.
- **Red gate ⇒ no commit**. Failures surface implicated item IDs to the operator; no auto-rollback.

## Test plan

- [ ] Interactive: `/implement-scenario <a known unfixed P-code>` runs all four stages end-to-end and lands one commit
- [ ] Interactive: `/next-items 3` picks 3 distinct engine sub-packages, runs four parallel waves, runs the gate once, lands 3 + 1 commits
- [ ] Interactive: `/next-docs 3` picks 3 distinct docs pages, dispatches 3 `doc-writer` agents in parallel, runs `uv run zensical build` once, lands 3 + 1 commits
- [ ] Hard-exclusion: queue an item that touches `engine/pipeline.py`, run `/next-items 3`, confirm it is forced single-stream
- [ ] Failure mode: introduce a contract-test violation in one batched item, run `/next-items 3`, confirm the gate fails with the implicated item ID surfaced and **no commits made**
- [ ] Headless: `./loop.sh 1` (build) and `./loop.sh docs_build 1` each produce the expected commit shape
- [ ] `uv run zensical serve` still builds (no spec/docs changes in this branch, but worth confirming)

https://claude.ai/code/session_01WxRi2VHEozYAzAdJGLttBr

---
_Generated by [Claude Code](https://claude.ai/code/session_01WxRi2VHEozYAzAdJGLttBr)_