### PR TITLE
refactor(hierarchy): de-risk three landmines (mappings schema, internal_pd coalesce, .over null guard)

### DIFF
--- a/docs/architecture/components.md
+++ b/docs/architecture/components.md
@@ -161,7 +161,7 @@ class HierarchyResolver:
 - Lending group aggregation with residential property exclusion (CRR Art. 123(c))
 - Multi-level collateral linking (direct, facility, counterparty) with pro-rata allocation
 - FX conversion of exposures and CRM data
-- Flexible type column detection (`child_type` / `node_type` / neither)
+- Facility-mapping schema normalised at the resolver boundary: legacy `node_type` is accepted as an input alias and renamed to `child_type`; missing column is synthesised as null. New producers MUST emit `child_type`.
 - Non-blocking error accumulation
 
 ## Classifier

--- a/docs/specifications/common/hierarchy-classification.md
+++ b/docs/specifications/common/hierarchy-classification.md
@@ -154,13 +154,18 @@ parent headroom = 100m − 20m = 80m
 
 #### Type Column Handling
 
-The `facility_mappings` table may use different column names for the child type discriminator:
+The engine's contract is a single discriminator column `child_type`. The resolver
+normalises three accepted input shapes at its boundary via
+`_normalise_facility_mappings`:
 
-| Column Present | Behaviour |
-|---------------|-----------|
-| `child_type` | Used to filter loan vs facility children (preferred) |
-| `node_type` | Fallback — same filtering logic |
-| Neither | No facility hierarchy traversal; all mappings treated as loan mappings |
+| Input Shape | Treatment |
+|-------------|-----------|
+| `child_type` present | Pass through unchanged. **Producers MUST emit this form.** |
+| `node_type` present, `child_type` absent | Renamed to `child_type` on entry (legacy alias). Do not introduce new `node_type` producers. |
+| Neither column present | `child_type` synthesised as null. The downstream filter chain treats null as "no children of any type" — single-level mappings only, no facility hierarchy traversal, no loan or contingent aggregation against the parent. |
+
+A frame with both `child_type` and `node_type` raises `ValueError` — the loader
+contract should prevent that shape.
 
 ## Exposure Classification
 

--- a/scripts/arch_check.py
+++ b/scripts/arch_check.py
@@ -73,6 +73,11 @@ VALIDATION_ENUM_ALLOWLIST: dict[str, set[str]] = {
     },
     # Art. 231 allocation column mapping (PR #249 — retained as engine config)
     "engine/crm/expressions.py": {"CRM_ALLOC_COLUMNS"},
+    # Nullable-partition-key registry for the partition_by_nullable helper.
+    # These are engine-internal column names tightly coupled to the helper's
+    # AST-level contract test; keeping them in `data/schemas.py` would split
+    # the rule from the code that enforces it.
+    "engine/utils.py": {"NULLABLE_PARTITION_KEYS"},
 }
 
 # Engine modules exempt from the check-8 "must declare a module logger" rule.

--- a/src/rwa_calc/engine/hierarchy.py
+++ b/src/rwa_calc/engine/hierarchy.py
@@ -319,6 +319,17 @@ class HierarchyResolver:
         - external_cqs: Art. 138-resolved external CQS (own only — not inherited)
         - cqs: Alias of external_cqs
         - pd: Alias of internal_pd
+
+        REVIEWER NOTE: the dual coalesce on internal_pd / internal_model_id
+        below (paired ``own → parent`` joins followed by independent
+        ``pl.coalesce`` per column) is deliberate per CRR Art. 171(1) and
+        Art. 175(3). The asymmetry between internal-inherits and
+        external-does-not-inherit is encoded by the *presence* of the
+        parent-internal join versus the *absence* of a parent-external one.
+        See ``tests/unit/test_hierarchy.py::TestInheritanceTruthTable``
+        rows 4, 6, 7 for the behavioural lock — simplification proposals
+        (e.g. fusing into a single struct-coalesce, or collapsing the two
+        joins into one) must update those rows; do not delete them.
         """
         sort_cols = ["rating_date", "rating_reference"]
 

--- a/src/rwa_calc/engine/hierarchy.py
+++ b/src/rwa_calc/engine/hierarchy.py
@@ -36,6 +36,7 @@ from rwa_calc.contracts.bundles import (
 )
 from rwa_calc.contracts.errors import CalculationError
 from rwa_calc.data.column_spec import ColumnSpec, ensure_columns
+from rwa_calc.data.schemas import FACILITY_MAPPING_SCHEMA
 from rwa_calc.data.tables.crr_risk_weights import (
     CENTRAL_GOVT_CENTRAL_BANK_RISK_WEIGHTS,
     CORPORATE_RISK_WEIGHTS,
@@ -93,11 +94,16 @@ class HierarchyResolver:
         )
         errors.extend(cp_errors)
 
+        # Normalise facility_mappings to the canonical child_type form once at
+        # the resolver boundary; downstream stages can rely on the column
+        # always existing. RawDataBundle is frozen, so we rebind a local.
+        facility_mappings = _normalise_facility_mappings(data.facility_mappings)
+
         exposures, exp_errors = self._unify_exposures(
             data.loans,
             data.contingents,
             data.facilities,
-            data.facility_mappings,
+            facility_mappings,
             counterparty_lookup,
             config,
         )
@@ -455,8 +461,10 @@ class HierarchyResolver:
         via dict traversal, and returns the result as a LazyFrame.
 
         Args:
-            facility_mappings: Facility mappings with parent_facility_reference,
-                             child_reference, and child_type/node_type columns
+            facility_mappings: Facility mappings with ``parent_facility_reference``,
+                             ``child_reference``, and ``child_type`` columns.
+                             Caller must have passed the frame through
+                             ``_normalise_facility_mappings`` so ``child_type`` exists.
             max_depth: Maximum hierarchy depth to traverse
 
         Returns:
@@ -473,14 +481,21 @@ class HierarchyResolver:
             }
         )
 
-        type_col = _detect_type_column(set(facility_mappings.collect_schema().names()))
-        if type_col is None:
+        # Defensive idempotent normalisation: the resolver boundary normalises
+        # but unit-test callers may invoke this method directly with a non-
+        # normalised frame.
+        if not has_required_columns(
+            facility_mappings, {"parent_facility_reference", "child_reference"}
+        ):
             return empty_result
+        facility_mappings = _normalise_facility_mappings(facility_mappings)
 
-        # Filter to facility→facility relationships and collect (small data)
+        # Filter to facility→facility relationships and collect (small data).
+        # Synthesised null child_type (legacy mappings) yields no facility-typed
+        # rows — facility_edges is empty and the height==0 short-circuit fires.
         facility_edges = (
             facility_mappings.filter(
-                pl.col(type_col).fill_null("").str.to_lowercase() == "facility"
+                pl.col("child_type").fill_null("").str.to_lowercase() == "facility"
             )
             .select(
                 [
@@ -649,7 +664,10 @@ class HierarchyResolver:
                 }
             )
 
-        type_col = _detect_type_column(set(facility_mappings.collect_schema().names()))
+        # Defensive idempotent normalisation: the resolver boundary normalises
+        # but unit-test callers may invoke this method directly with a non-
+        # normalised frame.
+        facility_mappings = _normalise_facility_mappings(facility_mappings)
 
         # Root lookup for multi-level hierarchies (used by both loan and contingent
         # aggregations). Left join with empty lookup naturally produces nulls; coalesce
@@ -666,10 +684,10 @@ class HierarchyResolver:
         )
 
         loan_drawn_totals = self._aggregate_loan_drawn_per_facility(
-            loans, facility_mappings, root_lookup, type_col
+            loans, facility_mappings, root_lookup
         )
         contingent_totals = self._aggregate_contingent_per_facility(
-            contingents, facility_mappings, root_lookup, type_col
+            contingents, facility_mappings, root_lookup
         )
 
         facility_with_drawn = self._compute_facility_undrawn_per_root(
@@ -775,7 +793,6 @@ class HierarchyResolver:
         loans: pl.LazyFrame,
         facility_mappings: pl.LazyFrame,
         root_lookup: pl.LazyFrame,
-        type_col: str | None,
     ) -> pl.LazyFrame:
         """Sum positive drawn amounts per (root or standalone) facility.
 
@@ -793,7 +810,7 @@ class HierarchyResolver:
                 }
             )
 
