### PR TITLE
chore(sonar): clear ~200 findings across UI, workbooks,   pillar3, and tests

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,8 +6,19 @@ sonar.organization=openafterhours
 #   e2: S125 (commented-out code) — explanatory hand-calc comments in tests
 #        (e.g. "# 3500 - 45 = 3455") trigger false positives; the comments
 #        are required documentation of the expected value.
-sonar.issue.ignore.multicriteria=e1,e2
+#   e3: S2259 (null dereference) — test setup guarantees non-None for dict
+#        accesses (e.g. `result["ead_final"]` after `if result is None:
+#        pytest.skip(...)`). Sonar's data-flow analysis does not track
+#        narrowing through pytest.skip / fixture-loader helpers.
+#   e4: S1244 (float equality) — test assertions on regulatory parameters
+#        (`assert df["risk_weight"][0] == 0.50`) require exact equality to
+#        the documented input value, not an approx-equal comparison.
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4
 sonar.issue.ignore.multicriteria.e1.ruleKey=python:S101
 sonar.issue.ignore.multicriteria.e1.resourceKey=tests/**/*.py
 sonar.issue.ignore.multicriteria.e2.ruleKey=python:S125
 sonar.issue.ignore.multicriteria.e2.resourceKey=tests/**/*.py
+sonar.issue.ignore.multicriteria.e3.ruleKey=pythonbugs:S2259
+sonar.issue.ignore.multicriteria.e3.resourceKey=tests/**/*.py
+sonar.issue.ignore.multicriteria.e4.ruleKey=python:S1244
+sonar.issue.ignore.multicriteria.e4.resourceKey=tests/**/*.py

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,13 @@
 sonar.projectKey=OpenAfterHours_rwa_calculator
 sonar.organization=openafterhours
-sonar.issue.ignore.multicriteria=e1
+
+# Issue-rule suppressions
+#   e1: S101 (PascalCase class names) — test classes use TestB31M01_, etc.
+#   e2: S125 (commented-out code) — explanatory hand-calc comments in tests
+#        (e.g. "# 3500 - 45 = 3455") trigger false positives; the comments
+#        are required documentation of the expected value.
+sonar.issue.ignore.multicriteria=e1,e2
 sonar.issue.ignore.multicriteria.e1.ruleKey=python:S101
 sonar.issue.ignore.multicriteria.e1.resourceKey=tests/**/*.py
+sonar.issue.ignore.multicriteria.e2.ruleKey=python:S125
+sonar.issue.ignore.multicriteria.e2.resourceKey=tests/**/*.py

--- a/src/rwa_calc/reporting/pillar3/templates.py
+++ b/src/rwa_calc/reporting/pillar3/templates.py
@@ -55,6 +55,35 @@ class P3Row:
 
 
 # ---------------------------------------------------------------------------
+# Shared label / group constants (DRY — referenced by multiple templates)
+# ---------------------------------------------------------------------------
+
+# --- Exposure-class display labels ---
+_LBL_CENTRAL_GOVT = "Central governments or central banks"
+_LBL_RETAIL_RE_MORTGAGE = "Retail — Secured by immovable property"
+_LBL_RETAIL_QRRE = "Retail — Qualifying revolving"
+_LBL_RETAIL_OTHER = "Retail — Other"
+_LBL_CORP_SPECIALISED_LENDING = "Corporates — Specialised lending"
+_LBL_ROW_CORPORATES_INDENTED = "  Corporates"
+
+# --- Common row labels ---
+_LBL_CREDIT_RISK_EX_CCR = "Credit risk (excluding CCR)"
+
+# --- Common column labels ---
+_LBL_COL_RWEA_DENSITY = "RWEA density"
+_LBL_COL_PD_RANGE = "PD range"
+_LBL_COL_ONBS_EXPOSURES = "On-BS exposures"
+_LBL_COL_EXP_VALUE_POST_CCF_CRM = "Exposure value post CCF and CRM"
+_LBL_COL_EXPECTED_LOSS = "Expected loss amount"
+_LBL_COL_EW_AVG_PD_POST_FLOOR = "Exposure-weighted average PD (%) — post input floor"
+
+# --- Common group labels ---
+_GRP_RISK_WEIGHT = "Risk weight"
+_GRP_EXPOSURE_BREAKDOWN = "Exposure breakdown"
+_GRP_FUNDED_CP = "Funded credit protection"
+
+
+# ---------------------------------------------------------------------------
 # Letter-ref helper (used for CR5 risk-weight bucket columns)
 # ---------------------------------------------------------------------------
 
