### PR TITLE
docs(readme): refresh test counts, exposure classes, Basel 3.1 status

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This calculator supports two regulatory regimes:
 | Regime | Effective Period | UK Implementation | Status |
 |--------|------------------|-------------------|--------|
 | **CRR (Basel 3.0)** | Until 31 December 2026 | UK CRR (EU 575/2013 as onshored) | **Active** |
-| **Basel 3.1** | From 1 January 2027 | PRA PS1/26 | **Active Development** |
+| **Basel 3.1** | From 1 January 2027 | PRA PS1/26 | **Implemented** |
 
 A configuration toggle allows switching between calculation modes for:
 - Current regulatory reporting under UK CRR
@@ -98,7 +98,7 @@ A configuration toggle allows switching between calculation modes for:
 
 ### Supported Exposure Classes
 
-Sovereign, Institution, Corporate, Corporate SME, Retail Mortgage, Retail QRRE, Retail Other, Specialised Lending, Equity
+Sovereign / Central Bank, Institution, Corporate, Corporate SME, PSE, MDB, RGLA, Retail Mortgage, Retail QRRE, Retail Other, Specialised Lending, Equity, Covered Bond, Residential Mortgage, Commercial Mortgage (Basel 3.1 RE split), High Risk, Defaulted, Other
 
 ## Documentation
 
@@ -127,7 +127,7 @@ uv run pytest --cov=src/rwa_calc
 uv run pytest tests/benchmarks/ -m "benchmark and not slow" -k "not 1m" -o "addopts=" --benchmark-only -v
 ```
 
-**Test Results:** ~1,915 tests (1,485 unit + 275 acceptance + 123 contract + ~30 benchmark)
+**Test Results:** ~5,500 tests (~4,675 unit + ~500 acceptance + ~165 contract + ~145 integration + ~30 benchmark)
 
 ## License
 


### PR DESCRIPTION
## Summary
- Update test count line from `~1,915 tests` to `~5,500 tests` and add the integration-test tier that was previously missing
- Mark Basel 3.1 row in the regulatory-scope table as **Implemented** (output floor, RE loan-splitter, ECRA/SCRA, and Basel 3.1 enums are all in place)
- Expand the Supported Exposure Classes list to match `src/rwa_calc/domain/enums.py` (adds PSE, MDB, RGLA, Covered Bond, Residential/Commercial Mortgage, High Risk, Defaulted, Other)

The top-of-file "in development / not production ready" caveat is untouched — package-level maturity remains pre-alpha per `pyproject.toml`. Verified API/CLI/extras claims still match the codebase, so the rest of the README is unchanged.

## Test plan
- [x] `git diff README.md` shows a tight 3-hunk change
- [x] Exposure-class list is a superset of `ExposureClass` in `src/rwa_calc/domain/enums.py`
- [x] Test count reflects current `pytest --collect-only` output (≈5,500)
- [ ] Render README on GitHub PR view to confirm tables/lists still render cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)