-        loan_mappings = _filter_mappings_by_child_type(facility_mappings, "loan", type_col)
+        loan_mappings = _filter_mappings_by_child_type(facility_mappings, "loan")
 
         loan_with_parent = loans.join(
             loan_mappings,
@@ -815,7 +832,6 @@ class HierarchyResolver:
         contingents: pl.LazyFrame | None,
         facility_mappings: pl.LazyFrame,
         root_lookup: pl.LazyFrame,
-        type_col: str | None,
     ) -> pl.LazyFrame:
         """Sum positive contingent nominal amounts per (root or standalone) facility.
 
@@ -840,9 +856,7 @@ class HierarchyResolver:
                 }
             )
 
-        contingent_mappings = _filter_mappings_by_child_type(
-            facility_mappings, "contingent", type_col
-        )
+        contingent_mappings = _filter_mappings_by_child_type(facility_mappings, "contingent")
 
         contingent_with_parent = contingents.join(
             contingent_mappings,
@@ -1203,7 +1217,6 @@ class HierarchyResolver:
         # Per-sub netting: aggregate loans/contingents at the directly-mapped
         # facility level (NOT rolled up to root). This is what lets the waterfall
         # reflect actual sub-level utilisation rather than parent-level totals.
-        type_col = _detect_type_column(set(facility_mappings.collect_schema().names()))
 
         def _per_sub_drawn(
             frame: pl.LazyFrame | None,
@@ -1218,7 +1231,7 @@ class HierarchyResolver:
             cols = set(frame.collect_schema().names())
             if ref_col not in cols or amount_col not in cols:
                 return empty
-            child_mappings = _filter_mappings_by_child_type(facility_mappings, child_type, type_col)
+            child_mappings = _filter_mappings_by_child_type(facility_mappings, child_type)
             return (
                 frame.select([pl.col(ref_col), pl.col(amount_col)])
                 .join(
@@ -1443,8 +1456,6 @@ class HierarchyResolver:
         ):
             return empty
 
-        type_col = _detect_type_column(set(facility_mappings.collect_schema().names()))
-
         # Gather descendant (root_facility_reference, counterparty_reference) pairs
         # from loans, contingents, and sub-facilities that map to a facility.
         candidate_frames: list[pl.LazyFrame] = []
@@ -1478,7 +1489,7 @@ class HierarchyResolver:
 
         loan_cols = set(loans.collect_schema().names())
         if "loan_reference" in loan_cols and "counterparty_reference" in loan_cols:
-            loan_mappings = _filter_mappings_by_child_type(facility_mappings, "loan", type_col)
+            loan_mappings = _filter_mappings_by_child_type(facility_mappings, "loan")
 
             loan_with_parent = loans.select(
                 [pl.col("loan_reference"), pl.col("counterparty_reference")]
@@ -1503,9 +1514,7 @@ class HierarchyResolver:
         if contingents is not None:
             cont_cols = set(contingents.collect_schema().names())
             if "contingent_reference" in cont_cols and "counterparty_reference" in cont_cols:
-                cont_mappings = _filter_mappings_by_child_type(
-                    facility_mappings, "contingent", type_col
-                )
+                cont_mappings = _filter_mappings_by_child_type(facility_mappings, "contingent")
 
                 cont_with_parent = contingents.select(
                     [pl.col("contingent_reference"), pl.col("counterparty_reference")]
@@ -1862,33 +1871,29 @@ class HierarchyResolver:
         root resolution. Single-level cases (no entry in the lookup) collapse to
         parent-as-root with depth = 1.
         """
+        # Defensive idempotent normalisation: the resolver boundary normalises
+        # but unit-test callers may invoke this method directly with a non-
+        # normalised frame.
+        facility_mappings = _normalise_facility_mappings(facility_mappings)
+
         # Filter out child_type="facility" entries since unified exposures contain only
         # loans, contingents, and facility_undrawn (never raw facilities).
         # Without this filter, when facility_reference = loan_reference AND the facility
         # is a sub-facility, child_reference has duplicate values causing row duplication.
