### PR TITLE
Refactor/hierarchy landmines batch2

### DIFF
--- a/src/rwa_calc/data/column_spec.py
+++ b/src/rwa_calc/data/column_spec.py
@@ -72,3 +72,53 @@ def dtypes_of(schema: Mapping[str, ColumnSpec]) -> dict[str, pl.DataType]:
     accept a plain dtype dict; this helper is the bridge for those call sites.
     """
     return {name: spec.dtype for name, spec in schema.items()}
+
+
+def apply_boolean_column_defaults(
+    lf: pl.LazyFrame, schema: Mapping[str, ColumnSpec]
+) -> pl.LazyFrame:
+    """Fill nulls in present Boolean columns with their schema defaults.
+
+    Pipeline position:
+        Called by ``loader.enforce_schema`` strictly *after* the cast pass:
+        ``ensure_columns -> cast -> apply_boolean_column_defaults``. The
+        order matters — running before cast against an inferred ``pl.Null``
+        column would fail to type-coerce the literal cleanly.
+
+    Why Boolean-only:
+        A naive helper that filled nulls on every ``ColumnSpec(default=...)``
+        column would also fill ``Float64`` defaults of ``0.0`` (e.g.
+        ``LOAN_SCHEMA.drawn_amount``, ``PROVISION_SCHEMA.amount``). That is
+        anti-conservative for EAD and provisions: a null in a parquet today
+        propagates and surfaces in arithmetic as a null-bearing EAD (caught
+        by validation); a silent ``0.0`` does not. Float and String defaults
+        are intentionally **not** filled by this helper — broadening it
+        requires Risk sign-off.
+
+        The Boolean-only boundary is enforced by
+        ``tests/contracts/test_boolean_defaults_only.py`` which asserts that
+        non-Boolean defaults are NOT filled by this helper. Any future
+        contributor who needs to broaden it must update both this helper
+        and the contract test, surfacing the change for explicit review.
+
+    Args:
+        lf: LazyFrame to fill nulls on.
+        schema: ColumnSpec schema. Only Boolean columns with a non-None
+            default are filled; non-Boolean entries are silently skipped
+            (the contract test pins this behaviour). Columns absent from
+            ``lf`` are not added (use ``ensure_columns`` for that).
+
+    Returns:
+        LazyFrame with nulls filled in present Boolean columns.
+    """
+    existing = set(lf.collect_schema().names())
+
+    fill_exprs = [
+        pl.col(name).fill_null(pl.lit(spec.default).cast(pl.Boolean)).alias(name)
+        for name, spec in schema.items()
+        if spec.default is not None and spec.dtype == pl.Boolean and name in existing
+    ]
+
+    if not fill_exprs:
+        return lf
+    return lf.with_columns(fill_exprs)

--- a/src/rwa_calc/engine/hierarchy.py
+++ b/src/rwa_calc/engine/hierarchy.py
@@ -35,8 +35,12 @@ from rwa_calc.contracts.bundles import (
     ResolvedHierarchyBundle,
 )
 from rwa_calc.contracts.errors import CalculationError
-from rwa_calc.data.column_spec import ColumnSpec, ensure_columns
-from rwa_calc.data.schemas import FACILITY_MAPPING_SCHEMA
+from rwa_calc.data.column_spec import (
+    ColumnSpec,
+    apply_boolean_column_defaults,
+    ensure_columns,
+)
+from rwa_calc.data.schemas import FACILITY_MAPPING_SCHEMA, FACILITY_SCHEMA
 from rwa_calc.data.tables.crr_risk_weights import (
     CENTRAL_GOVT_CENTRAL_BANK_RISK_WEIGHTS,
     CORPORATE_RISK_WEIGHTS,
@@ -670,6 +674,16 @@ class HierarchyResolver:
         if not has_required_columns(facilities, {"facility_reference", "limit"}):
             return self._empty_facility_undrawn_frame()
 
+        # Defensive idempotent normalisation: the loader path applies these via
+        # ``enforce_schema``; unit-test callers may invoke this method directly
+        # with hand-built frames missing optional Boolean columns. ``ensure_columns``
+        # synthesises any missing column with its schema default;
+        # ``apply_boolean_column_defaults`` then fills present-but-null Boolean
+        # cells. After this pair, ``committed`` / ``is_obs_commitment`` /
+        # ``is_revolving`` / ``is_qrre_transactor`` are guaranteed non-null.
+        facilities = ensure_columns(facilities, FACILITY_SCHEMA)
+        facilities = apply_boolean_column_defaults(facilities, FACILITY_SCHEMA)
+
         # Defensive empty mapping frame so downstream joins are well-typed even
         # when the caller passes a malformed facility_mappings.
         if not has_required_columns(
@@ -752,15 +766,13 @@ class HierarchyResolver:
         # Uncommitted (unconditionally cancellable) facilities generate no synthetic
         # undrawn exposure: the bank can refuse to lend, so no commitment EAD/RWA is
         # held against the unused headroom. Loans/contingents already mapped to the
-        # facility are unaffected — they remain independent exposure rows. Missing
-        # `committed` column or null values default to True (committed), matching
-        # FACILITY_SCHEMA's default.
-        committed_expr = (
-            pl.col("committed").fill_null(True) if "committed" in facility_cols else pl.lit(True)
-        )
-        return facility_with_drawn.filter((pl.col("undrawn_amount") > 0) & committed_expr).select(
-            select_exprs
-        )
+        # facility are unaffected — they remain independent exposure rows. The
+        # ``committed`` column is loader-defaulted to True via
+        # ``apply_boolean_column_defaults`` (data/column_spec.py), so we can read
+        # it directly without a defensive fill_null.
+        return facility_with_drawn.filter(
+            (pl.col("undrawn_amount") > 0) & pl.col("committed")
+        ).select(select_exprs)
 
     def _empty_facility_undrawn_frame(self) -> pl.LazyFrame:
         """Empty LazyFrame matching the canonical facility-undrawn output schema.