@@ -71,7 +100,7 @@ def _letter_ref(i: int) -> str:
 # ---------------------------------------------------------------------------
 
 SA_DISCLOSURE_CLASSES: list[tuple[str, str, tuple[str, ...]]] = [
-    ("1", "Central governments or central banks", ("central_govt_central_bank",)),
+    ("1", _LBL_CENTRAL_GOVT, ("central_govt_central_bank",)),
     ("2", "Regional governments or local authorities", ("rgla",)),
     ("3", "Public sector entities", ("pse",)),
     ("4", "Multilateral development banks", ("mdb",)),
@@ -91,14 +120,14 @@ SA_DISCLOSURE_CLASSES: list[tuple[str, str, tuple[str, ...]]] = [
 
 # IRB exposure class display names (used by CR6, CR6-A, CR7-A)
 IRB_EXPOSURE_CLASSES: dict[str, str] = {
-    "central_govt_central_bank": "Central governments or central banks",
+    "central_govt_central_bank": _LBL_CENTRAL_GOVT,
     "institution": "Institutions",
     "corporate": "Corporates",
     "corporate_sme": "Corporates — SME",
     "specialised_lending": "Specialised lending",
-    "retail_mortgage": "Retail — Secured by immovable property",
-    "retail_qrre": "Retail — Qualifying revolving",
-    "retail_other": "Retail — Other",
+    "retail_mortgage": _LBL_RETAIL_RE_MORTGAGE,
+    "retail_qrre": _LBL_RETAIL_QRRE,
+    "retail_other": _LBL_RETAIL_OTHER,
 }
 
 # ---------------------------------------------------------------------------
@@ -112,7 +141,7 @@ OV1_COLUMNS: list[P3Column] = [
 ]
 
 CRR_OV1_ROWS: list[P3Row] = [
-    P3Row("1", "Credit risk (excluding CCR)"),
+    P3Row("1", _LBL_CREDIT_RISK_EX_CCR),
     P3Row("2", "Of which: standardised approach"),
     P3Row("3", "Of which: foundation IRB approach"),
     P3Row("4", "Of which: slotting approach"),
@@ -123,7 +152,7 @@ CRR_OV1_ROWS: list[P3Row] = [
 ]
 
 B31_OV1_ROWS: list[P3Row] = [
-    P3Row("1", "Credit risk (excluding CCR)"),
+    P3Row("1", _LBL_CREDIT_RISK_EX_CCR),
     P3Row("2", "Of which: standardised approach"),
     P3Row("3", "Of which: foundation IRB approach"),
     P3Row("4", "Of which: slotting approach"),
@@ -156,7 +185,7 @@ CRR_CR4_COLUMNS: list[P3Column] = [
     P3Column("c", "On-BS amount post CCF and post CRM", "Exposures post CCF and CRM"),
     P3Column("d", "Off-BS amount post CCF and post CRM", "Exposures post CCF and CRM"),
     P3Column("e", "RWEAs"),
-    P3Column("f", "RWEA density"),
+    P3Column("f", _LBL_COL_RWEA_DENSITY),
 ]
 
 B31_CR4_COLUMNS: list[P3Column] = [
@@ -165,7 +194,7 @@ B31_CR4_COLUMNS: list[P3Column] = [
     P3Column("c", "On-BS amount post CF and post CRM", "Exposures post CF and CRM"),
     P3Column("d", "Off-BS amount post CF and post CRM", "Exposures post CF and CRM"),
     P3Column("e", "RWEAs"),
-    P3Column("f", "RWEA density"),
+    P3Column("f", _LBL_COL_RWEA_DENSITY),
 ]
 
 CRR_CR4_ROWS: list[P3Row] = [
@@ -254,18 +283,18 @@ def _build_cr5_columns(
     """Build CR5 columns from a risk-weight band list."""
     cols: list[P3Column] = []
     for i, (_, label) in enumerate(rw_list):
-        cols.append(P3Column(_letter_ref(i), label, "Risk weight"))
+        cols.append(P3Column(_letter_ref(i), label, _GRP_RISK_WEIGHT))
     n = len(rw_list)
-    cols.append(P3Column(_letter_ref(n), "Other/Deducted", "Risk weight"))
+    cols.append(P3Column(_letter_ref(n), "Other/Deducted", _GRP_RISK_WEIGHT))
     cols.append(P3Column(_letter_ref(n + 1), "Total"))
     cols.append(P3Column(_letter_ref(n + 2), "Of which: unrated"))
     if is_b31:
         cols.extend(
             [
-                P3Column("ba", "On-BS exposure amount", "Exposure breakdown"),
-                P3Column("bb", "Off-BS exposure amount", "Exposure breakdown"),
-                P3Column("bc", "Weighted average CF", "Exposure breakdown"),
-                P3Column("bd", "Total post CF and CRM", "Exposure breakdown"),
+                P3Column("ba", "On-BS exposure amount", _GRP_EXPOSURE_BREAKDOWN),
+                P3Column("bb", "Off-BS exposure amount", _GRP_EXPOSURE_BREAKDOWN),
+                P3Column("bc", "Weighted average CF", _GRP_EXPOSURE_BREAKDOWN),
+                P3Column("bd", "Total post CF and CRM", _GRP_EXPOSURE_BREAKDOWN),
             ]
         )
     return cols
@@ -284,34 +313,34 @@ B31_CR5_ROWS: list[P3Row] = B31_CR4_ROWS
 # ---------------------------------------------------------------------------
 
 CRR_CR6_COLUMNS: list[P3Column] = [
-    P3Column("a", "PD range"),
-    P3Column("b", "On-BS exposures"),
+    P3Column("a", _LBL_COL_PD_RANGE),
+    P3Column("b", _LBL_COL_ONBS_EXPOSURES),
     P3Column("c", "Off-BS exposures pre-CCF"),
     P3Column("d", "Exposure-weighted average CCF"),
-    P3Column("e", "Exposure value post CCF and CRM"),
+    P3Column("e", _LBL_COL_EXP_VALUE_POST_CCF_CRM),
     P3Column("f", "Exposure-weighted average PD (%)"),
     P3Column("g", "Number of obligors"),
     P3Column("h", "Exposure-weighted average LGD (%)"),
     P3Column("i", "Exposure-weighted average maturity (years)"),
     P3Column("j", "RWEAs"),
-    P3Column("k", "RWEA density"),
-    P3Column("l", "Expected loss amount"),
+    P3Column("k", _LBL_COL_RWEA_DENSITY),
+    P3Column("l", _LBL_COL_EXPECTED_LOSS),
     P3Column("m", "Value adjustments and provisions"),
 ]
 
 B31_CR6_COLUMNS: list[P3Column] = [
-    P3Column("a", "PD range"),
-    P3Column("b", "On-BS exposures"),
+    P3Column("a", _LBL_COL_PD_RANGE),
+    P3Column("b", _LBL_COL_ONBS_EXPOSURES),
     P3Column("c", "Off-BS exposures pre-CCF"),
     P3Column("d", "Exposure-weighted average CCF"),
-    P3Column("e", "Exposure value post CCF and CRM"),
-    P3Column("f", "Exposure-weighted average PD (%) — post input floor"),
+    P3Column("e", _LBL_COL_EXP_VALUE_POST_CCF_CRM),
+    P3Column("f", _LBL_COL_EW_AVG_PD_POST_FLOOR),
     P3Column("g", "Number of obligors"),
     P3Column("h", "Exposure-weighted average LGD (%) — including input floors"),
     P3Column("i", "Exposure-weighted average maturity (years)"),
     P3Column("j", "RWEAs"),
-    P3Column("k", "RWEA density"),
-    P3Column("l", "Expected loss amount"),
+    P3Column("k", _LBL_COL_RWEA_DENSITY),
+    P3Column("l", _LBL_COL_EXPECTED_LOSS),
     P3Column("m", "Value adjustments and provisions"),
 ]
 
@@ -349,23 +378,23 @@ CR6A_COLUMNS: list[P3Column] = [
 ]
 
 CRR_CR6A_ROWS: list[P3Row] = [
-    P3Row("1", "Central governments or central banks", ("central_govt_central_bank",)),
+    P3Row("1", _LBL_CENTRAL_GOVT, ("central_govt_central_bank",)),
     P3Row("2", "Institutions", ("institution",)),
     P3Row("3", "Corporates", ("corporate", "corporate_sme", "specialised_lending")),
-    P3Row("4", "Retail — Secured by immovable property", ("retail_mortgage",)),
-    P3Row("5", "Retail — Qualifying revolving", ("retail_qrre",)),
-    P3Row("6", "Retail — Other", ("retail_other",)),
+    P3Row("4", _LBL_RETAIL_RE_MORTGAGE, ("retail_mortgage",)),
+    P3Row("5", _LBL_RETAIL_QRRE, ("retail_qrre",)),
+    P3Row("6", _LBL_RETAIL_OTHER, ("retail_other",)),
     P3Row("7", "Equity", ("equity",)),
     P3Row("8", "Total", is_total=True),
 ]
 
 B31_CR6A_ROWS: list[P3Row] = [
-    P3Row("1", "Central governments or central banks", ("central_govt_central_bank",)),
+    P3Row("1", _LBL_CENTRAL_GOVT, ("central_govt_central_bank",)),
     P3Row("2", "Institutions", ("institution",)),
     P3Row("3", "Corporates", ("corporate", "corporate_sme", "specialised_lending")),
-    P3Row("4", "Retail — Secured by immovable property", ("retail_mortgage",)),
-    P3Row("5", "Retail — Qualifying revolving", ("retail_qrre",)),
-    P3Row("6", "Retail — Other", ("retail_other",)),
+    P3Row("4", _LBL_RETAIL_RE_MORTGAGE, ("retail_mortgage",)),
+    P3Row("5", _LBL_RETAIL_QRRE, ("retail_qrre",)),
+    P3Row("6", _LBL_RETAIL_OTHER, ("retail_other",)),
     P3Row("7", "Total", is_total=True),
 ]
 
@@ -385,7 +414,7 @@ CRR_CR7_ROWS: list[P3Row] = [
     P3Row("4", "  Corporates — SME"),
     P3Row("5", "  Corporates — Other"),
     P3Row("6", "A-IRB subtotal"),
-    P3Row("7", "  Corporates"),
+    P3Row("7", _LBL_ROW_CORPORATES_INDENTED),
     P3Row("8", "  Retail — Secured by immovable property"),
     P3Row("9", "  Retail — Other"),
     P3Row("10", "Total", is_total=True),
@@ -394,9 +423,9 @@ CRR_CR7_ROWS: list[P3Row] = [
 B31_CR7_ROWS: list[P3Row] = [
     P3Row("1", "F-IRB subtotal"),
     P3Row("2", "  Institutions"),
-    P3Row("3", "  Corporates"),
+    P3Row("3", _LBL_ROW_CORPORATES_INDENTED),
     P3Row("4", "A-IRB subtotal"),
-    P3Row("5", "  Corporates"),
+    P3Row("5", _LBL_ROW_CORPORATES_INDENTED),
     P3Row("6", "  Retail"),
     P3Row("7", "Slotting subtotal"),
     P3Row("8", "Total", is_total=True),
@@ -409,15 +438,15 @@ B31_CR7_ROWS: list[P3Row] = [
 
 CRR_CR7A_COLUMNS: list[P3Column] = [
     P3Column("a", "Total exposures", "Total"),
-    P3Column("b", "FCP: Financial collateral (%)", "Funded credit protection"),
-    P3Column("c", "FCP: Other eligible collateral (%)", "Funded credit protection"),
-    P3Column("d", "FCP: Immovable property (%)", "Funded credit protection"),
-    P3Column("e", "FCP: Receivables (%)", "Funded credit protection"),
-    P3Column("f", "FCP: Other physical collateral (%)", "Funded credit protection"),
-    P3Column("g", "FCP: Other funded CP (%)", "Funded credit protection"),
-    P3Column("h", "FCP: Cash on deposit (%)", "Funded credit protection"),
-    P3Column("i", "FCP: Life insurance policies (%)", "Funded credit protection"),
-    P3Column("j", "FCP: Instruments held by third party (%)", "Funded credit protection"),
+    P3Column("b", "FCP: Financial collateral (%)", _GRP_FUNDED_CP),
+    P3Column("c", "FCP: Other eligible collateral (%)", _GRP_FUNDED_CP),
+    P3Column("d", "FCP: Immovable property (%)", _GRP_FUNDED_CP),
+    P3Column("e", "FCP: Receivables (%)", _GRP_FUNDED_CP),
+    P3Column("f", "FCP: Other physical collateral (%)", _GRP_FUNDED_CP),
+    P3Column("g", "FCP: Other funded CP (%)", _GRP_FUNDED_CP),
+    P3Column("h", "FCP: Cash on deposit (%)", _GRP_FUNDED_CP),
+    P3Column("i", "FCP: Life insurance policies (%)", _GRP_FUNDED_CP),
+    P3Column("j", "FCP: Instruments held by third party (%)", _GRP_FUNDED_CP),
     P3Column("k", "UFCP: Guarantees (%)", "Unfunded credit protection"),
     P3Column("l", "UFCP: Credit derivatives (%)", "Unfunded credit protection"),
     P3Column("m", "RWEA post all CRM (obligor class)"),
@@ -432,19 +461,19 @@ B31_CR7A_COLUMNS: list[P3Column] = [
 
 # CR7-A rows per approach: F-IRB, A-IRB (separate disclosure tables)
 CR7A_FIRB_ROWS: list[P3Row] = [
-    P3Row("1", "Central governments or central banks", ("central_govt_central_bank",)),
+    P3Row("1", _LBL_CENTRAL_GOVT, ("central_govt_central_bank",)),
     P3Row("2", "Institutions", ("institution",)),
-    P3Row("3", "Corporates — Specialised lending", ("specialised_lending",)),
+    P3Row("3", _LBL_CORP_SPECIALISED_LENDING, ("specialised_lending",)),
     P3Row("4", "Corporates — Other", ("corporate", "corporate_sme")),
     P3Row("5", "Total", is_total=True),
 ]
 
 CR7A_AIRB_ROWS: list[P3Row] = [
-    P3Row("1", "Corporates — Specialised lending", ("specialised_lending",)),
+    P3Row("1", _LBL_CORP_SPECIALISED_LENDING, ("specialised_lending",)),
     P3Row("2", "Corporates — Other", ("corporate", "corporate_sme")),
-    P3Row("3", "Retail — Secured by immovable property", ("retail_mortgage",)),
-    P3Row("4", "Retail — Qualifying revolving", ("retail_qrre",)),
-    P3Row("5", "Retail — Other", ("retail_other",)),
+    P3Row("3", _LBL_RETAIL_RE_MORTGAGE, ("retail_mortgage",)),
+    P3Row("4", _LBL_RETAIL_QRRE, ("retail_qrre",)),
+    P3Row("5", _LBL_RETAIL_OTHER, ("retail_other",)),
     P3Row("6", "Total", is_total=True),
 ]
 
@@ -474,21 +503,21 @@ CR8_ROWS: list[P3Row] = [
 # ---------------------------------------------------------------------------
 
 CRR_CR10_COLUMNS: list[P3Column] = [
-    P3Column("a", "On-BS exposures"),
+    P3Column("a", _LBL_COL_ONBS_EXPOSURES),
     P3Column("b", "Off-BS exposures"),
-    P3Column("c", "Risk weight"),
+    P3Column("c", _GRP_RISK_WEIGHT),
     P3Column("d", "Exposure value"),
     P3Column("e", "RWEA"),
-    P3Column("f", "Expected loss amount"),
+    P3Column("f", _LBL_COL_EXPECTED_LOSS),
 ]
 
 B31_CR10_COLUMNS: list[P3Column] = [
-    P3Column("a", "On-BS exposures"),
+    P3Column("a", _LBL_COL_ONBS_EXPOSURES),
     P3Column("b", "Off-BS exposures"),
-    P3Column("c", "Risk weight"),
-    P3Column("d", "Exposure value post CCF and CRM"),
+    P3Column("c", _GRP_RISK_WEIGHT),
+    P3Column("d", _LBL_COL_EXP_VALUE_POST_CCF_CRM),
     P3Column("e", "RWEA"),
-    P3Column("f", "Expected loss amount"),
+    P3Column("f", _LBL_COL_EXPECTED_LOSS),
 ]
 
 CRR_CR10_SUBTEMPLATES: dict[str, str] = {
@@ -557,11 +586,11 @@ HVCRE_RISK_WEIGHTS: dict[str, float] = {
 
 CR9_COLUMNS: list[P3Column] = [
     P3Column("a", "Exposure class"),
-    P3Column("b", "PD range"),
+    P3Column("b", _LBL_COL_PD_RANGE),
     P3Column("c", "Number of obligors at end of previous year"),
     P3Column("d", "Of which: defaulted during the year"),
     P3Column("e", "Observed average default rate (%)"),
-    P3Column("f", "Exposure-weighted average PD (%) — post input floor"),
+    P3Column("f", _LBL_COL_EW_AVG_PD_POST_FLOOR),
     P3Column("g", "Average PD at disclosure date (%) — post input floor"),
     P3Column("h", "Average historical annual default rate (%)"),
 ]
@@ -571,18 +600,18 @@ CR9_COLUMN_REFS: list[str] = [c.ref for c in CR9_COLUMNS]
 # CR9 AIRB exposure class breakdown (Art. 147(2)(c)-(d))
 CR9_AIRB_CLASSES: list[tuple[str, str]] = [
     ("corporate", "Corporates"),
-    ("specialised_lending", "Corporates — Specialised lending"),
+    ("specialised_lending", _LBL_CORP_SPECIALISED_LENDING),
     ("corporate_sme", "Corporates — Other general corporates (SME)"),
-    ("retail_mortgage", "Retail — Secured by immovable property"),
-    ("retail_qrre", "Retail — Qualifying revolving"),
-    ("retail_other", "Retail — Other"),
+    ("retail_mortgage", _LBL_RETAIL_RE_MORTGAGE),
+    ("retail_qrre", _LBL_RETAIL_QRRE),
+    ("retail_other", _LBL_RETAIL_OTHER),
 ]
 
 # CR9 FIRB exposure class breakdown (Art. 147(2)(b)-(c))
 CR9_FIRB_CLASSES: list[tuple[str, str]] = [
     ("institution", "Institutions"),
     ("corporate", "Corporates"),
-    ("specialised_lending", "Corporates — Specialised lending"),
+    ("specialised_lending", _LBL_CORP_SPECIALISED_LENDING),
     ("corporate_sme", "Corporates — Other general corporates (SME)"),
 ]
 
@@ -608,7 +637,7 @@ CR9_1_COLUMNS: list[P3Column] = [
     P3Column("c", "Number of obligors at end of previous year"),
     P3Column("d", "Of which: defaulted during the year"),
     P3Column("e", "Observed average default rate (%)"),
-    P3Column("f", "Exposure-weighted average PD (%) — post input floor"),
+    P3Column("f", _LBL_COL_EW_AVG_PD_POST_FLOOR),
     P3Column("g", "Average PD at disclosure date (%) — post input floor"),
     P3Column("h", "Average historical annual default rate (%)"),
     # Additional ECAI columns are added dynamically per firm
@@ -630,7 +659,7 @@ CMS1_COLUMNS: list[P3Column] = [
 ]
 
 CMS1_ROWS: list[P3Row] = [
-    P3Row("0010", "Credit risk (excluding CCR)"),
+    P3Row("0010", _LBL_CREDIT_RISK_EX_CCR),
     P3Row("0020", "Counterparty credit risk"),
     P3Row("0030", "Credit valuation adjustment"),
     P3Row("0040", "Securitisation exposures in the banking book"),

--- a/src/rwa_calc/ui/marimo/server.py
+++ b/src/rwa_calc/ui/marimo/server.py
@@ -27,9 +27,9 @@ import shutil
 import subprocess
 import sys
 import webbrowser
+from collections.abc import Awaitable, Callable
 from datetime import UTC
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import marimo
 import uvicorn
@@ -37,10 +37,24 @@ from fastapi import FastAPI, HTTPException
 from starlette.requests import Request
 from starlette.responses import Response
 
-if TYPE_CHECKING:
-    pass
-
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Response documentation — used in `responses=` on route decorators so the
+# generated OpenAPI schema documents each raised HTTPException status code.
+# ---------------------------------------------------------------------------
+_RESP_400_INVALID_PATH: dict[int | str, dict[str, str]] = {
+    400: {"description": "Invalid path or input"}
+}
+_RESP_404_NOT_FOUND: dict[int | str, dict[str, str]] = {
+    404: {"description": "Resource not found"}
+}
+_RESP_409_CONFLICT: dict[int | str, dict[str, str]] = {
+    409: {"description": "Conflict with existing resource"}
+}
+_RESP_500_GIT_ERROR: dict[int | str, dict[str, str]] = {
+    500: {"description": "Git repository error"}
+}
 
 # ---------------------------------------------------------------------------
 # Paths
@@ -93,11 +107,14 @@ gateway = FastAPI(title="RWA Calculator")
 
 
 @gateway.middleware("http")
-async def _favicon_middleware(request: Request, call_next: object) -> Response:
+async def _favicon_middleware(
+    request: Request,
+    call_next: Callable[[Request], Awaitable[Response]],
+) -> Response:
     """Serve custom favicon for all app paths (marimo uses relative ./favicon.ico)."""
     if request.url.path.endswith("/favicon.ico") and _FAVICON_BYTES:
         return Response(content=_FAVICON_BYTES, media_type="image/png")
-    return await call_next(request)  # type: ignore[operator]
+    return await call_next(request)
 
 
 @gateway.on_event("startup")
@@ -124,46 +141,56 @@ def _sanitise_name(raw: str) -> str:
     return "".join(c if c.isalnum() or c == "_" else "_" for c in raw)
 
 
+def _relative_path(folder: str, name: str) -> str:
+    return f"{folder}/{name}" if folder else name
+
+
+def _folder_entry(entry: Path, folder: str) -> dict[str, str]:
+    py_count = sum(1 for f in entry.glob("*.py") if f.stem != "__init__")
+    return {
+        "type": "folder",
+        "name": entry.name,
+        "path": _relative_path(folder, entry.name),
+        "count": str(py_count),
+    }
+
+
+def _file_entry(entry: Path, folder: str) -> dict[str, str]:
+    from datetime import datetime
+
+    mod = datetime.fromtimestamp(entry.stat().st_mtime, tz=UTC)
+    return {
+        "type": "file",
+        "name": entry.stem,
+        "path": _relative_path(folder, entry.name),
+        "modified": mod.isoformat(),
+    }
+
+
+def _classify_entry(entry: Path, folder: str) -> dict[str, str] | None:
+    if entry.name.startswith((".", "__")):
+        return None
+    if entry.is_dir() and entry.name not in _SKIP_DIRS:
+        return _folder_entry(entry, folder)
+    if entry.is_file() and entry.suffix == ".py" and entry.stem != "__init__":
+        return _file_entry(entry, folder)
+    return None
+
+
 def _list_items(base: Path, folder: str = "") -> list[dict[str, str]]:
     """List workbook files and subfolders within *base* / *folder*.
 
     Returns a list of dicts with keys: type, name, path, modified.
     """
-    from datetime import datetime
-
     target = _validate_workspace_path(base, folder) if folder else base
     if not target.exists() or not target.is_dir():
         return []
 
-    items: list[dict[str, str]] = []
-
-    for entry in sorted(target.iterdir(), key=lambda p: p.name):
-        if entry.name.startswith(".") or entry.name.startswith("__"):
-            continue
-        if entry.is_dir() and entry.name not in _SKIP_DIRS:
-            py_count = len([f for f in entry.glob("*.py") if f.stem != "__init__"])
-            rel = f"{folder}/{entry.name}" if folder else entry.name
-            items.append(
-                {
-                    "type": "folder",
-                    "name": entry.name,
-                    "path": rel,
-                    "count": str(py_count),
-                }
-            )
-        elif entry.is_file() and entry.suffix == ".py" and entry.stem != "__init__":
-            mod = datetime.fromtimestamp(entry.stat().st_mtime, tz=UTC)
-            rel = f"{folder}/{entry.name}" if folder else entry.name
-            items.append(
-                {
-                    "type": "file",
-                    "name": entry.stem,
-                    "path": rel,
-                    "modified": mod.isoformat(),
-                }
-            )
-
-    return items
+    return [
+        item
+        for entry in sorted(target.iterdir(), key=lambda p: p.name)
+        if (item := _classify_entry(entry, folder)) is not None
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -190,7 +217,7 @@ async def list_workbooks(folder: str = "") -> dict[str, object]:
     return {"folder": folder, "items": items, "breadcrumbs": breadcrumbs}
 
 
-@gateway.post("/api/workbooks/duplicate")
+@gateway.post("/api/workbooks/duplicate", responses=_RESP_400_INVALID_PATH)
 async def duplicate_template(
     template: str,
     name: str | None = None,
@@ -219,7 +246,10 @@ async def duplicate_template(
     }
 
 
-@gateway.delete("/api/workbooks/{name:path}")
+@gateway.delete(
+    "/api/workbooks/{name:path}",
+    responses={**_RESP_404_NOT_FOUND, **_RESP_409_CONFLICT},
+)
 async def delete_workbook(name: str) -> dict[str, str]:
     """Delete a user workbook or an empty folder."""
     target = _validate_workspace_path(workspaces_dir, name)
@@ -243,7 +273,10 @@ async def delete_workbook(name: str) -> dict[str, str]:
     return {"deleted": name, "type": "file"}
 
 
-@gateway.post("/api/folders")
+@gateway.post(
+    "/api/folders",
+    responses={**_RESP_400_INVALID_PATH, **_RESP_409_CONFLICT},
+)
 async def create_folder(name: str, workspace: str = "local") -> dict[str, str]:
     """Create a new folder in the specified workspace."""
     sanitised = _sanitise_name(name)
@@ -257,7 +290,10 @@ async def create_folder(name: str, workspace: str = "local") -> dict[str, str]:
     return {"folder": sanitised, "workspace": workspace}
 
 
-@gateway.post("/api/workbooks/move")
+@gateway.post(
+    "/api/workbooks/move",
+    responses={**_RESP_404_NOT_FOUND, **_RESP_409_CONFLICT},
+)
 async def move_workbook(source: str, dest_folder: str = "") -> dict[str, str]:
     """Move a workbook to a different folder (or to root if *dest_folder* is empty)."""
     src = _validate_workspace_path(workspaces_dir, source)
@@ -293,7 +329,7 @@ async def list_team_workbooks(folder: str = "") -> dict[str, object]:
     return {"folder": folder, "items": items, "breadcrumbs": breadcrumbs}
 
 
-@gateway.get("/api/team/status")
+@gateway.get("/api/team/status", responses=_RESP_500_GIT_ERROR)
 async def team_status() -> dict[str, object]:
     """Return git status for all files in the team workspace."""
     from rwa_calc.ui.marimo.git_ops import find_repo_root, get_status
@@ -307,7 +343,7 @@ async def team_status() -> dict[str, object]:
     return {"files": [{"name": s.name, "folder": s.folder, "status": s.status} for s in statuses]}
 
 
-@gateway.post("/api/team/publish")
+@gateway.post("/api/team/publish", responses=_RESP_404_NOT_FOUND)
 async def publish_to_team(name: str, folder: str = "") -> dict[str, str]:
     """Copy a workbook from local/ to team/ and stage it."""
     from rwa_calc.ui.marimo.git_ops import publish
@@ -328,7 +364,7 @@ async def publish_to_team(name: str, folder: str = "") -> dict[str, str]:
     }
 
 
-@gateway.post("/api/team/commit")
+@gateway.post("/api/team/commit", responses=_RESP_500_GIT_ERROR)
 async def commit_team(message: str = "") -> dict[str, object]:
     """Stage all changes in team/, commit, and push."""
     from rwa_calc.ui.marimo.git_ops import find_repo_root, publish_changes
@@ -355,7 +391,7 @@ async def commit_team(message: str = "") -> dict[str, object]:
     }
 
 
-@gateway.post("/api/team/pull")
+@gateway.post("/api/team/pull", responses=_RESP_500_GIT_ERROR)
 async def pull_team() -> dict[str, object]:
     """Pull latest team changes from remote."""
     from rwa_calc.ui.marimo.git_ops import find_repo_root, pull

--- a/src/rwa_calc/ui/marimo/workbench_app.py
+++ b/src/rwa_calc/ui/marimo/workbench_app.py
@@ -14,6 +14,15 @@ import marimo
 __generated_with = "0.19.4"
 app = marimo.App(width="medium", css_file="shared/theme.css", html_head_file="shared/head.html")
 
+# Sentinel prefixes used in reactive state to encode pending actions.
+# Hoisted so the prefix string is defined once and referenced everywhere
+# (avoids drift between the producing cell that builds e.g. "__folder__:<name>"
+# and the consuming cell that strips that prefix).
+_FOLDER_SENTINEL = "__folder__:"
+_PUBLISH_SENTINEL = "__publish__:"
+# Dropdown label for "no subfolder / workspace root" in the move-workbook dialog.
+_ROOT_LABEL = "(root)"
+
 
 @app.cell
 def _():
@@ -445,9 +454,9 @@ def _(
         _btn_meta: dict[str, tuple[str, object]] = {}
         _cards: list[object] = []
 
-        # Folder cards
+        # Folder cards — buttons only; _py_count is recomputed in the card-display
+        # loop below where it is actually consumed.
         for _di, _d in enumerate(_folders):
-            _py_count = len([f for f in _d.glob("*.py") if f.stem != "__init__"])
             _open_key = f"folder_open_{_di}"
             _del_key = f"folder_del_{_di}"
             _btn_elements[_open_key] = mo.ui.button(
@@ -680,7 +689,7 @@ def _(mo, pending_delete):
     cancel_btn = mo.ui.run_button(label="Cancel")
 
     _label = pending_delete()
-    if _label.startswith("__folder__:"):
+    if _label.startswith(_FOLDER_SENTINEL):
         _display = f"folder **{_label[len('__folder__:') :]}"
     else:
         _display = f"**{_label}**"
@@ -712,9 +721,9 @@ def _(Path, cancel_btn, confirm_btn, mo, pending_delete, set_pending_delete, set
         _ws_dir = Path(__file__).parent / "workspaces" / "local"
         _label = pending_delete()
 
-        if _label.startswith("__folder__:"):
+        if _label.startswith(_FOLDER_SENTINEL):
             # Folder delete
-            _folder_name = _label[len("__folder__:") :]
+            _folder_name = _label[len(_FOLDER_SENTINEL) :]
             _folder_path = _ws_dir / _folder_name
             _py_files = (
                 [f for f in _folder_path.glob("*.py") if f.stem != "__init__"]
@@ -763,8 +772,8 @@ def _(Path, SKIP_DIRS, mo, pending_move, set_pending_move, set_refresh):
     _source_path, _source_name = pending_move()
 
     # Handle publish action
-    if _source_path.startswith("__publish__:"):
-        _pub_rel = _source_path[len("__publish__:") :]
+    if _source_path.startswith(_PUBLISH_SENTINEL):
+        _pub_rel = _source_path[len(_PUBLISH_SENTINEL) :]
         _ws_dir = Path(__file__).parent / "workspaces" / "local"
         _team_dir = Path(__file__).parent / "workspaces" / "team"
         _src = _ws_dir / f"{_pub_rel}.py"
@@ -792,7 +801,7 @@ def _(Path, SKIP_DIRS, mo, pending_move, set_pending_move, set_refresh):
     else:
         # Move dialog — show folder dropdown
         _ws_dir = Path(__file__).parent / "workspaces" / "local"
-        _available_folders = ["(root)"] + sorted(
+        _available_folders = [_ROOT_LABEL] + sorted(
             d.name
             for d in _ws_dir.iterdir()
             if d.is_dir() and d.name not in SKIP_DIRS and not d.name.startswith(".")
@@ -800,7 +809,7 @@ def _(Path, SKIP_DIRS, mo, pending_move, set_pending_move, set_refresh):
         move_dropdown = mo.ui.dropdown(
             options=_available_folders,
             label="Move to",
-            value="(root)",
+            value=_ROOT_LABEL,
         )
         move_confirm_btn = mo.ui.run_button(label="Move")
         move_cancel_btn = mo.ui.run_button(label="Cancel")
@@ -834,7 +843,7 @@ def _(
 
     _source_path, _source_name = pending_move()
     # Skip publish actions (handled above)
-    mo.stop(_source_path.startswith("__publish__:"))
+    mo.stop(_source_path.startswith(_PUBLISH_SENTINEL))
 
     mo.stop(not move_confirm_btn.value and not move_cancel_btn.value)
 
@@ -845,7 +854,7 @@ def _(
         _ws_dir = Path(__file__).parent / "workspaces" / "local"
         _src = _ws_dir / _source_path
         _dest_folder = move_dropdown.value
-        _dest_dir = _ws_dir if _dest_folder == "(root)" else _ws_dir / _dest_folder
+        _dest_dir = _ws_dir if _dest_folder == _ROOT_LABEL else _ws_dir / _dest_folder
         _dest = _dest_dir / _src.name
         if _dest.exists():
             mo.callout(

--- a/tests/unit/test_corep.py
+++ b/tests/unit/test_corep.py
@@ -1405,8 +1405,8 @@ class TestCombinedGeneration:
         crr = gen.generate_from_lazyframe(_sa_results(), framework="CRR")
         b31 = gen.generate_from_lazyframe(_sa_results(), framework="BASEL_3_1")
 
-        crr_cols = set(list(crr.c07_00.values())[0].columns)
-        b31_cols = set(list(b31.c07_00.values())[0].columns)
+        crr_cols = set(next(iter(crr.c07_00.values())).columns)
+        b31_cols = set(next(iter(b31.c07_00.values())).columns)
 
         # CRR has supporting factor columns, B3.1 doesn't
         assert "0215" in crr_cols
@@ -1510,7 +1510,7 @@ class TestSupportingFactors:
         gen = COREPGenerator()
         bundle = gen.generate_from_lazyframe(_sa_results_with_phase2_cols(), framework="BASEL_3_1")
 
-        corp = list(bundle.c07_00.values())[0]
+        corp = next(iter(bundle.c07_00.values()))
         assert "0215" not in corp.columns
         assert "0216" not in corp.columns
         assert "0217" not in corp.columns
@@ -1611,7 +1611,7 @@ class TestECAIUnratedSplit:
         gen = COREPGenerator()
         bundle = gen.generate_from_lazyframe(_sa_results_with_phase2_cols(), framework="BASEL_3_1")
 
-        corp = list(bundle.c07_00.values())[0]
+        corp = next(iter(bundle.c07_00.values()))
         assert "0235" in corp.columns
 
     def test_b31_unrated_exposure_in_0235(self) -> None:
@@ -8935,7 +8935,9 @@ class TestEquityTransitionalColumns:
         # Replace equity_transitional with our test config
         import dataclasses
 
-        config_with_trans = dataclasses.replace(config_b31, equity_transitional=eq_config)
+        config_with_trans: CalculationConfig = dataclasses.replace(
+            config_b31, equity_transitional=eq_config
+        )
 
         exposures = pl.LazyFrame(
             {

--- a/workbooks/crr_expected_outputs/generate_outputs.py
+++ b/workbooks/crr_expected_outputs/generate_outputs.py
@@ -64,6 +64,13 @@ from workbooks.shared.irb_formulas import (
     calculate_irb_rwa as base_calculate_irb_rwa,
 )
 
+# ---------------------------------------------------------------------------
+# Shared regulatory citation literals (hoisted — reused across scenarios)
+# ---------------------------------------------------------------------------
+_REG_FIRB_CORP = "CRR Art. 153, 161"  # F-IRB corporate / institution
+_REG_FCCR_HAIRCUTS = "CRR Art. 224"  # Financial collateral comprehensive method haircuts
+_REG_SLOTTING = "CRR Art. 153(5)"  # IRB slotting (specialised lending)
+
 
 @dataclass
 class CRRScenarioOutput:
@@ -506,7 +513,7 @@ def generate_crr_a_scenarios(fixtures) -> list[CRRScenarioOutput]:
     return scenarios
 
 
-def generate_crr_b_scenarios(fixtures) -> list[CRRScenarioOutput]:
+def generate_crr_b_scenarios(_fixtures) -> list[CRRScenarioOutput]:
     """Generate CRR Group B (F-IRB) scenario outputs.
 
     Tests Foundation IRB calculations under CRR:
@@ -569,7 +576,7 @@ def generate_crr_b_scenarios(fixtures) -> list[CRRScenarioOutput]:
             supporting_factor=1.0,
             rwa_after_sf=result_b1["rwa"],
             expected_loss=calculate_expected_loss(pd_floored_b1, lgd_b1, ead_b1),
-            regulatory_reference="CRR Art. 153, 161",
+            regulatory_reference=_REG_FIRB_CORP,
             calculation_notes="Senior unsecured, supervisory LGD 45%. Low PD with maturity > 2.5y.",
         )
     )
@@ -620,7 +627,7 @@ def generate_crr_b_scenarios(fixtures) -> list[CRRScenarioOutput]:
             supporting_factor=1.0,
             rwa_after_sf=result_b2["rwa"],
             expected_loss=calculate_expected_loss(pd_floored_b2, lgd_b2, ead_b2),
-            regulatory_reference="CRR Art. 153, 161",
+            regulatory_reference=_REG_FIRB_CORP,
             calculation_notes="High PD corporate. Correlation decreases at high PD (R→0.12).",
         )
     )
@@ -671,7 +678,7 @@ def generate_crr_b_scenarios(fixtures) -> list[CRRScenarioOutput]:
             supporting_factor=1.0,
             rwa_after_sf=result_b3["rwa"],
             expected_loss=calculate_expected_loss(pd_floored_b3, lgd_b3, ead_b3),
-            regulatory_reference="CRR Art. 153, 161",
+            regulatory_reference=_REG_FIRB_CORP,
             calculation_notes="Subordinated claim: 75% LGD vs 45% senior. Significantly higher RWA.",
         )
     )
@@ -907,7 +914,7 @@ def generate_crr_b_scenarios(fixtures) -> list[CRRScenarioOutput]:
     return scenarios
 
 
-def generate_crr_c_scenarios(fixtures) -> list[CRRScenarioOutput]:
+def generate_crr_c_scenarios(_fixtures) -> list[CRRScenarioOutput]:
     """Generate CRR Group C (A-IRB) scenario outputs."""
     scenarios = []
 
@@ -1054,7 +1061,7 @@ def generate_crr_c_scenarios(fixtures) -> list[CRRScenarioOutput]:
     return scenarios
 
 
-def generate_crr_d_scenarios(fixtures) -> list[CRRScenarioOutput]:
+def generate_crr_d_scenarios(_fixtures) -> list[CRRScenarioOutput]:
     """Generate CRR Group D (CRM) scenario outputs."""
     scenarios = []
 
@@ -1128,7 +1135,7 @@ def generate_crr_d_scenarios(fixtures) -> list[CRRScenarioOutput]:
             supporting_factor=1.0,
             rwa_after_sf=float(rwa_post_d2),
             expected_loss=None,
-            regulatory_reference="CRR Art. 224",
+            regulatory_reference=_REG_FCCR_HAIRCUTS,
             calculation_notes=f"CQS 1 govt bond >5y: {coll_haircut_d2 * 100:.1f}% haircut",
         )
     )
@@ -1165,7 +1172,7 @@ def generate_crr_d_scenarios(fixtures) -> list[CRRScenarioOutput]:
             supporting_factor=1.0,
             rwa_after_sf=float(rwa_post_d3),
             expected_loss=None,
-            regulatory_reference="CRR Art. 224",
+            regulatory_reference=_REG_FCCR_HAIRCUTS,
             calculation_notes="Main index equity: 15% haircut (other equity: 25%)",
         )
     )
@@ -1278,7 +1285,7 @@ def generate_crr_d_scenarios(fixtures) -> list[CRRScenarioOutput]:
             supporting_factor=1.0,
             rwa_after_sf=float(rwa_post_d6),
             expected_loss=None,
-            regulatory_reference="CRR Art. 224",
+            regulatory_reference=_REG_FCCR_HAIRCUTS,
             calculation_notes=f"FX mismatch: {fx_haircut_d6 * 100:.0f}% additional haircut",
         )
     )
@@ -1352,7 +1359,7 @@ def generate_crr_e_scenarios(fixtures) -> list[CRRScenarioOutput]:
             supporting_factor=1.0,
             rwa_after_sf=float(rwa),
             expected_loss=None,
-            regulatory_reference="CRR Art. 153(5)",
+            regulatory_reference=_REG_SLOTTING,
             calculation_notes=calculation_notes,
         )
 
@@ -1484,7 +1491,7 @@ def generate_crr_e_scenarios(fixtures) -> list[CRRScenarioOutput]:
             supporting_factor=1.0,
             rwa_after_sf=float(e9_rwa),
             expected_loss=float(e9_el),
-            regulatory_reference="CRR Art. 153(5)",
+            regulatory_reference=_REG_SLOTTING,
             calculation_notes=(
                 "HVCRE Strong, >=2.5yr: 70% RW (Table 1). UK CRR has no HVCRE "
                 "sub-class; is_hvcre=True preserved in audit trail. "
@@ -1496,7 +1503,7 @@ def generate_crr_e_scenarios(fixtures) -> list[CRRScenarioOutput]:
     return scenarios
 
 
-def generate_crr_f_scenarios(fixtures) -> list[CRRScenarioOutput]:
+def generate_crr_f_scenarios(_fixtures) -> list[CRRScenarioOutput]:
     """
     Generate CRR Group F (Supporting Factors) scenario outputs.
 
@@ -1540,7 +1547,7 @@ def generate_crr_f_scenarios(fixtures) -> list[CRRScenarioOutput]:
     return scenarios
 
 
-def generate_crr_g_scenarios(fixtures) -> list[CRRScenarioOutput]:
+def generate_crr_g_scenarios(_fixtures) -> list[CRRScenarioOutput]:
     """Generate CRR Group G (Provisions) scenario outputs."""
     scenarios = []
 
@@ -1674,7 +1681,7 @@ def generate_crr_g_scenarios(fixtures) -> list[CRRScenarioOutput]:
     return scenarios
 
 
-def generate_crr_h_scenarios(fixtures) -> list[CRRScenarioOutput]:
+def generate_crr_h_scenarios(_fixtures) -> list[CRRScenarioOutput]:
     """Generate CRR Group H (Complex/Combined) scenario outputs."""
     scenarios = []
 
@@ -1820,7 +1827,7 @@ def generate_all_outputs():
             "sa_risk_weights": "CRR Art. 112-134",
             "irb_approach": "CRR Art. 142-191",
             "crm": "CRR Art. 207-236",
-            "slotting": "CRR Art. 153(5)",
+            "slotting": _REG_SLOTTING,
             "provisions": "CRR Art. 110, 158-159, 62(d)",
         },
         "scenario_groups": {


### PR DESCRIPTION
## Summary

  Continuation of the SonarQube cleanup series. This branch clears
  ~200
  findings across six commits — four per-file refactors and two
  systemic
  suppressions for `tests/**`.

  ### Per-file refactors

  - **`marimo/server.py`** (17 cleared) — document HTTPException
  responses
    via reused `_RESP_*` maps, extract `_classify_entry` /
    `_folder_entry` / `_file_entry` helpers to drop `_list_items`
    cognitive complexity below 15, type the favicon middleware
    `call_next`, collapse chained `startswith`, drop dead
    `TYPE_CHECKING` block.
  - **`reporting/pillar3/templates.py`** (16 cleared) — hoist 16
  duplicated
    template label literals (6 exposure-class, 1 row, 6 column, 3
  group)
    to module-private constants. 72 occurrences across SA/IRB
  disclosure
    classes and CRR/B31 OV1/CR4/CR5/CR6/CR6A/CR7/CR7A/CR10/CMS
  templates
    now reference the shared constants.
  - **`workbooks/crr_expected_outputs/generate_outputs.py`** (9
  cleared) —
    rename intentionally-unused `fixtures` → `_fixtures` on 6
    hard-coded-expectation generators (S1172), hoist 3 duplicated
    regulatory citation literals to module constants (S1192).
  - **`marimo/workbench_app.py`** (4 of 7 cleared, 3 deferred) —
  hoist
    three sentinel literals (`"__folder__:"`, `"__publish__:"`,
    `"(root)"`) to module constants, drop one unused `_py_count`
    computation. 3 × S3776 cognitive-complexity findings on
    `@app.cell` functions deferred — refactoring requires splitting
    cells and would change marimo's reactive dependency graph;
  needs
    end-to-end UI test coverage first.

  ### Systemic test suppressions (`tests/**`)

  These match the precedent set by S101 (`2c295e1`) — rules that
  produce
  high noise on test code without losing signal on production:

  - **S125 "commented-out code"** — flagged 54 lines across 19 test
    files. All are inline hand-calc verification comments
    (`# 3500 - 45 = 3455`, `# 0150 = max(0, 0110 - 0130)`) that
  look
    like assignments to Sonar's parser. CLAUDE.md endorses keeping
    these. Also cleared 5 code-level findings on `test_corep.py`
    (S8519 × 4, S5655 × 1) in the same commit.
  - **S2259 "null dereference" (114)** + **S1244 "float equality"
  (41)**
    — both 100% concentrated in `tests/**`. S2259 fires on
    `result["col"]` after a `pytest.skip()` guard or fixture-loader
    helper (Sonar can't propagate the narrowing). S1244 fires on
    exact-equality assertions against regulatory parameters
    (`assert df["risk_weight"][0] == 0.50`) — `pytest.approx()`
  would
    weaken the assertion. The 1 S2259 in `src/` and 3 S1244 in
    `workbooks/` remain and are addressed per-file.

  ### Backlog impact

  Active backlog dropped from ~288 → ~80 findings, focusing
  remaining
  work on `src/`, `workbooks/`, and the deferred marimo cells.

  ## Test plan

  - [x] `uv run pytest tests/unit/test_corep.py` → 691/691 pass
  - [x] `uv run pytest tests/unit/test_pillar3.py` + integration
  `-k pillar3` → 197/197 pass
  - [x] `uv run pytest
  tests/acceptance/crr/test_scenario_crr_f_supporting_factors.py` →
   17 pass, 1 skipped
  - [x] `uv run pytest
  tests/unit/ui/test_starter_template_parseable.py` → 1 pass
  - [x] `uv run python scripts/arch_check.py` → all checks pass on
  every commit
  - [x] Semantic spot-checks confirm every hoisted label resolves
  to the identical string at call sites
  - [x] CI green on push