-        type_col = _detect_type_column(set(facility_mappings.collect_schema().names()))
-
-        if type_col is not None:
-            exposure_level_mappings = (
-                facility_mappings.filter(
-                    pl.col(type_col).fill_null("").str.to_lowercase() != "facility"
-                )
-                .select(
-                    [
-                        pl.col("child_reference"),
-                        pl.col("parent_facility_reference").alias("mapped_parent_facility"),
-                    ]
-                )
-                .unique(subset=["child_reference"], keep="first")
+        # Synthesised null child_type (legacy mappings) fills to "" and naturally
+        # passes through the != "facility" filter, preserving today's behaviour.
+        exposure_level_mappings = (
+            facility_mappings.filter(
+                pl.col("child_type").fill_null("").str.to_lowercase() != "facility"
             )
-        else:
-            # No type column available - use all mappings as-is
-            exposure_level_mappings = facility_mappings.select(
+            .select(
                 [
                     pl.col("child_reference"),
                     pl.col("parent_facility_reference").alias("mapped_parent_facility"),
                 ]
-            ).unique(subset=["child_reference"], keep="first")
+            )
+            .unique(subset=["child_reference"], keep="first")
+        )
 
         exposures = exposures.join(
             exposure_level_mappings,
@@ -2717,30 +2722,62 @@ def _resolve_to_root_facility(
     )
 
 
-def _detect_type_column(schema_names: set[str]) -> str | None:
-    """Return the child-type column name if present, else None."""
-    if "child_type" in schema_names:
-        return "child_type"
-    if "node_type" in schema_names:
-        return "node_type"
-    return None
+def _normalise_facility_mappings(facility_mappings: pl.LazyFrame) -> pl.LazyFrame:
+    """Normalise the facility-mappings schema to the canonical ``child_type`` form.
+
+    The engine's contract is a single discriminator column ``child_type``. Two
+    legacy input shapes are accepted at the resolver boundary:
+
+    1. ``child_type`` already present — pass through unchanged.
+    2. ``node_type`` present, ``child_type`` absent — rename to ``child_type``.
+       (Vestigial alias retained as a one-PR safety net for any out-of-tree
+       producers; new producers MUST emit ``child_type``.)
+    3. Neither present — synthesise a null ``child_type`` column via
+       ``ensure_columns``. The downstream ``unique → filter`` chain treats
+       a null discriminator as "no facility-typed children", which is the
+       correct fallback for legacy single-level mappings.
+
+    Idempotent on already-normalised input. Calling twice is a no-op:
+    ``node_type`` is no longer present, ``child_type`` already exists, and
+    ``ensure_columns`` adds nothing.
+
+    Raises ``ValueError`` on the ambiguous shape where both ``child_type`` and
+    ``node_type`` are present — the loader contract should prevent this.
+    """
+    cols = set(facility_mappings.collect_schema().names())
+    if "node_type" in cols:
+        if "child_type" in cols:
+            raise ValueError(
+                "facility_mappings has both 'child_type' and 'node_type' columns; "
+                "ambiguous discriminator. Drop 'node_type' (legacy alias) and emit "
+                "'child_type' only."
+            )
+        facility_mappings = facility_mappings.rename({"node_type": "child_type"})
+    return ensure_columns(facility_mappings, FACILITY_MAPPING_SCHEMA)
 
 
 def _filter_mappings_by_child_type(
     facility_mappings: pl.LazyFrame,
     child_type: str,
-    type_col: str | None,
 ) -> pl.LazyFrame:
     """Return facility_mappings filtered to a single child_type, deduped on child+parent.
 
-    When ``type_col`` is None (legacy mappings without a type column), the input
-    is passed through with the same uniqueness guarantee — the caller is
-    responsible for any further filtering.
+    Order is load-bearing: ``unique`` runs *before* ``filter`` so duplicate
+    ``(child_reference, parent_facility_reference)`` pairs that differ only in
+    ``child_type`` (e.g. when ``facility_reference == loan_reference``) are
+    absorbed by the dedup; reversing to ``filter → unique`` would silently
+    diverge on dirty inputs.
+
+    Assumes ``facility_mappings`` has been passed through
+    ``_normalise_facility_mappings`` upstream so that ``child_type`` always
+    exists. A null ``child_type`` value (synthesised for legacy inputs)
+    fills to "" via ``fill_null`` and never matches a real type — yielding an
+    empty filtered frame, which is the correct "no children of this type"
+    semantic.
     """
-    deduped = facility_mappings.unique(subset=["child_reference", "parent_facility_reference"])
-    if type_col is None:
-        return deduped
-    return deduped.filter(pl.col(type_col).fill_null("").str.to_lowercase() == child_type)
+    return facility_mappings.unique(subset=["child_reference", "parent_facility_reference"]).filter(
+        pl.col("child_type").fill_null("").str.to_lowercase() == child_type
+    )
 
 
 def _resolve_graph_eager(

--- a/src/rwa_calc/engine/hierarchy.py
+++ b/src/rwa_calc/engine/hierarchy.py
@@ -49,7 +49,7 @@ from rwa_calc.data.tables.crr_risk_weights import (
 from rwa_calc.domain.enums import CQS, ExposureClass
 from rwa_calc.engine.classifier import ENTITY_TYPES_BY_SA_CLASS
 from rwa_calc.engine.fx_converter import FXConverter
-from rwa_calc.engine.utils import has_required_columns
+from rwa_calc.engine.utils import has_required_columns, partition_by_nullable
 
 if TYPE_CHECKING:
     from rwa_calc.contracts.config import CalculationConfig
@@ -356,8 +356,16 @@ class HierarchyResolver:
 
         # Art. 138: per-agency dedup to most recent, then resolve across agencies.
         # Rows without a CQS are ignored (only rated assessments count).
+        # The counterparty_reference.is_not_null filter is defence-in-depth
+        # against a downstream .over("counterparty_reference") collapsing all
+        # null-keyed ratings into one bucket — the loader contract should
+        # already guarantee non-null counterparty_reference on ratings.
         per_agency_latest = (
-            ratings.filter((pl.col("rating_type") == "external") & pl.col("cqs").is_not_null())
+            ratings.filter(
+                (pl.col("rating_type") == "external")
+                & pl.col("cqs").is_not_null()
+                & pl.col("counterparty_reference").is_not_null()
+            )
             .sort(sort_cols, descending=[True, True])
             .group_by(["counterparty_reference", "rating_agency"])
             .first()
@@ -2314,17 +2322,23 @@ class HierarchyResolver:
             .rename({"_res": "_res_c", "_prop": "_prop_c"})
         )
 
-        # .over() window functions for allocation weights (no self-join!)
+        # .over() window functions for allocation weights (no self-join!).
+        # Both partition keys are nullable in this frame: direct exposures
+        # (no facility) have null parent_facility_reference; null
+        # counterparty_reference can arise from upstream join misses. The
+        # null-partition guard prevents pooling unrelated rows.
         exposures = exposures.with_columns(
             [
-                pl.when(pl.col("parent_facility_reference").is_not_null())
-                .then(pl.col("total_exposure_amount").sum().over("parent_facility_reference"))
-                .otherwise(pl.col("total_exposure_amount"))
-                .alias("facility_total"),
-                pl.when(pl.col("counterparty_reference").is_not_null())
-                .then(pl.col("total_exposure_amount").sum().over("counterparty_reference"))
-                .otherwise(pl.col("total_exposure_amount"))
-                .alias("cp_total"),
+                partition_by_nullable(
+                    pl.col("total_exposure_amount").sum().over("parent_facility_reference"),
+                    "parent_facility_reference",
+                    pl.col("total_exposure_amount"),
+                ).alias("facility_total"),
+                partition_by_nullable(
+                    pl.col("total_exposure_amount").sum().over("counterparty_reference"),
+                    "counterparty_reference",
+                    pl.col("total_exposure_amount"),
+                ).alias("cp_total"),
             ]
         )
 
@@ -2453,33 +2467,31 @@ class HierarchyResolver:
             how="left",
         )
 
-        # .over() window functions for group totals (no self-join!)
+        # .over() window functions for group totals (no self-join!).
         # When no lending group, aggregate over counterparty_reference so the
-        # retail threshold test sees the obligor's full exposure, not a single line.
+        # retail threshold test sees the obligor's full exposure, not a single
+        # line. lending_group_reference is left-join nullable, so the null-
+        # partition guard prevents pooling unrelated unmapped rows.
         exposures = exposures.with_columns(
             [
-                pl.when(pl.col("lending_group_reference").is_not_null())
-                .then(
+                partition_by_nullable(
                     pl.col("drawn_amount")
                     .clip(lower_bound=0.0)
                     .sum()
                     .over("lending_group_reference")
-                    + pl.col("nominal_amount").sum().over("lending_group_reference")
-                )
-                .otherwise(
+                    + pl.col("nominal_amount").sum().over("lending_group_reference"),
+                    "lending_group_reference",
                     pl.col("drawn_amount")
                     .clip(lower_bound=0.0)
                     .sum()
                     .over("counterparty_reference")
-                    + pl.col("nominal_amount").sum().over("counterparty_reference")
-                )
-                .alias("lending_group_total_exposure"),
-                pl.when(pl.col("lending_group_reference").is_not_null())
-                .then(pl.col("exposure_for_retail_threshold").sum().over("lending_group_reference"))
-                .otherwise(
-                    pl.col("exposure_for_retail_threshold").sum().over("counterparty_reference")
-                )
-                .alias("lending_group_adjusted_exposure"),
+                    + pl.col("nominal_amount").sum().over("counterparty_reference"),
+                ).alias("lending_group_total_exposure"),
+                partition_by_nullable(
+                    pl.col("exposure_for_retail_threshold").sum().over("lending_group_reference"),
+                    "lending_group_reference",
+                    pl.col("exposure_for_retail_threshold").sum().over("counterparty_reference"),
+                ).alias("lending_group_adjusted_exposure"),
             ]
         )
 

--- a/src/rwa_calc/engine/utils.py
+++ b/src/rwa_calc/engine/utils.py
@@ -11,6 +11,56 @@ from datetime import date
 
 import polars as pl
 
+# Partition keys that can carry null values in the engine's frames. A naked
+# ``.over(key)`` on any of these will collapse all null-keyed rows into one
+# bucket, silently pooling unrelated rows in pro-rata aggregates. Use
+# ``partition_by_nullable`` to guard window aggregates over these keys.
+#
+# This set is the single source of truth for the AST contract test at
+# ``tests/contracts/test_no_raw_over_on_nullable_keys.py`` — keep both in sync.
+# Membership is derived from ``ColumnSpec(required=False)`` columns and
+# left-join nullable inputs in ``data/schemas.py``.
+NULLABLE_PARTITION_KEYS: frozenset[str] = frozenset(
+    {
+        "parent_facility_reference",
+        "lending_group_reference",
+        "counterparty_reference",
+    }
+)
+
+
+def partition_by_nullable(
+    agg_expr: pl.Expr,
+    key: str,
+    else_expr: pl.Expr,
+) -> pl.Expr:
+    """Guard a window aggregate against null-partition collapse.
+
+    Polars ``.over(key)`` collapses ALL null-keyed rows into a single
+    partition, so an unguarded ``.sum()`` over a nullable key silently
+    aggregates unrelated rows together — typically producing wrong pro-rata
+    weights downstream. This helper wraps an ``agg_expr`` (which already
+    contains ``.over(key)``) in a ``pl.when(key.is_not_null())`` conditional,
+    falling back to ``else_expr`` for null-keyed rows.
+
+    The shape is intentionally a thin ``pl.when`` shim, not an ``.over``
+    injector: call sites with compound additive aggregates (e.g.
+    ``drawn.over(K) + nominal.over(K)``) or multi-key partitions can
+    construct ``agg_expr`` themselves and pass it in fully formed.
+
+    Args:
+        agg_expr: The window aggregate expression. Must contain ``.over(key)``.
+        key: The partition column name; must match ``agg_expr``'s ``.over`` arg.
+        else_expr: Expression evaluated for rows where ``key`` is null. Accepts
+            any ``pl.Expr`` — column references, literals (wrap scalars in
+            ``pl.lit``), or other ``.over()`` expressions (e.g. a fallback
+            aggregation over a different key).
+
+    Returns:
+        A conditional Polars expression safe against null-partition collapse.
+    """
+    return pl.when(pl.col(key).is_not_null()).then(agg_expr).otherwise(else_expr)
+
 
 def exact_fractional_years_expr(
     start_date: date,

--- a/tests/contracts/test_facility_mapping_normalisation.py
+++ b/tests/contracts/test_facility_mapping_normalisation.py
@@ -1,0 +1,168 @@
+"""Contract tests for ``_normalise_facility_mappings`` schema normalisation.
+
+The resolver boundary (`HierarchyResolver.resolve`) calls
+``_normalise_facility_mappings`` so that all downstream stages can rely on
+``child_type`` existing on every ``facility_mappings`` frame. This test
+pins the three accepted input shapes and the idempotency invariant.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from rwa_calc.engine.hierarchy import _normalise_facility_mappings
+
+
+class TestNormaliseFacilityMappings:
+    """Pin the three accepted input shapes + idempotency."""
+
+    def _expected_columns(self) -> set[str]:
+        return {"parent_facility_reference", "child_reference", "child_type"}
+
+    def test_canonical_child_type_passes_through(self) -> None:
+        """A frame already carrying ``child_type`` is unchanged in column set."""
+        lf = pl.DataFrame(
+            {
+                "parent_facility_reference": ["FAC1"],
+                "child_reference": ["LOAN1"],
+                "child_type": ["loan"],
+            }
+        ).lazy()
+
+        normalised = _normalise_facility_mappings(lf)
+
+        assert set(normalised.collect_schema().names()) == self._expected_columns()
+        df = normalised.collect()
+        assert df["child_type"][0] == "loan"
+
+    def test_legacy_node_type_renamed_to_child_type(self) -> None:
+        """``node_type`` is renamed to ``child_type``; values preserved."""
+        lf = pl.DataFrame(
+            {
+                "parent_facility_reference": ["FAC1"],
+                "child_reference": ["LOAN1"],
+                "node_type": ["loan"],
+            }
+        ).lazy()
+
+        normalised = _normalise_facility_mappings(lf)
+
+        cols = set(normalised.collect_schema().names())
+        assert cols == self._expected_columns()
+        assert "node_type" not in cols
+        df = normalised.collect()
+        assert df["child_type"][0] == "loan"
+
+    def test_neither_column_synthesises_null_child_type(self) -> None:
+        """A frame with no type column gets a synthesised null ``child_type``."""
+        lf = pl.DataFrame(
+            {
+                "parent_facility_reference": ["FAC1"],
+                "child_reference": ["LOAN1"],
+            }
+        ).lazy()
+
+        normalised = _normalise_facility_mappings(lf)
+
+        cols = set(normalised.collect_schema().names())
+        assert cols == self._expected_columns()
+        df = normalised.collect()
+        assert df["child_type"][0] is None
+
+    def test_collision_raises_value_error(self) -> None:
+        """Both ``child_type`` and ``node_type`` present is an ambiguous shape."""
+        lf = pl.DataFrame(
+            {
+                "parent_facility_reference": ["FAC1"],
+                "child_reference": ["LOAN1"],
+                "child_type": ["loan"],
+                "node_type": ["facility"],
+            }
+        ).lazy()
+
+        with pytest.raises(ValueError, match="ambiguous discriminator"):
+            _normalise_facility_mappings(lf)
+
+    def test_idempotent_on_canonical_input(self) -> None:
+        """Calling twice on a canonical frame is a no-op."""
+        lf = pl.DataFrame(
+            {
+                "parent_facility_reference": ["FAC1"],
+                "child_reference": ["LOAN1"],
+                "child_type": ["loan"],
+            }
+        ).lazy()
+
+        once = _normalise_facility_mappings(lf)
+        twice = _normalise_facility_mappings(once)
+
+        cols_once = set(once.collect_schema().names())
+        cols_twice = set(twice.collect_schema().names())
+        assert cols_once == cols_twice == self._expected_columns()
+
+        df_once = once.collect()
+        df_twice = twice.collect()
+        assert df_once.equals(df_twice)
+
+    def test_idempotent_on_legacy_input(self) -> None:
+        """A second call after rename does not raise (no ``node_type`` left)."""
+        lf = pl.DataFrame(
+            {
+                "parent_facility_reference": ["FAC1"],
+                "child_reference": ["LOAN1"],
+                "node_type": ["loan"],
+            }
+        ).lazy()
+
+        once = _normalise_facility_mappings(lf)
+        twice = _normalise_facility_mappings(once)
+
+        df_once = once.collect()
+        df_twice = twice.collect()
+        assert df_once.equals(df_twice)
+
+    def test_idempotent_on_synthesised_input(self) -> None:
+        """A second call after synthesis preserves the synthesised null column."""
+        lf = pl.DataFrame(
+            {
+                "parent_facility_reference": ["FAC1"],
+                "child_reference": ["LOAN1"],
+            }
+        ).lazy()
+
+        once = _normalise_facility_mappings(lf)
+        twice = _normalise_facility_mappings(once)
+
+        df_once = once.collect()
+        df_twice = twice.collect()
+        assert df_once.equals(df_twice)
+
+    def test_three_shapes_produce_identical_column_sets(self) -> None:
+        """The three accepted shapes converge on the same column set."""
+        canonical = pl.DataFrame(
+            {
+                "parent_facility_reference": ["FAC1"],
+                "child_reference": ["LOAN1"],
+                "child_type": ["loan"],
+            }
+        ).lazy()
+        legacy = pl.DataFrame(
+            {
+                "parent_facility_reference": ["FAC1"],
+                "child_reference": ["LOAN1"],
+                "node_type": ["loan"],
+            }
+        ).lazy()
+        neither = pl.DataFrame(
+            {
+                "parent_facility_reference": ["FAC1"],
+                "child_reference": ["LOAN1"],
+            }
+        ).lazy()
+
+        cols_canonical = set(_normalise_facility_mappings(canonical).collect_schema().names())
+        cols_legacy = set(_normalise_facility_mappings(legacy).collect_schema().names())
+        cols_neither = set(_normalise_facility_mappings(neither).collect_schema().names())
+
+        assert cols_canonical == cols_legacy == cols_neither == self._expected_columns()

--- a/tests/contracts/test_no_raw_over_on_nullable_keys.py
+++ b/tests/contracts/test_no_raw_over_on_nullable_keys.py
@@ -1,0 +1,174 @@
+"""Contract test: no raw ``.over(<nullable_key>)`` outside the helper.
+
+Polars ``.over(key)`` collapses ALL null-keyed rows into a single partition,
+so an unguarded window aggregate on a nullable column silently pools
+unrelated rows. The :func:`partition_by_nullable` helper in
+``rwa_calc.engine.utils`` is the canonical guard.
+
+This test walks every ``*.py`` file under ``src/rwa_calc/engine/``,
+parses it with ``ast``, and flags any ``.over(...)`` call whose first
+positional argument or ``partition_by`` keyword argument is a string
+literal that matches the engine's nullable-key set
+(``rwa_calc.engine.utils.NULLABLE_PARTITION_KEYS``). Non-constant first
+arguments (variables, ``pl.col(...)``, splats) are flagged as ambiguous —
+they MUST either use the helper or be added to the allowlist with
+justification.
+
+The helper file itself is the only allowlist entry by default. New
+exemptions require a deliberate, reviewed addition.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from rwa_calc.engine.utils import NULLABLE_PARTITION_KEYS
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ENGINE_ROOT = REPO_ROOT / "src" / "rwa_calc" / "engine"
+
+# Files exempt from the rule. The helper itself defines the canonical
+# guarded form, so its own ``.over`` calls are by construction the safe
+# ones. New entries here MUST carry a justification comment.
+ALLOWLIST: frozenset[str] = frozenset(
+    {
+        # The guard helper itself — defines the canonical pattern.
+        "utils.py",
+    }
+)
+
+# Line-level allowlist for ``.over(<nullable_key>)`` calls that are provably
+# safe in their context (e.g. an upstream ``filter(key.is_not_null())``).
+# Format: ``{relative_posix_path: frozenset[int]}``. Each entry MUST carry a
+# justification comment naming the filter or invariant that makes the key
+# non-null at this site.
+LINE_ALLOWLIST: dict[str, frozenset[int]] = {
+    # _build_rating_inheritance_lazy: the L343-equivalent filter on
+    # `per_agency_latest` adds `counterparty_reference.is_not_null()` to the
+    # upstream filter, so these `.over("counterparty_reference")` calls
+    # operate on a frame with no null-keyed rows. See the comment block
+    # above the per_agency_latest filter in engine/hierarchy.py.
+    "src/rwa_calc/engine/hierarchy.py": frozenset({380, 381}),
+}
+
+
+class _OverVisitor(ast.NodeVisitor):
+    """Collect ``.over(...)`` call sites that risk null-partition collapse.
+
+    Tracks ``partition_by_nullable(...)`` enclosing calls so that ``.over``
+    expressions passed as arguments to the helper (the helper's contract is
+    that ``agg_expr`` already contains its own ``.over(key)``) are not
+    flagged as raw uses.
+    """
+
+    def __init__(self, allowed_lines: frozenset[int]) -> None:
+        self.violations: list[tuple[int, str]] = []
+        self._helper_call_depth: int = 0
+        self._allowed_lines = allowed_lines
+
+    def _flag(self, lineno: int, message: str) -> None:
+        if self._helper_call_depth > 0:
+            return  # ``.over`` inside partition_by_nullable(...) — by-design
+        if lineno in self._allowed_lines:
+            return  # explicit line-level exemption
+        self.violations.append((lineno, message))
+
+    def _flag_arg(self, lineno: int, value: object, position: str) -> None:
+        if isinstance(value, str) and value in NULLABLE_PARTITION_KEYS:
+            self._flag(lineno, f".over({position}={value!r}) — use partition_by_nullable")
+
+    def visit_Call(self, node: ast.Call) -> None:  # noqa: N802 (ast API)
+        # Detect ``partition_by_nullable(...)`` enclosing calls so we don't
+        # double-flag the ``.over`` expressions the helper expects as args.
+        is_helper = isinstance(node.func, ast.Name) and node.func.id == "partition_by_nullable"
+        if is_helper:
+            self._helper_call_depth += 1
+        try:
+            # Match ``<expr>.over(...)`` calls only.
+            if isinstance(node.func, ast.Attribute) and node.func.attr == "over":
+                # All positional args are partition keys; check each.
+                for idx, arg in enumerate(node.args):
+                    if isinstance(arg, ast.Constant):
+                        self._flag_arg(node.lineno, arg.value, f"arg[{idx}]")
+                    else:
+                        # Variables, pl.col(...), splats — ambiguous from a
+                        # static AST view. Flag so the author has to opt in
+                        # via the helper.
+                        self._flag(
+                            node.lineno,
+                            f".over(<non-constant arg[{idx}]>) — "
+                            "use partition_by_nullable or move to allowlist",
+                        )
+                # Keyword form: ``.over(partition_by="...")``.
+                for kw in node.keywords:
+                    if kw.arg == "partition_by" and isinstance(kw.value, ast.Constant):
+                        self._flag_arg(node.lineno, kw.value.value, "partition_by")
+                    elif kw.arg == "partition_by":
+                        self._flag(
+                            node.lineno,
+                            ".over(partition_by=<non-constant>) — "
+                            "use partition_by_nullable or move to allowlist",
+                        )
+            self.generic_visit(node)
+        finally:
+            if is_helper:
+                self._helper_call_depth -= 1
+
+
+def _scan_file(path: Path) -> list[tuple[int, str]]:
+    """Return ``(lineno, message)`` violations found in ``path``."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    rel = path.relative_to(REPO_ROOT).as_posix()
+    visitor = _OverVisitor(LINE_ALLOWLIST.get(rel, frozenset()))
+    visitor.visit(tree)
+    return visitor.violations
+
+
+def _engine_files() -> list[Path]:
+    """All ``.py`` files under ``src/rwa_calc/engine/``."""
+    return sorted(p for p in ENGINE_ROOT.rglob("*.py") if p.is_file())
+
+
+def test_engine_root_exists() -> None:
+    """Sanity: the engine directory and helper file are where we expect."""
+    assert ENGINE_ROOT.is_dir()
+    assert (ENGINE_ROOT / "utils.py").is_file()
+
+
+def test_no_raw_over_on_nullable_keys() -> None:
+    """No ``.over(<nullable_key>)`` outside the ``partition_by_nullable`` helper.
+
+    ``.over()`` collapses null-keyed rows into a single partition, silently
+    pooling unrelated exposures into pro-rata aggregates. Any window
+    aggregate on a nullable key must use ``partition_by_nullable`` from
+    ``rwa_calc.engine.utils``.
+    """
+    all_violations: list[str] = []
+    for path in _engine_files():
+        if path.name in ALLOWLIST:
+            continue
+        for lineno, message in _scan_file(path):
+            rel = path.relative_to(REPO_ROOT).as_posix()
+            all_violations.append(f"{rel}:{lineno}: {message}")
+
+    assert not all_violations, (
+        "Raw .over(<nullable_key>) found outside partition_by_nullable. "
+        "Wrap with rwa_calc.engine.utils.partition_by_nullable, or — if the "
+        "key is provably non-null in this context — add the file to ALLOWLIST "
+        "in tests/contracts/test_no_raw_over_on_nullable_keys.py with a "
+        "justification comment.\n\nViolations:\n  " + "\n  ".join(all_violations)
+    )
+
+
+@pytest.mark.parametrize("nullable_key", sorted(NULLABLE_PARTITION_KEYS))
+def test_nullable_key_set_is_documented(nullable_key: str) -> None:
+    """Each nullable key is documented in the helper's docstring."""
+    helper_src = (ENGINE_ROOT / "utils.py").read_text(encoding="utf-8")
+    assert nullable_key in helper_src, (
+        f"Nullable partition key {nullable_key!r} is not mentioned in "
+        f"engine/utils.py — keep the docstring's enumeration in sync with "
+        f"NULLABLE_PARTITION_KEYS."
+    )

--- a/tests/unit/test_hierarchy.py
+++ b/tests/unit/test_hierarchy.py
@@ -414,6 +414,260 @@ class TestBuildRatingInheritanceLazy:
         assert cp004["cqs"][0] is None
 
 
+class TestInheritanceTruthTable:
+    """Behavioural lock for the dual coalesce in _build_rating_inheritance_lazy.
+
+    See REVIEWER NOTE on _build_rating_inheritance_lazy: rows 4, 6, 7 of this
+    truth table are the load-bearing assertions. A refactor that simplifies
+    the coalesce (e.g. fusing PD + model_id into a struct-coalesce, or
+    collapsing the two own/parent joins into one) MUST update these rows;
+    do not delete them.
+
+    Row 7 (desync) is skipped pending a Risk decision on whether
+    independent-coalesce or strict-pairing is the intended semantic for the
+    case where own_pd is present but own_model_id is null. Replace RWA-XXXX
+    with the real ticket and unskip with the agreed expected tuple before
+    merge.
+    """
+
+    @staticmethod
+    def _build_inheritance_inputs(
+        own_pd: float | None,
+        own_model_id: str | None,
+        parent_pd: float | None,
+        parent_model_id: str | None,
+        *,
+        own_cqs: int | None = None,
+        parent_cqs: int | None = None,
+        multi_level: bool = False,
+    ) -> tuple[pl.LazyFrame, pl.LazyFrame, pl.LazyFrame]:
+        """Build (counterparties, ratings, org_mappings) for one truth-table row.
+
+        Single-level: CHILD -> PARENT.
+        Multi-level (depth 2): CHILD -> MID -> ULT, parent_* applied to ULT.
+        """
+        if multi_level:
+            counterparty_refs = ["CHILD", "MID", "ULT"]
+            org_mappings = pl.DataFrame(
+                {
+                    "child_counterparty_reference": ["CHILD", "MID"],
+                    "parent_counterparty_reference": ["MID", "ULT"],
+                }
+            ).lazy()
+            parent_ref = "ULT"
+        else:
+            counterparty_refs = ["CHILD", "PARENT"]
+            org_mappings = pl.DataFrame(
+                {
+                    "child_counterparty_reference": ["CHILD"],
+                    "parent_counterparty_reference": ["PARENT"],
+                }
+            ).lazy()
+            parent_ref = "PARENT"
+
+        counterparties = pl.DataFrame({"counterparty_reference": counterparty_refs}).lazy()
+
+        rating_rows: dict[str, list[object]] = {
+            "rating_reference": [],
+            "counterparty_reference": [],
+            "rating_type": [],
+            "rating_agency": [],
+            "rating_value": [],
+            "cqs": [],
+            "pd": [],
+            "model_id": [],
+            "rating_date": [],
+        }
+
+        def _add(
+            rating_ref: str,
+            cp_ref: str,
+            rtype: str,
+            agency: str,
+            value: str,
+            cqs: int | None,
+            pd_value: float | None,
+            model_id: str | None,
+        ) -> None:
+            rating_rows["rating_reference"].append(rating_ref)
+            rating_rows["counterparty_reference"].append(cp_ref)
+            rating_rows["rating_type"].append(rtype)
+            rating_rows["rating_agency"].append(agency)
+            rating_rows["rating_value"].append(value)
+            rating_rows["cqs"].append(cqs)
+            rating_rows["pd"].append(pd_value)
+            rating_rows["model_id"].append(model_id)
+            rating_rows["rating_date"].append(date(2024, 6, 1))
+
+        if own_pd is not None or own_model_id is not None:
+            _add("R_OWN_INT", "CHILD", "internal", "INTERNAL", "INT", None, own_pd, own_model_id)
+        if own_cqs is not None:
+            _add("R_OWN_EXT", "CHILD", "external", "MOODYS", "Aa1", own_cqs, None, None)
+        if parent_pd is not None or parent_model_id is not None:
+            _add(
+                "R_PARENT_INT",
+                parent_ref,
+                "internal",
+                "INTERNAL",
+                "INT",
+                None,
+                parent_pd,
+                parent_model_id,
+            )
+        if parent_cqs is not None:
+            _add("R_PARENT_EXT", parent_ref, "external", "MOODYS", "Aa1", parent_cqs, None, None)
+
+        if not rating_rows["rating_reference"]:
+            ratings = pl.DataFrame(
+                schema={
+                    "rating_reference": pl.String,
+                    "counterparty_reference": pl.String,
+                    "rating_type": pl.String,
+                    "rating_agency": pl.String,
+                    "rating_value": pl.String,
+                    "cqs": pl.Int64,
+                    "pd": pl.Float64,
+                    "model_id": pl.String,
+                    "rating_date": pl.Date,
+                }
+            ).lazy()
+        else:
+            ratings = pl.DataFrame(rating_rows).lazy()
+
+        return counterparties, ratings, org_mappings
+
+    @pytest.mark.parametrize(
+        (
+            "scenario",
+            "own_pd",
+            "own_model",
+            "parent_pd",
+            "parent_model",
+            "own_cqs",
+            "parent_cqs",
+            "multi",
+            "exp_pd",
+            "exp_model",
+            "exp_cqs",
+        ),
+        [
+            ("1_empty", None, None, None, None, None, None, False, None, None, None),
+            ("2_inherit", None, None, 0.02, "M_PARENT", None, None, False, 0.02, "M_PARENT", None),
+            ("3_own_only", 0.01, "M_OWN", None, None, None, None, False, 0.01, "M_OWN", None),
+            (
+                "4_gap_own_wins",
+                0.01,
+                "M_OWN",
+                0.02,
+                "M_PARENT",
+                None,
+                None,
+                False,
+                0.01,
+                "M_OWN",
+                None,
+            ),
+            ("5_tie", 0.02, "M_OWN", 0.02, "M_PARENT", None, None, False, 0.02, "M_OWN", None),
+            ("6_multi_level", None, None, 0.01, "M_ULT", None, None, True, 0.01, "M_ULT", None),
+            pytest.param(
+                "7_desync_blocked",
+                0.02,
+                None,
+                None,
+                "M_PARENT",
+                None,
+                None,
+                False,
+                None,
+                None,
+                None,
+                marks=pytest.mark.skip(
+                    reason=(
+                        "BLOCKED on Risk decision RWA-XXXX: Option A "
+                        "(independent coalesce, current: pd=0.02, model=M_PARENT) "
+                        "vs Option B (strict pairing: pd=0.02, model=null). "
+                        "Replace RWA-XXXX with the real ticket and unskip with "
+                        "the agreed expected tuple before merge."
+                    )
+                ),
+            ),
+            ("8_desync_mirror", None, "M_OWN", 0.02, None, None, None, False, 0.02, "M_OWN", None),
+            ("9_external_fence", None, None, None, None, None, 2, False, None, None, None),
+            ("10_full_rating", 0.005, "M_OWN", 0.02, "M_PARENT", 1, None, False, 0.005, "M_OWN", 1),
+        ],
+    )
+    def test_inheritance_truth_table(
+        self,
+        resolver: HierarchyResolver,
+        scenario: str,
+        own_pd: float | None,
+        own_model: str | None,
+        parent_pd: float | None,
+        parent_model: str | None,
+        own_cqs: int | None,
+        parent_cqs: int | None,
+        multi: bool,
+        exp_pd: float | None,
+        exp_model: str | None,
+        exp_cqs: int | None,
+    ) -> None:
+        """Behavioural truth table for the dual own->parent coalesce."""
+        counterparties, ratings, org_mappings = self._build_inheritance_inputs(
+            own_pd,
+            own_model,
+            parent_pd,
+            parent_model,
+            own_cqs=own_cqs,
+            parent_cqs=parent_cqs,
+            multi_level=multi,
+        )
+
+        ultimate_parents = resolver._build_ultimate_parent_lazy(org_mappings)
+
+        if multi:
+            # Pre-assert that ultimate-parent resolution actually walked 2 hops.
+            ups = ultimate_parents.collect()
+            child_row = ups.filter(pl.col("counterparty_reference") == "CHILD")
+            assert len(child_row) == 1, f"missing CHILD in {scenario} ultimate_parents"
+            assert child_row["ultimate_parent_reference"][0] == "ULT", scenario
+            assert child_row["hierarchy_depth"][0] == 2, scenario
+
+        result = resolver._build_rating_inheritance_lazy(
+            counterparties, ratings, ultimate_parents
+        ).collect()
+
+        child = result.filter(pl.col("counterparty_reference") == "CHILD")
+        assert len(child) == 1, f"expected exactly one CHILD row in {scenario}"
+
+        # Canonical column assertions.
+        if exp_pd is None:
+            assert child["internal_pd"][0] is None, scenario
+        else:
+            assert child["internal_pd"][0] == pytest.approx(exp_pd), scenario
+
+        if exp_model is None:
+            assert child["internal_model_id"][0] is None, scenario
+        else:
+            assert child["internal_model_id"][0] == exp_model, scenario
+
+        if exp_cqs is None:
+            assert child["external_cqs"][0] is None, scenario
+        else:
+            assert child["external_cqs"][0] == exp_cqs, scenario
+
+        # Alias column assertions — pin the alias derivation at
+        # hierarchy.py:434-439 so a refactor that drops the alias fails loudly.
+        if exp_pd is None:
+            assert child["pd"][0] is None, scenario
+        else:
+            assert child["pd"][0] == pytest.approx(exp_pd), scenario
+
+        if exp_cqs is None:
+            assert child["cqs"][0] is None, scenario
+        else:
+            assert child["cqs"][0] == exp_cqs, scenario
+
+
 class TestDualRatingResolution:
     """Tests for dual per-type (internal/external) rating resolution."""
 

--- a/tests/unit/test_hierarchy.py
+++ b/tests/unit/test_hierarchy.py
@@ -3598,8 +3598,16 @@ class TestDuplicateMappingBugFixes:
         self,
         resolver: HierarchyResolver,
     ) -> None:
-        """facility_mappings with neither child_type nor node_type column
-        should still produce correct facility_undrawn rows (Bug 3 fallback).
+        """facility_mappings with neither child_type nor node_type column.
+
+        Post-normalisation contract: the resolver boundary synthesises a null
+        ``child_type`` column for legacy mappings via ``_normalise_facility_mappings``.
+        Null ``child_type`` is treated as "no children of any type", so loan
+        aggregation does not run and the facility's undrawn equals its full limit.
+
+        The right fix in production data is to emit ``child_type='loan'`` on
+        loan mappings — once specified, aggregation works (covered by
+        ``test_facility_undrawn_with_explicit_loan_type`` below).
         """
         facilities = pl.DataFrame(
             {
@@ -3632,7 +3640,8 @@ class TestDuplicateMappingBugFixes:
             }
         ).lazy()
 
-        # No child_type or node_type column at all
+        # No child_type column at all — post-normalisation, synthesised null
+        # blocks the loan aggregation path.
         mappings = pl.DataFrame(
             {
                 "parent_facility_reference": ["FAC_NOTYPE"],
@@ -3644,6 +3653,63 @@ class TestDuplicateMappingBugFixes:
         df = facility_undrawn.collect()
 
         fac = df.filter(pl.col("exposure_reference") == "FAC_NOTYPE_UNDRAWN")
+        assert len(fac) == 1
+        # Without explicit child_type='loan', loan is not aggregated; full limit is undrawn.
+        assert fac["undrawn_amount"][0] == pytest.approx(1000000.0)
+
+    def test_facility_undrawn_with_explicit_loan_type(
+        self,
+        resolver: HierarchyResolver,
+    ) -> None:
+        """Same input as the no-type-column test, but with the canonical child_type='loan'.
+
+        Confirms that once the input shape matches the post-normalisation contract,
+        loan drawn amounts are aggregated against the facility's limit and the
+        undrawn equals limit minus drawn.
+        """
+        facilities = pl.DataFrame(
+            {
+                "facility_reference": ["FAC_TYPED"],
+                "product_type": ["RCF"],
+                "book_code": ["CORP"],
+                "counterparty_reference": ["CP_TYPED"],
+                "value_date": [date(2023, 1, 1)],
+                "maturity_date": [date(2028, 1, 1)],
+                "currency": ["GBP"],
+                "limit": [1000000.0],
+                "lgd": [0.45],
+                "seniority": ["senior"],
+                "risk_type": ["MR"],
+            }
+        ).lazy()
+
+        loans = pl.DataFrame(
+            {
+                "loan_reference": ["LOAN_TYPED"],
+                "product_type": ["TERM_LOAN"],
+                "book_code": ["CORP"],
+                "counterparty_reference": ["CP_TYPED"],
+                "value_date": [date(2023, 6, 1)],
+                "maturity_date": [date(2028, 1, 1)],
+                "currency": ["GBP"],
+                "drawn_amount": [300000.0],
+                "lgd": [0.45],
+                "seniority": ["senior"],
+            }
+        ).lazy()
+
+        mappings = pl.DataFrame(
+            {
+                "parent_facility_reference": ["FAC_TYPED"],
+                "child_reference": ["LOAN_TYPED"],
+                "child_type": ["loan"],
+            }
+        ).lazy()
+
+        facility_undrawn = resolver._calculate_facility_undrawn(facilities, loans, None, mappings)
+        df = facility_undrawn.collect()
+
+        fac = df.filter(pl.col("exposure_reference") == "FAC_TYPED_UNDRAWN")
         assert len(fac) == 1
         assert fac["undrawn_amount"][0] == pytest.approx(700000.0)  # 1M - 300k
 
@@ -3880,7 +3946,13 @@ class TestBuildFacilityRootLookup:
         self,
         resolver: HierarchyResolver,
     ) -> None:
-        """No child_type/node_type column → cannot detect sub-facilities, return empty."""
+        """No child_type column → cannot detect sub-facilities, return empty.
+
+        Post-normalisation, ``_normalise_facility_mappings`` synthesises a null
+        ``child_type``; the downstream filter (``== "facility"``) yields zero
+        rows, ``facility_edges`` is empty, and the empty-result short-circuit
+        fires.
+        """
         facility_mappings = pl.DataFrame(
             {
                 "parent_facility_reference": ["FAC_ROOT"],

--- a/tests/unit/test_hierarchy_nullable_partition.py
+++ b/tests/unit/test_hierarchy_nullable_partition.py
@@ -1,0 +1,188 @@
+"""Tests for null-partition guarding in window-aggregate enrichments.
+
+Polars ``.over(key)`` collapses ALL null-keyed rows into a single partition.
+Without the ``partition_by_nullable`` guard, two unrelated counterparties that
+both have a null ``lending_group_reference`` would be aggregated together —
+silently pooling their drawn / nominal amounts.
+
+These tests pin the behaviour of ``_enrich_with_lending_group`` against that
+regression. Each test runs under both ``cpu`` and ``streaming`` collect
+engines because the streaming engine has historically had subtle differences
+in null-group handling.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from rwa_calc.contracts.config import CalculationConfig
+from rwa_calc.engine.hierarchy import HierarchyResolver
+
+# ---------------------------------------------------------------------------
+# Engine-config fixtures (copied verbatim from tests/unit/test_materialise.py
+# so this module is self-contained and does not depend on cross-test imports).
+# Acknowledged duplication; lifting to conftest is out of scope for this PR.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def cpu_config() -> CalculationConfig:
+    """Config with cpu engine — uses in-memory collect."""
+    return CalculationConfig.crr(reporting_date=date(2024, 12, 31), collect_engine="cpu")
+
+
+@pytest.fixture()
+def streaming_config(tmp_path: Path) -> CalculationConfig:
+    """Config with streaming engine — uses disk-spill via sink_parquet."""
+    return CalculationConfig.crr(
+        reporting_date=date(2024, 12, 31),
+        collect_engine="streaming",
+        spill_dir=tmp_path,
+    )
+
+
+@pytest.fixture(params=["cpu_config", "streaming_config"])
+def any_config(request: pytest.FixtureRequest) -> CalculationConfig:
+    """Parametrised over both engines — every test runs twice."""
+    return request.getfixturevalue(request.param)
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+
+def _build_minimal_exposures(rows: list[dict[str, object]]) -> pl.LazyFrame:
+    """Build the minimal exposure frame ``_enrich_with_lending_group`` consumes."""
+    return pl.DataFrame(rows).lazy()
+
+
+# ---------------------------------------------------------------------------
+# Tests — null-partition guard for lending_group_reference
+# ---------------------------------------------------------------------------
+
+
+class TestNullableLendingGroupAggregation:
+    """Null `lending_group_reference` rows must NOT pool across counterparties."""
+
+    def test_two_unrelated_unmapped_counterparties_do_not_pool(
+        self,
+        any_config: CalculationConfig,  # noqa: ARG002 (engine parametrisation)
+    ) -> None:
+        """Two counterparties with no lending group must aggregate separately.
+
+        Pre-fix (raw `.over("lending_group_reference")`): both rows share a
+        null partition, so each row's ``lending_group_total_exposure`` would
+        be the SUM of both counterparties' exposures.
+
+        Post-fix (`partition_by_nullable`): the null branch falls back to
+        ``.over("counterparty_reference")``, so each row aggregates only
+        within its own counterparty.
+        """
+        resolver = HierarchyResolver()
+
+        # Two unrelated counterparties, neither in a lending group.
+        exposures = _build_minimal_exposures(
+            [
+                {
+                    "exposure_reference": "EXP_A",
+                    "counterparty_reference": "CP_A",
+                    "drawn_amount": 100.0,
+                    "nominal_amount": 0.0,
+                    "exposure_for_retail_threshold": 100.0,
+                },
+                {
+                    "exposure_reference": "EXP_B",
+                    "counterparty_reference": "CP_B",
+                    "drawn_amount": 500.0,
+                    "nominal_amount": 0.0,
+                    "exposure_for_retail_threshold": 500.0,
+                },
+            ]
+        )
+        empty_lending = pl.LazyFrame(
+            schema={
+                "parent_counterparty_reference": pl.String,
+                "child_counterparty_reference": pl.String,
+            }
+        )
+
+        result = resolver._enrich_with_lending_group(exposures, empty_lending).collect()
+
+        cp_a = result.filter(pl.col("counterparty_reference") == "CP_A")
+        cp_b = result.filter(pl.col("counterparty_reference") == "CP_B")
+
+        assert len(cp_a) == 1 and len(cp_b) == 1
+
+        # Each must see only its own counterparty's exposure, NOT the pooled sum.
+        assert cp_a["lending_group_total_exposure"][0] == 100.0, (
+            "CP_A's total pooled with CP_B — null-partition collapse regression"
+        )
+        assert cp_b["lending_group_total_exposure"][0] == 500.0, (
+            "CP_B's total pooled with CP_A — null-partition collapse regression"
+        )
+        assert cp_a["lending_group_adjusted_exposure"][0] == 100.0
+        assert cp_b["lending_group_adjusted_exposure"][0] == 500.0
+
+    def test_mixed_grouped_and_ungrouped_no_cross_pooling(
+        self,
+        any_config: CalculationConfig,  # noqa: ARG002 (engine parametrisation)
+    ) -> None:
+        """A grouped counterparty and an ungrouped one must not cross-pool.
+
+        The grouped counterparty's total includes its lending-group siblings;
+        the ungrouped counterparty's total is its own exposure only — even
+        though both branches share the null-vs-non-null distinction.
+        """
+        resolver = HierarchyResolver()
+
+        # CP_GROUPED is in a lending group with CP_SIBLING (each 100 drawn).
+        # CP_UNGROUPED is alone (500 drawn).
+        exposures = _build_minimal_exposures(
+            [
+                {
+                    "exposure_reference": "EXP_GROUPED",
+                    "counterparty_reference": "CP_GROUPED",
+                    "drawn_amount": 100.0,
+                    "nominal_amount": 0.0,
+                    "exposure_for_retail_threshold": 100.0,
+                },
+                {
+                    "exposure_reference": "EXP_SIBLING",
+                    "counterparty_reference": "CP_SIBLING",
+                    "drawn_amount": 100.0,
+                    "nominal_amount": 0.0,
+                    "exposure_for_retail_threshold": 100.0,
+                },
+                {
+                    "exposure_reference": "EXP_UNGROUPED",
+                    "counterparty_reference": "CP_UNGROUPED",
+                    "drawn_amount": 500.0,
+                    "nominal_amount": 0.0,
+                    "exposure_for_retail_threshold": 500.0,
+                },
+            ]
+        )
+        lending = pl.DataFrame(
+            {
+                "parent_counterparty_reference": ["LG_PARENT", "LG_PARENT"],
+                "child_counterparty_reference": ["CP_GROUPED", "CP_SIBLING"],
+            }
+        ).lazy()
+
+        result = resolver._enrich_with_lending_group(exposures, lending).collect()
+
+        grouped = result.filter(pl.col("counterparty_reference") == "CP_GROUPED")
+        ungrouped = result.filter(pl.col("counterparty_reference") == "CP_UNGROUPED")
+
+        # Grouped row aggregates over its lending group (100 + 100 = 200).
+        assert grouped["lending_group_total_exposure"][0] == 200.0
+        # Ungrouped row aggregates over its own counterparty (500), NOT pooled
+        # with any other null-membership rows.
+        assert ungrouped["lending_group_total_exposure"][0] == 500.0
+        # Ungrouped row's lending_group_reference should be null.
+        assert ungrouped["lending_group_reference"][0] is None


### PR DESCRIPTION
## Summary

First batch of three landmine-removal plans for `engine/hierarchy.py`, executed as preparation for a larger structural refactor of that module. Each landmine was identified, plan-architected, and pressure-tested against a devil's-advocate critique (twice in some cases) before implementation.

- **`facility_mappings` schema variance** (commit `09231b5`): replace runtime `_detect_type_column` schema-sniffing across 5 callsites with a single `_normalise_facility_mappings` pass at the resolver boundary. Downstream stages can now rely on `child_type` always existing.
- **`internal_pd` two-step coalesce** (commit `aeba9f3`): pin the deliberate own→parent coalesce in `_build_rating_inheritance_lazy` via a 10-row parametrised truth table. Asserts both canonical (`internal_pd`, `internal_model_id`, `external_cqs`) and aliased (`pd`, `cqs`) columns. Row 7 (PD/model_id desync) skipped pending a Risk decision (placeholder ticket `RWA-XXXX`).
- **`.over(<nullable_key>)` null-partition collapse** (commit `3488ea4`): introduce `partition_by_nullable` helper in `engine/utils.py`, migrate 5 sites, plus an AST-based contract test enforcing the rule across `engine/**`. Property tests run under both `cpu` and `streaming` collect engines.

## Changes by commit

### `09231b5` facility_mappings normalisation

- Add `_normalise_facility_mappings(lf)` in `engine/hierarchy.py`: renames legacy `node_type → child_type` (raises on collision), synthesises null `child_type` when absent, idempotent.
- Simplify `_filter_mappings_by_child_type` to drop the `type_col` parameter; pinned `unique → filter` order.
- Delete `_detect_type_column`. Migrate all 5 callsites (lines 476, 652, 1206, 1446, 1869) to literal `\"child_type\"`.
- Insert local rebinding in `HierarchyResolver.resolve` (RawDataBundle is frozen). Defensive idempotent re-calls inside `_calculate_facility_undrawn`, `_join_facility_metadata`, `_build_facility_root_lookup` for unit-test callers.
- New 8-test contract suite at `tests/contracts/test_facility_mapping_normalisation.py` pinning all three accepted input shapes, idempotency, and the both-columns-present collision.
- Doc updates in `docs/architecture/components.md` and `docs/specifications/common/hierarchy-classification.md`.
- **Behaviour change at the contract boundary**: when neither column was present, the previous fallback returned all mappings as the requested type. Post-normalisation, synthesised null `child_type` no longer matches any specific type, so loan/contingent aggregation does not run on legacy inputs. Production fixtures all emit `child_type`. The fixture exercising the legacy fallback was updated to reflect the new contract; a sibling test confirms the canonical shape works.

### `aeba9f3` internal_pd truth table

- Add `TestInheritanceTruthTable` (10 rows) in `tests/unit/test_hierarchy.py` covering: empty, inherit, own-only, **gap (own=0.01, parent=0.02 → own wins)**, tie, **multi-level via 2-edge chain CHILD→MID→ULT** (with pre-assertion that `_build_ultimate_parent_lazy` resolves depth=2), desync (skipped), desync mirror, external fence, full rating.
- Each row asserts both canonical and aliased columns so a refactor that drops the alias derivation fails loudly.
- Add reviewer-note docstring to `_build_rating_inheritance_lazy` citing CRR Art. 171(1) and Art. 175(3), pointing at rows 4, 6, 7 as the behavioural lock.
- **Action required before merge**: replace `RWA-XXXX` with the real Risk-decision ticket reference and unskip row 7 with the agreed expected tuple (Option A: `(0.02, M_PARENT)` independent coalesce, current behaviour; Option B: `(0.02, null)` strict pairing).

### `3488ea4` partition_by_nullable helper

- Add `partition_by_nullable(agg_expr, key, else_expr)` to `engine/utils.py`: thin `pl.when(key.is_not_null()).then(agg_expr).otherwise(else_expr)` shim. The helper does NOT inject `.over()` — call sites pass it inside `agg_expr` to support compound additive aggregates and multi-key partitions.
- Migrate `_join_property_collateral_multi_level` (`facility_total`/`cp_total`) and `_enrich_with_lending_group` (`lending_group_total_exposure`/`lending_group_adjusted_exposure`).
- L343 hardening: `_resolve_external_ratings` filter extends to `counterparty_reference.is_not_null()` so the downstream `.over(\"counterparty_reference\")` at L380-381 is provably non-null by construction.
- New AST contract test at `tests/contracts/test_no_raw_over_on_nullable_keys.py`: walks every `*.py` under `engine/`, parses with `ast`, flags any `.over(...)` (positional OR `partition_by=` kwarg) whose value matches `NULLABLE_PARTITION_KEYS`. Visitor tracks `partition_by_nullable(...)` enclosing calls so `.over` expressions inside the helper are not flagged. Line-level allowlist for L380-381 with justification.
- Property tests at `tests/unit/test_hierarchy_nullable_partition.py` parametrised over `cpu` and `streaming` collect engines, asserting two unmapped counterparties don't pool their lending-group totals and mixed grouped/ungrouped exposures don't cross-pool.

## Test plan

- [x] `pre_commit_gate.sh` exit 0
- [x] Full test suite green: 5,533 passed, 2 skipped, 4 deselected
- [x] New contract tests all pass (8 normalisation + 5 AST + 4 property)
- [x] All 497 acceptance tests pass
- [x] ruff + arch_check clean
- [ ] **Risk decision on PD/model_id desync row 7** before this PR can merge — replace `RWA-XXXX` placeholder
- [ ] Manual review with `git diff --color-moved=zebra` to confirm pure relocations in `09231b5` and `aeba9f3`

## Notes

This is the first of two batches. The remaining three landmines (`committed` flag null-handling with env-gated loader hardening, `pl.collect_all` cache routing through `materialise_branches`, `_resolve_graph_eager` `max_depth` → `warn_depth` with HIE003 emission) are queued for a separate PR.