@@ -1108,12 +1120,10 @@ class HierarchyResolver:
             ),
             # CRR Art. 166(8)(d): facility undrawn is a credit line by construction,
             # so default True. An explicit False override flips the row to the
-            # Art. 166(10) issued-item bucket (50% MR / 20% MLR).
-            (
-                pl.col("is_obs_commitment").fill_null(True)
-                if "is_obs_commitment" in facility_cols
-                else pl.lit(True).alias("is_obs_commitment")
-            ),
+            # Art. 166(10) issued-item bucket (50% MR / 20% MLR). The column is
+            # synthesised to True and null-filled by the entry-point normalisation,
+            # so we can read it directly here.
+            pl.col("is_obs_commitment"),
             (
                 pl.col("is_payroll_loan").fill_null(False)
                 if "is_payroll_loan" in facility_cols
@@ -1140,17 +1150,11 @@ class HierarchyResolver:
                 else pl.lit(None).cast(pl.Float64).alias("effective_maturity")
             ),
             pl.lit(False).alias("has_netting_agreement"),
-            # QRRE classification fields (CRR Art. 147(5), CRE30.55)
-            (
-                pl.col("is_revolving").fill_null(False)
-                if "is_revolving" in facility_cols
-                else pl.lit(False).alias("is_revolving")
-            ),
-            (
-                pl.col("is_qrre_transactor").fill_null(False)
-                if "is_qrre_transactor" in facility_cols
-                else pl.lit(False).alias("is_qrre_transactor")
-            ),
+            # QRRE classification fields (CRR Art. 147(5), CRE30.55).
+            # Both columns are synthesised to False and null-filled by the
+            # entry-point normalisation, so we can read them directly.
+            pl.col("is_revolving"),
+            pl.col("is_qrre_transactor"),
             (
                 pl.col("limit").alias("facility_limit")
                 if "limit" in facility_cols
@@ -1300,10 +1304,9 @@ class HierarchyResolver:
             sub_select.append(pl.col("limit").alias("_sub_limit"))
         else:
             sub_select.append(pl.lit(0.0).alias("_sub_limit"))
-        if "committed" in fac_cols:
-            sub_select.append(pl.col("committed").fill_null(True).alias("_sub_committed"))
-        else:
-            sub_select.append(pl.lit(True).alias("_sub_committed"))
+        # `committed` is synthesised+null-filled at the entry point of
+        # `_calculate_facility_undrawn`, so we can read it directly here.
+        sub_select.append(pl.col("committed").alias("_sub_committed"))
 
         sub_facilities = facilities.select(sub_select)
 

--- a/src/rwa_calc/engine/loader.py
+++ b/src/rwa_calc/engine/loader.py
@@ -30,33 +30,6 @@ from pathlib import Path
 
 import polars as pl
 
-UNSAFE_LOAD_ENV_VAR = "RWA_ALLOW_UNSAFE_LOAD"
-
-
-def _check_enforce_schemas_flag(enforce_schemas: bool, loader_name: str) -> None:
-    """Reject ``enforce_schemas=False`` unless the unsafe-load env var is set.
-
-    Skipping schema enforcement bypasses the regulatory column-default
-    fills (committed, is_obs_commitment, is_revolving, is_qrre_transactor)
-    applied by ``apply_boolean_column_defaults``. A null cell in any of
-    those columns silently changes RWA — wrong-direction for committed
-    flags. This guard fails fast in production; legitimate test paths
-    that need the unsafe behaviour set ``RWA_ALLOW_UNSAFE_LOAD=1``
-    explicitly via ``monkeypatch.setenv`` and document why.
-    """
-    if enforce_schemas:
-        return
-    if os.environ.get(UNSAFE_LOAD_ENV_VAR) == "1":
-        return
-    raise ValueError(
-        f"{loader_name}(enforce_schemas=False) bypasses regulatory column-default "
-        f"fills (committed, is_obs_commitment, is_revolving, is_qrre_transactor) "
-        f"and silently changes RWA. Set {UNSAFE_LOAD_ENV_VAR}=1 in the environment "
-        f"to authorise the unsafe path; this should only be used by tests that "
-        f"explicitly cover null-tolerant behaviour."
-    )
-
-
 from rwa_calc.config.data_sources import DataSourceRegistry
 from rwa_calc.contracts.bundles import RawDataBundle
 from rwa_calc.contracts.errors import CalculationError
@@ -86,6 +59,33 @@ from rwa_calc.data.schemas import (
 from rwa_calc.engine.utils import has_rows
 
 logger = logging.getLogger(__name__)
+
+UNSAFE_LOAD_ENV_VAR = "RWA_ALLOW_UNSAFE_LOAD"
+
+
+def _check_enforce_schemas_flag(enforce_schemas: bool, loader_name: str) -> None:
+    """Reject ``enforce_schemas=False`` unless the unsafe-load env var is set.
+
+    Skipping schema enforcement bypasses the regulatory column-default
+    fills (committed, is_obs_commitment, is_revolving, is_qrre_transactor)
+    applied by ``apply_boolean_column_defaults``. A null cell in any of
+    those columns silently changes RWA — wrong-direction for committed
+    flags. This guard fails fast in production; legitimate test paths
+    that need the unsafe behaviour set ``RWA_ALLOW_UNSAFE_LOAD=1``
+    explicitly via ``monkeypatch.setenv`` and document why.
+    """
+    if enforce_schemas:
+        return
+    if os.environ.get(UNSAFE_LOAD_ENV_VAR) == "1":
+        return
+    raise ValueError(
+        f"{loader_name}(enforce_schemas=False) bypasses regulatory column-default "
+        f"fills (committed, is_obs_commitment, is_revolving, is_qrre_transactor) "
+        f"and silently changes RWA. Set {UNSAFE_LOAD_ENV_VAR}=1 in the environment "
+        f"to authorise the unsafe path; this should only be used by tests that "
+        f"explicitly cover null-tolerant behaviour."
+    )
+
 
 type ScanFn = Callable[[Path], pl.LazyFrame]
 

--- a/src/rwa_calc/engine/loader.py
+++ b/src/rwa_calc/engine/loader.py
@@ -22,6 +22,7 @@ Usage:
 from __future__ import annotations
 
 import logging
+import os
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
@@ -29,10 +30,41 @@ from pathlib import Path
 
 import polars as pl
 
+UNSAFE_LOAD_ENV_VAR = "RWA_ALLOW_UNSAFE_LOAD"
+
+
+def _check_enforce_schemas_flag(enforce_schemas: bool, loader_name: str) -> None:
+    """Reject ``enforce_schemas=False`` unless the unsafe-load env var is set.
+
+    Skipping schema enforcement bypasses the regulatory column-default
+    fills (committed, is_obs_commitment, is_revolving, is_qrre_transactor)
+    applied by ``apply_boolean_column_defaults``. A null cell in any of
+    those columns silently changes RWA — wrong-direction for committed
+    flags. This guard fails fast in production; legitimate test paths
+    that need the unsafe behaviour set ``RWA_ALLOW_UNSAFE_LOAD=1``
+    explicitly via ``monkeypatch.setenv`` and document why.
+    """
+    if enforce_schemas:
+        return
+    if os.environ.get(UNSAFE_LOAD_ENV_VAR) == "1":
+        return
+    raise ValueError(
+        f"{loader_name}(enforce_schemas=False) bypasses regulatory column-default "
+        f"fills (committed, is_obs_commitment, is_revolving, is_qrre_transactor) "
+        f"and silently changes RWA. Set {UNSAFE_LOAD_ENV_VAR}=1 in the environment "
+        f"to authorise the unsafe path; this should only be used by tests that "
+        f"explicitly cover null-tolerant behaviour."
+    )
+
+
 from rwa_calc.config.data_sources import DataSourceRegistry
 from rwa_calc.contracts.bundles import RawDataBundle
 from rwa_calc.contracts.errors import CalculationError
-from rwa_calc.data.column_spec import ColumnSpec, ensure_columns
+from rwa_calc.data.column_spec import (
+    ColumnSpec,
+    apply_boolean_column_defaults,
+    ensure_columns,
+)
 from rwa_calc.data.schemas import (
     CIU_HOLDINGS_SCHEMA,
     COLLATERAL_SCHEMA,
@@ -96,10 +128,18 @@ def enforce_schema(
         if col_name in current_cols and current_schema[col_name] != _dtype(entry)
     ]
 
-    if not cast_exprs:
-        return lf
+    if cast_exprs:
+        lf = lf.with_columns(cast_exprs)
 
-    return lf.with_columns(cast_exprs)
+    # Apply Boolean-column null fills strictly AFTER cast — ordering is
+    # load-bearing. An inferred pl.Null column must be cast to pl.Boolean
+    # first so the subsequent fill_null can type-coerce its literal cleanly.
+    # Float/String defaults are intentionally excluded; see
+    # ``apply_boolean_column_defaults`` for rationale.
+    if is_column_spec_schema:
+        lf = apply_boolean_column_defaults(lf, schema)  # type: ignore[arg-type]
+
+    return lf
 
 
 def normalize_columns(lf: pl.LazyFrame) -> pl.LazyFrame:
@@ -324,6 +364,7 @@ class ParquetLoader:
         config: DataSourceConfig | None = None,
         enforce_schemas: bool = True,
     ) -> None:
+        _check_enforce_schemas_flag(enforce_schemas, "ParquetLoader")
         self.base_path = Path(base_path)
         self.config = config or DataSourceConfig.from_registry(extension="parquet")
         self.enforce_schemas = enforce_schemas
@@ -374,6 +415,7 @@ class CSVLoader:
         config: DataSourceConfig | None = None,
         enforce_schemas: bool = True,
     ) -> None:
+        _check_enforce_schemas_flag(enforce_schemas, "CSVLoader")
         self.base_path = Path(base_path)
         self.config = config or DataSourceConfig.from_registry(extension="csv")
         self.enforce_schemas = enforce_schemas

--- a/tests/contracts/test_boolean_defaults_only.py
+++ b/tests/contracts/test_boolean_defaults_only.py
@@ -1,0 +1,92 @@
+"""Contract tests for ``apply_boolean_column_defaults``.
+
+The helper is deliberately scoped to Boolean columns only. Float and String
+defaults are anti-conservative for EAD and provisions and require Risk
+sign-off to broaden. These tests pin the boundary so a future contributor
+who tries to widen the helper without renaming it must also update this
+contract — surfacing the change for explicit review.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+from rwa_calc.data.column_spec import ColumnSpec, apply_boolean_column_defaults
+
+
+class TestBooleanFillContract:
+    """Pin the post-fill invariant for Boolean columns."""
+
+    def test_fills_present_null_boolean(self) -> None:
+        """A present-but-null Boolean column with non-None default is filled."""
+        lf = pl.DataFrame({"committed": pl.Series([None, True, False], dtype=pl.Boolean)}).lazy()
+        schema = {"committed": ColumnSpec(pl.Boolean, default=True, required=False)}
+
+        out = apply_boolean_column_defaults(lf, schema).collect()
+
+        assert out["committed"].to_list() == [True, True, False]
+
+    def test_preserves_explicit_false_when_default_true(self) -> None:
+        """Explicit False is regulatory-load-bearing and must not be flipped."""
+        lf = pl.DataFrame({"committed": pl.Series([False, False], dtype=pl.Boolean)}).lazy()
+        schema = {"committed": ColumnSpec(pl.Boolean, default=True, required=False)}
+
+        out = apply_boolean_column_defaults(lf, schema).collect()
+
+        assert out["committed"].to_list() == [False, False]
+
+    def test_no_op_when_column_absent(self) -> None:
+        """A missing column is not added (use ``ensure_columns`` for that)."""
+        lf = pl.DataFrame({"other": [1, 2]}).lazy()
+        schema = {"committed": ColumnSpec(pl.Boolean, default=True, required=False)}
+
+        out = apply_boolean_column_defaults(lf, schema).collect()
+
+        assert "committed" not in out.columns
+        assert out["other"].to_list() == [1, 2]
+
+
+class TestNonBooleanBoundary:
+    """Pin that non-Boolean defaults are NOT filled by this helper."""
+
+    def test_float_default_not_filled(self) -> None:
+        """Float default is silently skipped (anti-conservative if filled)."""
+        lf = pl.DataFrame({"amount": pl.Series([None, 1.5], dtype=pl.Float64)}).lazy()
+        schema = {"amount": ColumnSpec(pl.Float64, default=0.0, required=False)}
+
+        out = apply_boolean_column_defaults(lf, schema).collect()
+
+        # First row stays None — must NOT become 0.0 silently.
+        assert out["amount"][0] is None
+        assert out["amount"][1] == 1.5
+
+    def test_string_default_not_filled(self) -> None:
+        """String default is silently skipped."""
+        lf = pl.DataFrame({"book_code": pl.Series([None, "X"], dtype=pl.String)}).lazy()
+        schema = {"book_code": ColumnSpec(pl.String, default="", required=False)}
+
+        out = apply_boolean_column_defaults(lf, schema).collect()
+
+        assert out["book_code"][0] is None
+        assert out["book_code"][1] == "X"
+
+    def test_mixed_schema_only_boolean_filled(self) -> None:
+        """A schema with mixed dtypes fills Boolean only; others left as null."""
+        lf = pl.DataFrame(
+            {
+                "committed": pl.Series([None], dtype=pl.Boolean),
+                "amount": pl.Series([None], dtype=pl.Float64),
+                "book_code": pl.Series([None], dtype=pl.String),
+            }
+        ).lazy()
+        schema = {
+            "committed": ColumnSpec(pl.Boolean, default=True, required=False),
+            "amount": ColumnSpec(pl.Float64, default=0.0, required=False),
+            "book_code": ColumnSpec(pl.String, default="", required=False),
+        }
+
+        out = apply_boolean_column_defaults(lf, schema).collect()
+
+        assert out["committed"][0] is True  # filled
+        assert out["amount"][0] is None  # NOT filled — Risk sign-off required
+        assert out["book_code"][0] is None  # NOT filled

--- a/tests/contracts/test_no_raw_over_on_nullable_keys.py
+++ b/tests/contracts/test_no_raw_over_on_nullable_keys.py
@@ -46,12 +46,12 @@ ALLOWLIST: frozenset[str] = frozenset(
 # justification comment naming the filter or invariant that makes the key
 # non-null at this site.
 LINE_ALLOWLIST: dict[str, frozenset[int]] = {
-    # _build_rating_inheritance_lazy: the L343-equivalent filter on
-    # `per_agency_latest` adds `counterparty_reference.is_not_null()` to the
-    # upstream filter, so these `.over("counterparty_reference")` calls
-    # operate on a frame with no null-keyed rows. See the comment block
-    # above the per_agency_latest filter in engine/hierarchy.py.
-    "src/rwa_calc/engine/hierarchy.py": frozenset({380, 381}),
+    # _build_rating_inheritance_lazy: the per_agency_latest filter adds
+    # `counterparty_reference.is_not_null()` to the upstream filter, so these
+    # `.over("counterparty_reference")` calls operate on a frame with no
+    # null-keyed rows. See the comment block above the per_agency_latest
+    # filter in engine/hierarchy.py.
+    "src/rwa_calc/engine/hierarchy.py": frozenset({384, 385}),
 }
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -239,6 +239,12 @@ def _rows_to_lazyframe(rows: list[dict[str, Any]], schema: dict[str, Any]) -> pl
     ``schema`` may be a plain ``{name: dtype}`` dict or a ``{name: ColumnSpec}``
     schema from ``rwa_calc.data.schemas`` — ColumnSpec entries are unwrapped to
     their dtype before casting.
+
+    For ColumnSpec schemas, routes through ``loader.enforce_schema`` after the
+    initial cast so present-but-null Boolean columns receive their schema
+    defaults via ``apply_boolean_column_defaults`` — closing the loader-bypass
+    surface that previously left integration test bundles inconsistent with
+    production-loaded ones.
     """
     dtype_schema = dtypes_of(schema) if _is_column_spec_schema(schema) else schema
     if not rows:
@@ -250,7 +256,15 @@ def _rows_to_lazyframe(rows: list[dict[str, Any]], schema: dict[str, Any]) -> pl
             cast_exprs.append(pl.col(col_name).cast(col_type, strict=False))
         else:
             cast_exprs.append(pl.lit(None).cast(col_type).alias(col_name))
-    return df.lazy().select(cast_exprs)
+    lf = df.lazy().select(cast_exprs)
+
+    if _is_column_spec_schema(schema):
+        # Defer the import to avoid a hard dependency on the engine package
+        # at conftest collection time.
+        from rwa_calc.engine.loader import enforce_schema
+
+        lf = enforce_schema(lf, schema, strict=False)
+    return lf
 
 
 def _is_column_spec_schema(schema: dict[str, Any]) -> bool:

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -863,8 +863,15 @@ class TestSchemaEnforcementInLoaders:
         assert result["interest"].dtype == pl.Float64
         assert result["interest"][0] == 50.5
 
-    def test_parquet_loader_can_disable_schema_enforcement(self, tmp_path: Path) -> None:
-        """ParquetLoader should preserve original types when enforce_schemas=False."""
+    def test_parquet_loader_can_disable_schema_enforcement(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """ParquetLoader should preserve original types when enforce_schemas=False.
+
+        Requires explicit ``RWA_ALLOW_UNSAFE_LOAD=1`` env var because
+        bypassing schema enforcement also bypasses regulatory column-default
+        fills.
+        """
         (tmp_path / "exposures").mkdir()
 
         # Create parquet with wrong types
@@ -876,6 +883,7 @@ class TestSchemaEnforcementInLoaders:
         )
         df.write_parquet(tmp_path / "exposures" / "loans.parquet")
 
+        monkeypatch.setenv("RWA_ALLOW_UNSAFE_LOAD", "1")
         loader = ParquetLoader(tmp_path, enforce_schemas=False)
         from rwa_calc.data.schemas import LOAN_SCHEMA
 
@@ -899,6 +907,54 @@ class TestSchemaEnforcementInLoaders:
 
         # book_code should be cast to String
         assert result["book_code"].dtype == pl.String
+
+
+class TestEnforceSchemasFalseEnvGate:
+    """Pin the env-gated guard against unsafe ``enforce_schemas=False``.
+
+    Bypassing schema enforcement also bypasses ``apply_boolean_column_defaults``,
+    so a parquet with null ``committed`` cells silently becomes RWA-impacting
+    data. The guard rejects ``enforce_schemas=False`` unless the caller has
+    explicitly opted in via ``RWA_ALLOW_UNSAFE_LOAD=1``.
+    """
+
+    def test_parquet_loader_rejects_unsafe_load_without_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without the env var, ParquetLoader(enforce_schemas=False) raises."""
+        monkeypatch.delenv("RWA_ALLOW_UNSAFE_LOAD", raising=False)
+        with pytest.raises(ValueError, match="RWA_ALLOW_UNSAFE_LOAD"):
+            ParquetLoader(tmp_path, enforce_schemas=False)
+
+    def test_csv_loader_rejects_unsafe_load_without_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without the env var, CSVLoader(enforce_schemas=False) raises."""
+        monkeypatch.delenv("RWA_ALLOW_UNSAFE_LOAD", raising=False)
+        with pytest.raises(ValueError, match="RWA_ALLOW_UNSAFE_LOAD"):
+            CSVLoader(tmp_path, enforce_schemas=False)
+
+    def test_parquet_loader_accepts_unsafe_load_with_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With ``RWA_ALLOW_UNSAFE_LOAD=1``, the unsafe path is permitted."""
+        monkeypatch.setenv("RWA_ALLOW_UNSAFE_LOAD", "1")
+        loader = ParquetLoader(tmp_path, enforce_schemas=False)
+        assert loader.enforce_schemas is False
+
+    def test_csv_loader_accepts_unsafe_load_with_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With ``RWA_ALLOW_UNSAFE_LOAD=1``, the unsafe path is permitted."""
+        monkeypatch.setenv("RWA_ALLOW_UNSAFE_LOAD", "1")
+        loader = CSVLoader(tmp_path, enforce_schemas=False)
+        assert loader.enforce_schemas is False
+
+    def test_default_enforce_schemas_true_unaffected(self, tmp_path: Path) -> None:
+        """The default path (``enforce_schemas=True``) is never gated."""
+        # No env var manipulation; should construct cleanly.
+        ParquetLoader(tmp_path)
+        CSVLoader(tmp_path)
 
 
 # =============================================================================
@@ -937,18 +993,21 @@ class TestEdgeCases:
             loader._load_parquet(loader.config.counterparties_file, COUNTERPARTY_SCHEMA)
 
     def test_corrupted_parquet_file_raises_error_at_collect_without_schema_enforcement(
-        self, tmp_path: Path
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Corrupted parquet file raises error at collect time when schema enforcement is off.
 
         With schema enforcement disabled, errors occur at collect time (lazy).
-        This is the original Polars behavior for lazy evaluation.
+        This is the original Polars behavior for lazy evaluation. Requires
+        explicit ``RWA_ALLOW_UNSAFE_LOAD=1`` env var since the unsafe path
+        bypasses regulatory column-default fills.
         """
         (tmp_path / "counterparty").mkdir()
 
         # Create a file that's not valid parquet
         (tmp_path / "counterparty" / "counterparties.parquet").write_text("not parquet data")
 
+        monkeypatch.setenv("RWA_ALLOW_UNSAFE_LOAD", "1")
         loader = ParquetLoader(tmp_path, enforce_schemas=False)
         # scan_parquet succeeds (lazy) when schema enforcement is off
         lf = loader._load_parquet("counterparty/counterparties.parquet")


### PR DESCRIPTION
The committed flag (and 3 sibling Boolean columns: is_obs_commitment,
is_revolving, is_qrre_transactor) was defended by scattered
`fill_null(default) if "X" in cols else pl.lit(default)` chains across
hierarchy.py. A naive refactor flipping the default would silently
zero CCF-driven RWA — regulatory misstatement.

Add `apply_boolean_column_defaults(lf, schema)` to data/column_spec.py:
fills nulls in present Boolean columns with their schema defaults,
silently skips non-Boolean entries (Float/String defaults are
anti-conservative for EAD/provisions and require Risk sign-off). The
Boolean-only boundary is pinned by
tests/contracts/test_boolean_defaults_only.py.

Wire into engine/loader.enforce_schema strictly after the cast pass:
ensure_columns -> cast -> apply_boolean_column_defaults. Order is
load-bearing: pre-cast against an inferred pl.Null column would fail to
type-coerce the literal cleanly.

Defensive entry-point normalisation in `_calculate_facility_undrawn`
(ensure_columns + apply_boolean_column_defaults against FACILITY_SCHEMA)
so unit-test callers that bypass the loader still get the same contract.
After this, the 4 named Booleans are guaranteed non-null at their read
sites; the defensive `if "X" in cols` chains at L759, L1111, L1143,
L1148, L1304 are stripped to bare `pl.col("X")` reads.

Env-gated guard against `enforce_schemas=False`: ParquetLoader and
CSVLoader now raise ValueError unless RWA_ALLOW_UNSAFE_LOAD=1 is set in
the environment. Bypassing schema enforcement also bypasses the column-
default fills, silently changing RWA. The two existing legitimate test
callers (test_loader.py L879, L952) opt in via monkeypatch.setenv. New
TestEnforceSchemasFalseEnvGate class pins the gate behaviour.

Integration conftest's `_rows_to_lazyframe` now routes through
`enforce_schema` for ColumnSpec schemas, so 15+ integration test bundles
get the same fill chain as production loads — closing the loader-bypass
surface that previously left them inconsistent.