### PR TITLE
refactor(data): move entity-class mapping dicts to data/tables/

### DIFF
--- a/src/rwa_calc/data/tables/__init__.py
+++ b/src/rwa_calc/data/tables/__init__.py
@@ -14,6 +14,7 @@ Modules:
     firb_lgd: F-IRB supervisory LGD values (CRR Art. 161 and PRA PS1/26 Art. 161)
     crr_equity_rw: CRR equity risk weights (Art. 133 SA, Art. 155 IRB Simple)
     b31_equity_rw: Basel 3.1 equity risk weights (PRA PS1/26 Art. 133)
+    entity_class_mapping: entity_type → SA/IRB exposure class lookup
 """
 
 from .b31_equity_rw import (
@@ -69,6 +70,11 @@ from .crr_slotting import (
     SLOTTING_RISK_WEIGHTS_SHORT,
     calculate_slotting_rwa,
     lookup_slotting_rw,
+)
+from .entity_class_mapping import (
+    ENTITY_TYPE_TO_IRB_CLASS,
+    ENTITY_TYPE_TO_SA_CLASS,
+    ENTITY_TYPES_BY_SA_CLASS,
 )
 from .eu_sovereign import (
     EU_COUNTRY_DOMESTIC_CURRENCY,
@@ -172,6 +178,10 @@ __all__ = [
     "EU_MEMBER_STATES",
     "EU_COUNTRY_DOMESTIC_CURRENCY",
     "build_eu_domestic_currency_expr",
+    # Entity-type to exposure-class mappings
+    "ENTITY_TYPE_TO_SA_CLASS",
+    "ENTITY_TYPE_TO_IRB_CLASS",
+    "ENTITY_TYPES_BY_SA_CLASS",
     # Equity risk weights — CRR
     "SA_EQUITY_RISK_WEIGHTS",
     "IRB_SIMPLE_EQUITY_RISK_WEIGHTS",

--- a/src/rwa_calc/data/tables/entity_class_mapping.py
+++ b/src/rwa_calc/data/tables/entity_class_mapping.py
@@ -1,0 +1,110 @@
+"""
+Entity-type to exposure-class mappings.
+
+Pipeline position:
+    Consumed by ``engine.classifier`` (entity_type → SA/IRB class via
+    ``replace_strict``), ``engine.hierarchy`` (SA RW preview), and the
+    SA / IRB / CRM guarantee branches that need to derive a guarantor's
+    SA exposure class from its entity_type.
+
+Key responsibilities:
+- Map every supported ``entity_type`` input string to its CRR / Basel 3.1
+  Standardised Approach exposure class (CRR Art. 112).
+- Map every supported ``entity_type`` to its IRB exposure class — different
+  from the SA class for RGLA / PSE counterparties (CRR Art. 147(3)/(4)(b)).
+- Provide the inverse SA-class → tuple-of-entity-types mapping used by the
+  hierarchy resolver's SA RW preview.
+
+References:
+- CRR Art. 112 Table A2 — SA exposure classes
+- CRR Art. 128 — high-risk items (SA-only, 150% unconditional)
+- CRR Art. 134 — Other Items (SA-only, no IRB class)
+- CRR Art. 147(3) — RGLA/PSE sovereign-equivalence under IRB
+- CRR Art. 147(4)(b) — RGLA/PSE institution treatment under IRB
+"""
+
+from __future__ import annotations
+
+from rwa_calc.domain.enums import ExposureClass
+
+# entity_type → SA exposure class (for risk weight lookup)
+ENTITY_TYPE_TO_SA_CLASS: dict[str, str] = {
+    "sovereign": ExposureClass.CENTRAL_GOVT_CENTRAL_BANK.value,
+    "central_bank": ExposureClass.CENTRAL_GOVT_CENTRAL_BANK.value,
+    "rgla_sovereign": ExposureClass.RGLA.value,
+    "rgla_institution": ExposureClass.RGLA.value,
+    "pse_sovereign": ExposureClass.PSE.value,
+    "pse_institution": ExposureClass.PSE.value,
+    "mdb": ExposureClass.MDB.value,
+    "mdb_named": ExposureClass.MDB.value,
+    "international_org": ExposureClass.MDB.value,
+    "institution": ExposureClass.INSTITUTION.value,
+    "bank": ExposureClass.INSTITUTION.value,
+    "ccp": ExposureClass.INSTITUTION.value,
+    "financial_institution": ExposureClass.INSTITUTION.value,
+    "corporate": ExposureClass.CORPORATE.value,
+    "company": ExposureClass.CORPORATE.value,
+    "individual": ExposureClass.RETAIL_OTHER.value,
+    "retail": ExposureClass.RETAIL_OTHER.value,
+    # Art. 112(1)(g): SL is a corporate sub-type under SA, not a separate class.
+    # The sl_type column (from the specialised_lending join) drives SL-specific
+    # risk weight lookup; the exposure_class_sa column is CORPORATE.
+    "specialised_lending": ExposureClass.CORPORATE.value,
+    "equity": ExposureClass.EQUITY.value,
+    "covered_bond": ExposureClass.COVERED_BOND.value,
+    "other_cash": ExposureClass.OTHER.value,
+    "other_gold": ExposureClass.OTHER.value,
+    "other_items_in_collection": ExposureClass.OTHER.value,
+    "other_tangible": ExposureClass.OTHER.value,
+    "other_residual_lease": ExposureClass.OTHER.value,
+    # High-risk items (CRR Art. 128): 150% unconditional
+    "high_risk": ExposureClass.HIGH_RISK.value,
+    "high_risk_venture_capital": ExposureClass.HIGH_RISK.value,
+    "high_risk_private_equity": ExposureClass.HIGH_RISK.value,
+    "high_risk_speculative_re": ExposureClass.HIGH_RISK.value,
+}
+
+# entity_type → IRB exposure class (for IRB formula selection)
+# Other Items (Art. 134) are SA-only — no IRB class exists for these.
+# High-risk items (Art. 128) are SA-only — they map to HIGH_RISK for SA treatment.
+ENTITY_TYPE_TO_IRB_CLASS: dict[str, str] = {
+    "sovereign": ExposureClass.CENTRAL_GOVT_CENTRAL_BANK.value,
+    "central_bank": ExposureClass.CENTRAL_GOVT_CENTRAL_BANK.value,
+    "rgla_sovereign": ExposureClass.CENTRAL_GOVT_CENTRAL_BANK.value,
+    "rgla_institution": ExposureClass.INSTITUTION.value,
+    "pse_sovereign": ExposureClass.CENTRAL_GOVT_CENTRAL_BANK.value,
+    "pse_institution": ExposureClass.INSTITUTION.value,
+    "mdb": ExposureClass.CENTRAL_GOVT_CENTRAL_BANK.value,
+    "mdb_named": ExposureClass.CENTRAL_GOVT_CENTRAL_BANK.value,
+    "international_org": ExposureClass.CENTRAL_GOVT_CENTRAL_BANK.value,
+    "institution": ExposureClass.INSTITUTION.value,
+    "bank": ExposureClass.INSTITUTION.value,
+    "ccp": ExposureClass.INSTITUTION.value,
+    "financial_institution": ExposureClass.INSTITUTION.value,
+    "corporate": ExposureClass.CORPORATE.value,
+    "company": ExposureClass.CORPORATE.value,
+    "individual": ExposureClass.RETAIL_OTHER.value,
+    "retail": ExposureClass.RETAIL_OTHER.value,
+    "specialised_lending": ExposureClass.SPECIALISED_LENDING.value,
+    "equity": ExposureClass.EQUITY.value,
+    "covered_bond": ExposureClass.COVERED_BOND.value,
+    "other_cash": ExposureClass.OTHER.value,
+    "other_gold": ExposureClass.OTHER.value,
+    "other_items_in_collection": ExposureClass.OTHER.value,
+    "other_tangible": ExposureClass.OTHER.value,
+    "other_residual_lease": ExposureClass.OTHER.value,
+    # High-risk items (Art. 128) are SA-only — they map to OTHER for IRB
+    # (no separate IRB treatment; HIGH_RISK is an SA exposure class).
+    "high_risk": ExposureClass.HIGH_RISK.value,
+    "high_risk_venture_capital": ExposureClass.HIGH_RISK.value,
+    "high_risk_private_equity": ExposureClass.HIGH_RISK.value,
+    "high_risk_speculative_re": ExposureClass.HIGH_RISK.value,
+}
+
+# Inverse of ENTITY_TYPE_TO_SA_CLASS: SA exposure class → tuple of entity_types.
+# Derived at module load so any addition to ENTITY_TYPE_TO_SA_CLASS automatically
+# flows through to consumers (e.g. the SA RW preview in engine/hierarchy.py).
+ENTITY_TYPES_BY_SA_CLASS: dict[str, tuple[str, ...]] = {
+    sa_class: tuple(et for et, c in ENTITY_TYPE_TO_SA_CLASS.items() if c == sa_class)
+    for sa_class in dict.fromkeys(ENTITY_TYPE_TO_SA_CLASS.values())
+}

--- a/src/rwa_calc/engine/classifier.py
+++ b/src/rwa_calc/engine/classifier.py
@@ -57,6 +57,10 @@ from rwa_calc.data.schemas import (
     B31_SOVEREIGN_LIKE_ENTITY_TYPES,
     RGLA_PSE_ENTITY_TYPES,
 )
+from rwa_calc.data.tables.entity_class_mapping import (
+    ENTITY_TYPE_TO_IRB_CLASS,
+    ENTITY_TYPE_TO_SA_CLASS,
+)
 from rwa_calc.data.tables.eu_sovereign import (
     build_eu_domestic_currency_expr,
     denomination_currency_expr,
@@ -74,91 +78,13 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-# =============================================================================
-# ENTITY TYPE TO EXPOSURE CLASS MAPPINGS
-# =============================================================================
-
-# entity_type → SA exposure class (for risk weight lookup)
-ENTITY_TYPE_TO_SA_CLASS: dict[str, str] = {
-    "sovereign": ExposureClass.CENTRAL_GOVT_CENTRAL_BANK.value,
-    "central_bank": ExposureClass.CENTRAL_GOVT_CENTRAL_BANK.value,
-    "rgla_sovereign": ExposureClass.RGLA.value,
-    "rgla_institution": ExposureClass.RGLA.value,
-    "pse_sovereign": ExposureClass.PSE.value,
-    "pse_institution": ExposureClass.PSE.value,
-    "mdb": ExposureClass.MDB.value,
-    "mdb_named": ExposureClass.MDB.value,
-    "international_org": ExposureClass.MDB.value,
-    "institution": ExposureClass.INSTITUTION.value,
-    "bank": ExposureClass.INSTITUTION.value,
-    "ccp": ExposureClass.INSTITUTION.value,
-    "financial_institution": ExposureClass.INSTITUTION.value,
-    "corporate": ExposureClass.CORPORATE.value,
-    "company": ExposureClass.CORPORATE.value,
-    "individual": ExposureClass.RETAIL_OTHER.value,
-    "retail": ExposureClass.RETAIL_OTHER.value,
-    # Art. 112(1)(g): SL is a corporate sub-type under SA, not a separate class.
-    # The sl_type column (from the specialised_lending join) drives SL-specific
-    # risk weight lookup; the exposure_class_sa column is CORPORATE.
-    "specialised_lending": ExposureClass.CORPORATE.value,
-    "equity": ExposureClass.EQUITY.value,
-    "covered_bond": ExposureClass.COVERED_BOND.value,
-    "other_cash": ExposureClass.OTHER.value,
-    "other_gold": ExposureClass.OTHER.value,
-    "other_items_in_collection": ExposureClass.OTHER.value,
-    "other_tangible": ExposureClass.OTHER.value,
-    "other_residual_lease": ExposureClass.OTHER.value,
-    # High-risk items (CRR Art. 128): 150% unconditional
-    "high_risk": ExposureClass.HIGH_RISK.value,
-    "high_risk_venture_capital": ExposureClass.HIGH_RISK.value,
-    "high_risk_private_equity": ExposureClass.HIGH_RISK.value,
-    "high_risk_speculative_re": ExposureClass.HIGH_RISK.value,
-}
-
-# entity_type → IRB exposure class (for IRB formula selection)
-# Other Items (Art. 134) are SA-only — no IRB class exists for these.
-# High-risk items (Art. 128) are SA-only — they map to HIGH_RISK for SA treatment.
-ENTITY_TYPE_TO_IRB_CLASS: dict[str, str] = {
-    "sovereign": ExposureClass.CENTRAL_GOVT_CENTRAL_BANK.value,
-    "central_bank": ExposureClass.CENTRAL_GOVT_CENTRAL_BANK.value,
-    "rgla_sovereign": ExposureClass.CENTRAL_GOVT_CENTRAL_BANK.value,
-    "rgla_institution": ExposureClass.INSTITUTION.value,
-    "pse_sovereign": ExposureClass.CENTRAL_GOVT_CENTRAL_BANK.value,
-    "pse_institution": ExposureClass.INSTITUTION.value,
-    "mdb": ExposureClass.CENTRAL_GOVT_CENTRAL_BANK.value,
-    "mdb_named": ExposureClass.CENTRAL_GOVT_CENTRAL_BANK.value,
-    "international_org": ExposureClass.CENTRAL_GOVT_CENTRAL_BANK.value,
-    "institution": ExposureClass.INSTITUTION.value,
-    "bank": ExposureClass.INSTITUTION.value,
-    "ccp": ExposureClass.INSTITUTION.value,
-    "financial_institution": ExposureClass.INSTITUTION.value,
-    "corporate": ExposureClass.CORPORATE.value,
-    "company": ExposureClass.CORPORATE.value,
-    "individual": ExposureClass.RETAIL_OTHER.value,
-    "retail": ExposureClass.RETAIL_OTHER.value,
-    "specialised_lending": ExposureClass.SPECIALISED_LENDING.value,
-    "equity": ExposureClass.EQUITY.value,
-    "covered_bond": ExposureClass.COVERED_BOND.value,
-    "other_cash": ExposureClass.OTHER.value,
-    "other_gold": ExposureClass.OTHER.value,
-    "other_items_in_collection": ExposureClass.OTHER.value,
-    "other_tangible": ExposureClass.OTHER.value,
-    "other_residual_lease": ExposureClass.OTHER.value,
-    # High-risk items (Art. 128) are SA-only — they map to OTHER for IRB
-    # (no separate IRB treatment; HIGH_RISK is an SA exposure class).
-    "high_risk": ExposureClass.HIGH_RISK.value,
-    "high_risk_venture_capital": ExposureClass.HIGH_RISK.value,
-    "high_risk_private_equity": ExposureClass.HIGH_RISK.value,
-    "high_risk_speculative_re": ExposureClass.HIGH_RISK.value,
-}
-
-# Inverse of ENTITY_TYPE_TO_SA_CLASS: SA exposure class → tuple of entity_types.
-# Derived at module load so any addition to ENTITY_TYPE_TO_SA_CLASS automatically
-# flows through to consumers (e.g. the SA RW preview in engine/hierarchy.py).
-ENTITY_TYPES_BY_SA_CLASS: dict[str, tuple[str, ...]] = {
-    sa_class: tuple(et for et, c in ENTITY_TYPE_TO_SA_CLASS.items() if c == sa_class)
-    for sa_class in dict.fromkeys(ENTITY_TYPE_TO_SA_CLASS.values())
-}
+# Entity-type → exposure-class mappings live in ``data/tables/entity_class_mapping``.
+# Re-exported here because ``rwa_calc.engine.classifier`` is the long-standing
+# public-import location for ``ENTITY_TYPE_TO_SA_CLASS`` and
+# ``ENTITY_TYPE_TO_IRB_CLASS``; downstream tests, notebooks, and the engine's
+# own SA / IRB / CRM guarantee branches import them via this module.
+# ``ENTITY_TYPES_BY_SA_CLASS`` is consumed only by ``engine/hierarchy.py``,
+# which imports it directly from ``data.tables.entity_class_mapping``.
 
 # SL types restricted to slotting-only under B31 Art. 147A(1)(c)
 _B31_SLOTTING_ONLY_SL_TYPES = {

--- a/src/rwa_calc/engine/crm/guarantees.py
+++ b/src/rwa_calc/engine/crm/guarantees.py
@@ -23,6 +23,7 @@ import polars as pl
 
 from rwa_calc.data.column_spec import ColumnSpec, ensure_columns
 from rwa_calc.data.schemas import DIRECT_BENEFICIARY_TYPES
+from rwa_calc.data.tables.entity_class_mapping import ENTITY_TYPE_TO_SA_CLASS
 from rwa_calc.data.tables.eu_sovereign import (
     build_domestic_cgcb_guarantor_expr,
     denomination_currency_expr,
@@ -35,7 +36,6 @@ from rwa_calc.engine.ccf import (
     on_balance_ead,
     sa_ccf_expression,
 )
-from rwa_calc.engine.classifier import ENTITY_TYPE_TO_SA_CLASS
 
 if TYPE_CHECKING:
     from rwa_calc.contracts.config import CalculationConfig

--- a/src/rwa_calc/engine/hierarchy.py
+++ b/src/rwa_calc/engine/hierarchy.py
@@ -50,8 +50,8 @@ from rwa_calc.data.tables.crr_risk_weights import (
     MDB_RISK_WEIGHTS_TABLE_2B,
     RETAIL_RISK_WEIGHT,
 )
+from rwa_calc.data.tables.entity_class_mapping import ENTITY_TYPES_BY_SA_CLASS
 from rwa_calc.domain.enums import CQS, ExposureClass
-from rwa_calc.engine.classifier import ENTITY_TYPES_BY_SA_CLASS
 from rwa_calc.engine.fx_converter import FXConverter
 from rwa_calc.engine.utils import has_required_columns, partition_by_nullable
 

--- a/src/rwa_calc/engine/irb/guarantee.py
+++ b/src/rwa_calc/engine/irb/guarantee.py
@@ -188,7 +188,7 @@ def _compute_guarantor_rw_sa(
     # Ensure guarantor_exposure_class is available (set by CRM processor;
     # fallback for unit tests that construct LazyFrames directly)
     if "guarantor_exposure_class" not in cols:
-        from rwa_calc.engine.classifier import ENTITY_TYPE_TO_SA_CLASS
+        from rwa_calc.data.tables.entity_class_mapping import ENTITY_TYPE_TO_SA_CLASS
 
         lf = lf.with_columns(
             pl.col("guarantor_entity_type")

--- a/src/rwa_calc/engine/sa/namespace.py
+++ b/src/rwa_calc/engine/sa/namespace.py
@@ -575,7 +575,7 @@ def _ensure_guarantee_substitution_columns(exposures: pl.LazyFrame) -> pl.LazyFr
     to_add: list[pl.Expr] = []
 
     if "guarantor_exposure_class" not in schema_names:
-        from rwa_calc.engine.classifier import ENTITY_TYPE_TO_SA_CLASS
+        from rwa_calc.data.tables.entity_class_mapping import ENTITY_TYPE_TO_SA_CLASS
 
         to_add.append(
             pl.col("guarantor_entity_type")

--- a/tests/unit/test_covered_bonds.py
+++ b/tests/unit/test_covered_bonds.py
@@ -39,11 +39,11 @@ from rwa_calc.data.tables.crr_risk_weights import (
     get_all_risk_weight_tables,
     get_combined_cqs_risk_weights,
 )
-from rwa_calc.domain.enums import CQS, ApproachType, ExposureClass
-from rwa_calc.engine.classifier import (
+from rwa_calc.data.tables.entity_class_mapping import (
     ENTITY_TYPE_TO_IRB_CLASS,
     ENTITY_TYPE_TO_SA_CLASS,
 )
+from rwa_calc.domain.enums import CQS, ApproachType, ExposureClass
 from rwa_calc.engine.sa.calculator import SACalculator
 from rwa_calc.reporting.corep.templates import SA_EXPOSURE_CLASS_ROWS
 

--- a/tests/unit/test_equity_routing.py
+++ b/tests/unit/test_equity_routing.py
@@ -290,7 +290,7 @@ class TestClassifierEquityApproach:
 
     def test_equity_class_gets_equity_approach(self) -> None:
         """Equity-class rows from entity_type mapping get EQUITY approach."""
-        from rwa_calc.engine.classifier import ENTITY_TYPE_TO_SA_CLASS
+        from rwa_calc.data.tables.entity_class_mapping import ENTITY_TYPE_TO_SA_CLASS
 
         assert ENTITY_TYPE_TO_SA_CLASS["equity"] == ExposureClass.EQUITY.value
 

--- a/tests/unit/test_high_risk_items.py
+++ b/tests/unit/test_high_risk_items.py
@@ -40,11 +40,11 @@ from tests.fixtures.single_exposure import calculate_single_sa_exposure
 from rwa_calc.contracts.config import CalculationConfig
 from rwa_calc.data.tables.b31_risk_weights import B31_HIGH_RISK_RW
 from rwa_calc.data.tables.crr_risk_weights import HIGH_RISK_RW
-from rwa_calc.domain.enums import ExposureClass
-from rwa_calc.engine.classifier import (
+from rwa_calc.data.tables.entity_class_mapping import (
     ENTITY_TYPE_TO_IRB_CLASS,
     ENTITY_TYPE_TO_SA_CLASS,
 )
+from rwa_calc.domain.enums import ExposureClass
 from rwa_calc.engine.sa import SACalculator
 
 # =============================================================================

--- a/tests/unit/test_sa_sl_classification.py
+++ b/tests/unit/test_sa_sl_classification.py
@@ -30,16 +30,16 @@ from rwa_calc.contracts.bundles import (
     ResolvedHierarchyBundle,
 )
 from rwa_calc.contracts.config import CalculationConfig
+from rwa_calc.data.tables.entity_class_mapping import (
+    ENTITY_TYPE_TO_IRB_CLASS,
+    ENTITY_TYPE_TO_SA_CLASS,
+)
 from rwa_calc.domain.enums import (
     ApproachType,
     ExposureClass,
     PermissionMode,
 )
-from rwa_calc.engine.classifier import (
-    ENTITY_TYPE_TO_IRB_CLASS,
-    ENTITY_TYPE_TO_SA_CLASS,
-    ExposureClassifier,
-)
+from rwa_calc.engine.classifier import ExposureClassifier
 from rwa_calc.engine.sa.calculator import SACalculator
 from rwa_calc.reporting.corep.generator import COREPGenerator
 


### PR DESCRIPTION
## Summary

Relocates the three entity-type → exposure-class lookup constants (~75 lines) from ``src/rwa_calc/engine/classifier.py`` to a new ``src/rwa_calc/data/tables/entity_class_mapping.py`` module. The dicts encode regulatory taxonomy (CRR Art. 112, 147(3), 147(4)(b)) — per ``CLAUDE.md`` they belong in ``data/tables/``, not ``engine/``. ``arch_check.py``'s heuristic missed them because their RHS values are ``ExposureClass.X.value`` (``ast.Attribute``), not raw string literals.

- New module: ``src/rwa_calc/data/tables/entity_class_mapping.py`` holding ``ENTITY_TYPE_TO_SA_CLASS``, ``ENTITY_TYPE_TO_IRB_CLASS``, ``ENTITY_TYPES_BY_SA_CLASS``.
- ``engine/classifier.py`` imports the two consumed by the classifier at module level — the long-standing public path ``from rwa_calc.engine.classifier import ENTITY_TYPE_TO_SA_CLASS`` keeps working unchanged via Python's normal name resolution (no ``__all__`` change needed).
- 4 engine import sites re-targeted: ``hierarchy.py``, ``sa/namespace.py``, ``irb/guarantee.py``, ``crm/guarantees.py``.
- 4 test import sites re-targeted: ``test_high_risk_items.py``, ``test_covered_bonds.py``, ``test_sa_sl_classification.py``, ``test_equity_routing.py``.
- Re-exported from ``data/tables/__init__.py`` for the tidy ``from rwa_calc.data.tables import ENTITY_TYPE_TO_SA_CLASS`` pattern that other ``data/tables/*`` modules already enjoy.

## Stacks on #309

Branched off ``refactor/classifier-readability`` (the readability refactor in PR #309). The diff for this PR is purely the dict relocation. Independently correct on master too — the dicts exist there as well; merge order doesn't affect correctness.

## Test plan

- [x] ``uv run python scripts/arch_check.py`` — green
- [x] ``uv run ruff check`` (changed files) — green
- [x] ``uv run ty check`` (changed files) — green
- [x] Public-import spot-check — both ``engine.classifier`` and ``data.tables.entity_class_mapping`` resolve to the same objects (verified via ``is`` assertion)
- [x] Full ``uv run pytest tests/`` — 5778 passed, 2 skipped (3:27s)
