### PR TITLE
refactor(loader): collapse _build_bundle duplication and pin Protocol conformance

### DIFF
--- a/src/rwa_calc/engine/loader.py
+++ b/src/rwa_calc/engine/loader.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import logging
 import os
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from functools import partial
 from pathlib import Path
 
@@ -33,6 +33,7 @@ import polars as pl
 from rwa_calc.config.data_sources import DataSourceRegistry
 from rwa_calc.contracts.bundles import RawDataBundle
 from rwa_calc.contracts.errors import CalculationError
+from rwa_calc.contracts.protocols import LoaderProtocol
 from rwa_calc.data.column_spec import (
     ColumnSpec,
     apply_boolean_column_defaults,
@@ -318,28 +319,7 @@ def _build_bundle(
         model_permissions=load_optional(config.model_permissions_file, MODEL_PERMISSIONS_SCHEMA),
     )
     errors = _run_bundle_validation(bundle)
-    if not errors:
-        return bundle
-    # Frozen dataclass — reconstruct with errors attached
-    return RawDataBundle(
-        facilities=bundle.facilities,
-        loans=bundle.loans,
-        counterparties=bundle.counterparties,
-        facility_mappings=bundle.facility_mappings,
-        lending_mappings=bundle.lending_mappings,
-        org_mappings=bundle.org_mappings,
-        contingents=bundle.contingents,
-        collateral=bundle.collateral,
-        guarantees=bundle.guarantees,
-        provisions=bundle.provisions,
-        ratings=bundle.ratings,
-        specialised_lending=bundle.specialised_lending,
-        equity_exposures=bundle.equity_exposures,
-        ciu_holdings=bundle.ciu_holdings,
-        fx_rates=bundle.fx_rates,
-        model_permissions=bundle.model_permissions,
-        errors=errors,
-    )
+    return replace(bundle, errors=errors) if errors else bundle
 
 
 # ---------------------------------------------------------------------------
@@ -347,7 +327,7 @@ def _build_bundle(
 # ---------------------------------------------------------------------------
 
 
-class ParquetLoader:
+class ParquetLoader(LoaderProtocol):
     """
     Load data from Parquet files.
 
@@ -399,7 +379,7 @@ class ParquetLoader:
         return _build_bundle(load, load_opt, self.config)
 
 
-class CSVLoader:
+class CSVLoader(LoaderProtocol):
     """
     Load data from CSV files.
 


### PR DESCRIPTION
## Summary

- Replace the 19-line frozen-dataclass reconstruction in `_build_bundle` (`src/rwa_calc/engine/loader.py`) with `dataclasses.replace(bundle, errors=errors) if errors else bundle`. Matches the existing pattern at `engine/pipeline.py:318` for `AggregatedResultBundle`. New `RawDataBundle` fields no longer require edits inside this function.
- Make `ParquetLoader` and `CSVLoader` inherit from `LoaderProtocol` so `ty` verifies structural conformance at the class definitions themselves, rather than only transitively at the four call sites in `engine/pipeline.py` / `api/service.py`. If `load()` is ever renamed or its signature drifts, the error now fires on `loader.py` directly instead of on whichever consumer is touched next.

No behaviour change. The runtime `isinstance(..., LoaderProtocol)` check in `tests/contracts/test_protocols.py` continues to use `StubLoader`; the new inheritance just hardens the static check on the real loaders.

## Test plan

- [x] `uv run ruff check src/rwa_calc/engine/loader.py` — clean
- [x] `uv run ty check src/rwa_calc/engine/loader.py` — clean
- [x] `uv run python scripts/arch_check.py` — clean
- [x] `uv run pytest tests/contracts/test_protocols.py tests/unit/test_loader.py tests/integration/test_loader_to_hierarchy.py` — 98 passed
