### PR TITLE
chore(sonar): add /sonar-clean orchestrator and clear 13 issues across 3 engine files

### DIFF
--- a/.claude/commands/sonar-clean.md
+++ b/.claude/commands/sonar-clean.md
@@ -1,0 +1,553 @@
+---
+description: Pick top N non-conflicting files from the open SonarQube backlog and drive them through engine-implementer + reviewer in parallel worktrees. Default N=3, capped at 5. Production-only (`src/rwa_calc/`). Hard-excludes shared engine files.
+argument-hint: [N]
+---
+
+You are draining open **SonarQube** issues from `src/rwa_calc/` in batches.
+Each batch item is **one file** with its full set of open Sonar issues.
+Items run in their own git worktree, on `sonar/<batch-id>/<slug>` branches.
+You drive a two-wave pipeline directly: `engine-implementer` fixes the
+file, then `reviewer` gates the fix. Agents run with
+`run_in_background: true` so your turns end after dispatch and the
+operator can chat with you freely while the batch is in flight.
+
+After every item has reached `merge_ready` or been dropped, squash-merge
+each surviving worktree branch into the **current branch** (operator
+pre-creates a feature branch like `chore/sonar-clean-<batch>` before
+invoking this command), run the global validation gate **once** on the
+merged tree, then re-query SonarQube to report the delta and clean up
+the worktrees.
+
+Parse `$ARGUMENTS` as integer **N** (default 3, cap 5). If `$ARGUMENTS`
+is empty or not an integer, use 3.
+
+## Core architecture
+
+This command spans **multiple turns**. The orchestrator (you) is an
+event-driven supervisor: kick off the batch in one turn, end the turn,
+then react to agent completion notifications and operator messages
+across subsequent turns until the batch is fully resolved.
+
+To survive context compactions and operator interruptions, the
+orchestrator persists batch state to
+`.claude/state/sonar-clean-<batch-id>.json` and **reads that file at
+the start of every turn** before doing anything else. The state file is
+the source of truth for what is in flight.
+
+## Step 1 — pull and bucket the Sonar backlog
+
+Query SonarCloud via the MCP:
+
+```
+mcp__sonarqube__search_sonar_issues_in_projects
+  projects=["OpenAfterHours_rwa_calculator"]
+  issueStatuses=["OPEN", "CONFIRMED"]
+  ps=500
+```
+
+The result is large — if it overflows the response and is saved to a
+file under `.claude/projects/.../tool-results/`, parse it from that file
+with `python3` (jq is not available in the sandbox). Page 2 may be
+required (`p=2`) if `paging.total > 500`.
+
+**Filter to production code only**: keep only issues whose `component`
+contains `src/rwa_calc/`. Discard everything else (tests, workbooks,
+scripts) — those are out of scope for this command.
+
+**Bucket by file**: group issues by `component`. Each file becomes one
+candidate item with this shape:
+
+```json
+{
+  "file": "src/rwa_calc/engine/hierarchy.py",
+  "slug": "engine-hierarchy",
+  "issues": [
+    {"key": "AZ...", "rule": "python:S3776", "severity": "CRITICAL",
+     "line": 99, "message": "Refactor this function..."}
+  ],
+  "issue_count": 6,
+  "critical_count": 4
+}
+```
+
+The `slug` is the file path relative to `src/rwa_calc/`, with `/`
+replaced by `-` and `.py` stripped (e.g. `engine/crm/guarantees.py` →
+`engine-crm-guarantees`). It is used in branch names and worktree paths.
+
+**Sort candidates** by `(critical_count desc, issue_count desc,
+file asc)`. Take the top **N** (after hard exclusions in Step 1.5).
+
+## Step 1.5 — hard exclusions
+
+Force any file under these paths to single-stream / main-tree mode (no
+worktree, no parallelism — pick it alone even if N>1 was requested):
+
+- `src/rwa_calc/engine/pipeline.py`
+- `src/rwa_calc/contracts/protocols.py`
+- `src/rwa_calc/contracts/bundles.py`
+- `src/rwa_calc/engine/aggregator/aggregator.py`
+
+If the top-priority candidate is on this list, downgrade to N=1
+single-stream, surface the downgrade ("Picked <file> only; touches
+shared infrastructure — single-stream, no worktree"), and run it in
+the main tree.
+
+If the queue is empty (no `src/rwa_calc/` issues remain), report
+"nothing to do" and stop.
+
+Generate a short batch identifier `<batch-id>` (e.g. timestamp
+`YYYYMMDD-HHMM`).
+
+## Step 2 — confirm before dispatch
+
+Capture the **current branch** (`git branch --show-current`) — this is
+the merge target. If it is `master`, warn the operator: squash commits
+will land on master unless they abort and check out a feature branch.
+
+State to the operator, one line per item:
+
+```
+<slug> | file: <relative path> | issues: <count> (<crit> crit) | branch: sonar/<batch-id>/<slug> | worktree: ../rwa_calculator-sonar-<slug>
+```
+
+If any candidate was downgraded to single-stream, say so and skip
+Step 3 (no worktree).
+
+## Step 3 — provision worktrees
+
+Skip this step entirely for single-stream / hard-excluded items.
+
+For each batched item, run from the main repo:
+
+```
+git worktree add -b sonar/<batch-id>/<slug> ../rwa_calculator-sonar-<slug> HEAD
+```
+
+Capture each worktree's absolute path — the engine-implementer needs it.
+
+Sanity check after all worktrees are created:
+
+```
+git worktree list
+```
+
+Expect the main tree plus N sibling entries.
+
+## Step 4 — drive the two-wave pipeline (background, with reviewer loop)
+
+This step is multi-turn. It begins with a kickoff (Step 4a), then the
+orchestrator processes one turn at a time (Step 4b) until every item
+has reached `merge_ready` or `dropped`.
+
+### Step 4a — kickoff
+
+Write the state file at `.claude/state/sonar-clean-<batch-id>.json`
+with this initial schema. Use the Write tool to overwrite the file as a
+complete JSON document — do not patch line by line.
+
+```json
+{
+  "batch_id": "<batch-id>",
+  "merge_target_branch": "<current branch>",
+  "main_repo_path": "<absolute path to main repo>",
+  "main_venv_path": "<absolute path to repo .venv>",
+  "started_at": "<ISO 8601 timestamp>",
+  "initial_open_count": <total open issues in src/rwa_calc/ at start>,
+  "items": [
+    {
+      "slug": "engine-hierarchy",
+      "file": "src/rwa_calc/engine/hierarchy.py",
+      "issue_count": 6,
+      "critical_count": 4,
+      "issues": [ {"key":"...", "rule":"...", "severity":"...",
+                   "line":N, "message":"..."} ],
+      "stream": "worktree",
+      "branch": "sonar/<batch-id>/engine-hierarchy",
+      "worktree_path": "<absolute worktree path>",
+      "current_wave": "engine_implementer",
+      "agent_status": "in_flight",
+      "revision_count": { "engine_implementer": 0 },
+      "outputs": {},
+      "drop_reason": null,
+      "current_agent_name": "sonar-fix-engine-hierarchy-r0"
+    }
+  ]
+}
+```
+
+`stream` is `"worktree"` for batched items and `"main_tree"` for
+single-stream / hard-excluded items. For `main_tree` items,
+`worktree_path` is `null`.
+
+In a single message, dispatch one `engine-implementer` Agent call per
+item, **all with `run_in_background: true`** and a stable `name` of the
+form `sonar-fix-<slug>-r0`. Use the prompt template:
+
+```
+You are fixing SonarQube issues in **one file only**:
+`<absolute path to file in worktree>` (relative: `<relative path>`).
+
+You may add private helpers within the same file. You may NOT:
+- modify any other file
+- change a regulatory scalar (risk weight, CCF, LGD, supervisory
+  haircut, supporting factor, output floor percentage, slotting band)
+- alter the public API of any function/class (signature, return type,
+  raised exceptions). The single exception is removing an unused
+  parameter flagged by S1172 — that is the intended fix.
+- introduce a new module-level dependency
+- run the global pytest suite. Only the targeted test below.
+
+If you believe an issue is a false-positive, do NOT add a `# noqa` or
+`# NOSONAR` suppression — report `deferred: <rule> at line <N>: <reason>`
+in your return value and leave the code as-is for that issue.
+
+Address each Sonar issue listed below.
+
+After fixing, run the local validation gate as defined in your system
+prompt, in order, fixing issues as they appear. Replace the "new test
+path" step with the targeted-test path below.
+
+Targeted test path: `<derived test path>`
+  - For `src/rwa_calc/engine/<sub>/<mod>.py` try `tests/unit/test_<mod>.py`
+    first; if missing, fall back to `tests/unit/test_<sub>_<mod>.py`,
+    then to `tests/unit/<sub>/` (directory).
+  - For `src/rwa_calc/data/tables/<mod>.py` try `tests/unit/test_<mod>.py`.
+  - For `src/rwa_calc/ui/marimo/*.py` there is often no unit test. If
+    you cannot find a targeted test, report `targeted_test: none — orchestrator will run global suite` and skip that step. Do NOT invent one.
+
+--- worktree preamble ---
+Operate inside the worktree at `<absolute worktree path>` for this
+task. Use absolute paths beginning with that prefix in all Read /
+Edit / Write / Bash calls. Do **not** edit files in the main repo
+tree. The repo's main virtual environment is shared via
+`UV_PROJECT_ENVIRONMENT=<absolute main .venv path>` — prepend it to
+any `uv run` command, e.g.
+`UV_PROJECT_ENVIRONMENT=<...> uv run pytest <...>`.
+
+--- file under fix ---
+<relative path>
+
+--- SonarQube issues to address ---
+- <rule> [<severity>] line <line>: <message>
+- <rule> [<severity>] line <line>: <message>
+- ...
+
+--- return value ---
+Report:
+1. Files modified (absolute paths).
+2. Per-issue disposition: `addressed` (one-line description of the
+   fix) | `deferred` (with reason).
+3. Local validation gate output (pass/fail per step).
+4. Targeted-test outcome (pass + summary line, or `none`).
+```
+
+For `main_tree`-stream items, omit the worktree preamble.
+
+End the kickoff turn with a one-line summary to the operator:
+
+> Batch `<batch-id>` kicked off: N Sonar files in flight at Wave 1
+> (engine-implementer). I'll continue when each returns; you can ask
+> me anything — status, drop an item, inspect outputs — in the
+> meantime.
+
+### Step 4b — supervisor protocol (every subsequent turn)
+
+At the start of every turn during a live batch, before responding to
+the operator or processing notifications:
+
+1. **Read the state file** `.claude/state/sonar-clean-<batch-id>.json`.
+   If it does not exist, the batch is over — proceed to Step 5 if
+   there are merge-ready items, otherwise stop.
+
+2. **Identify what changed since last turn**:
+   - **Operator message**: respond to the operator. Common requests:
+     - *Status*: summarise the state file. Format per item:
+       `<slug>: wave=<current_wave> status=<agent_status> revisions=<sum>`.
+     - *Drop an item*: set its `agent_status` to `dropped`,
+       `drop_reason` to `"operator-drop"`, and if the agent for that
+       item is still in flight, attempt `TaskStop`. Persist state.
+       Confirm to operator.
+     - *Inspect output*: read the corresponding entry's `outputs` map
+       and surface it.
+   - **Agent completion notification**: identify which item it
+     corresponds to (by `current_agent_name`). Store the agent's
+     output in the appropriate `outputs` slot. Then progress that
+     item per the rules below.
+
+3. **Per-item progression rules**:
+
+   | Current state | Trigger | Next action |
+   |---|---|---|
+   | `agent_status: in_flight` | (no completion yet) | keep waiting |
+   | `agent_status: returned` (engine-implementer just finished) | — | dispatch reviewer per Step 4c; set `agent_status: in_review`; set `current_agent_name: reviewer-engine-implementer-<slug>-r<N>` |
+   | `agent_status: in_review` | reviewer returned `VERDICT: pass` | set `current_wave: merge_ready`. Stop dispatching for this item. |
+   | `agent_status: in_review` | reviewer returned `VERDICT: revise` AND `revision_count.engine_implementer == 0` | re-dispatch engine-implementer per Step 4e; increment `revision_count.engine_implementer`; set `agent_status: in_flight` with `current_agent_name: sonar-fix-<slug>-r1` |
+   | `agent_status: in_review` | reviewer returned `VERDICT: revise` AND `revision_count.engine_implementer >= 1` | drop. Set `agent_status: dropped`, `drop_reason: "revision-failed-engine_implementer"`. Stop dispatching for this item. |
+   | `agent_status: in_review` | reviewer returned `VERDICT: drop` | drop. Set `agent_status: dropped`, `drop_reason: "reviewer-drop: <reviewer's drop-reason text>"`. Stop dispatching for this item. |
+
+4. **Persist state**: after processing all changes in this turn, write
+   the updated state file. Use atomic-write semantics: write to
+   `<file>.tmp` via Write, then `mv <file>.tmp <file>` via Bash.
+
+5. **Decide whether to end turn or continue**:
+   - If at least one new role-agent or reviewer was dispatched this
+     turn, end the turn with a brief one-line status summary so the
+     operator can interject. Do not poll.
+   - If every item is either `merge_ready` or `dropped`, the batch is
+     complete — proceed to Step 5 in this same turn.
+   - If you only processed an operator message and no new dispatches
+     were made, end the turn after responding.
+
+### Step 4c — reviewer dispatch
+
+When an engine-implementer returns and you're advancing to review:
+
+Spawn one `reviewer` Agent call per just-returned item, with
+`run_in_background: true` and `name: reviewer-engine-implementer-<slug>-r<revision-count>`.
+Use this prompt template:
+
+```
+You are reviewing the output of an `engine-implementer` agent for the
+Sonar-clean item **<slug>** in batch `<batch-id>`. Apply only the
+criteria below and return a structured verdict per your system prompt.
+
+--- pass criteria ---
+C1 — Exactly one file under `src/rwa_calc/` was modified. List it.
+     Use Bash `git -C <worktree_path> diff --name-only HEAD` (or
+     `git -C <main_repo_path> diff --name-only HEAD` for main_tree
+     items) to confirm.
+C2 — Every Sonar issue from the supplied list was either addressed
+     or explicitly deferred (with a reason in the agent's report).
+     Spot-check 2 fixes against the line range cited in the issue by
+     reading the file at the cited line range.
+C3 — No regulatory scalar was changed. Grep the modified hunks for
+     numeric literals that look like risk weights, CCFs, LGDs, or
+     haircuts (e.g. patterns like `0\.[0-9]+`, `1\.5`, `12\.5`). Any
+     change to such a literal versus the file at HEAD warrants
+     `revise`. Use `git -C <repo> show HEAD:<file>` and diff against
+     the modified version to surface scalar changes.
+C4 — No public API was changed. List the file's top-level `def` and
+     `class` signatures before/after — counts and parameter lists
+     must match. The single allowed exception is removal of a
+     function parameter flagged by S1172 — confirm any such removal
+     corresponds to an S1172 issue in the supplied list.
+C5 — Targeted-pytest result was PASS (or explicitly `none`, with
+     justification). The report quotes the pytest summary line.
+C6 — The engine-implementer ran arch_check + ruff + ty + tests/contracts/
+     as part of its local gate and they passed. The report confirms
+     this; if any step failed or was skipped without justification,
+     `revise`.
+
+--- prior context ---
+Sonar issues for this file:
+{{full issue list, one per line, formatted as
+  - <rule> [<severity>] line <line>: <message>}}
+
+Worktree path: {{worktree_path or "n/a (main_tree, edits in main repo)"}}
+Main repo path: {{main_repo_path}}
+File under fix: {{relative path}}
+
+--- agent output ---
+{{engine-implementer's full return value}}
+```
+
+After dispatching, set `agent_status: in_review` in the state file.
+
+### Step 4e — re-dispatch on revision
+
+When a reviewer returns `VERDICT: revise` and the revision count is 0:
+
+Spawn a fresh `engine-implementer` Agent, with `run_in_background: true`
+and `name: sonar-fix-<slug>-r1`. Prompt:
+
+```
+Your prior Sonar-fix output for **<slug>** failed review. Address the
+following feedback and resubmit. Do not re-design unless the feedback
+explicitly asks you to.
+
+--- reviewer feedback ---
+{{reviewer's "Feedback" section verbatim}}
+
+--- your prior output ---
+{{engine-implementer's prior return value}}
+
+--- original task ---
+{{original Sonar-fix prompt from Step 4a — including worktree preamble
+for worktree items and the full issue list}}
+```
+
+Increment `revision_count.engine_implementer` to 1 and set
+`agent_status: in_flight`.
+
+If a reviewer returns `VERDICT: revise` on a revised submission
+(`revision_count.engine_implementer == 1` already), do not retry —
+drop the item per Step 4b's table.
+
+## Step 5 — squash-merge into the current branch
+
+Skip any item with `agent_status: dropped` — its worktree branch has
+nothing to merge. Tear it down in Step 8 and keep going.
+
+Single-stream / hard-excluded items: this step is replaced by an
+in-place commit in the main tree:
+
+```
+git -C <main_repo_path> add <relative file path>
+git -C <main_repo_path> commit -m "refactor(sonar): clear <issue_count> issues in <relative file> [batch <batch-id>]"
+```
+
+Skip to Step 6.
+
+For multi-item batches, in `(critical_count desc, issue_count desc)`
+order, for every item with `current_wave: merge_ready`:
+
+```
+git -C <main_repo_path> checkout <merge-target-branch>
+git -C <main_repo_path> merge --squash sonar/<batch-id>/<slug>
+git -C <main_repo_path> commit -m "refactor(sonar): clear <issue_count> issues in <relative file> [batch <batch-id>]"
+```
+
+The pre-commit gate (`scripts/pre_commit_gate.sh`) fires on each commit
+and runs `arch_check.py` + `ruff check src/`. Substantive gating
+happens once at Step 6.
+
+### Conflict policy
+
+If `git merge --squash` reports a conflict for item X:
+
+1. `git merge --abort` (resets the index but leaves the worktree branch
+   intact).
+2. Mark item X as **dropped** in the state file with
+   `drop_reason: "merge-conflict-<files>"`. Surface to the operator:
+   "Dropped <slug>: merge conflict in <files>". The branch and
+   worktree are torn down with the others in Step 8 — the work is not
+   lost because the failing item is regenerated cleanly in a future
+   batch.
+3. Continue with the remaining items. Do **not** abort the rest of the
+   batch.
+
+Drop also applies if a per-commit hook fails for item X.
+
+## Step 6 — single global validation gate
+
+Run once, on the merged tree, in this order:
+
+```
+uv run python scripts/arch_check.py
+uv run ruff check src/ && uv run ruff format --check src/
+uv run ty src/
+uv run pytest tests/ --benchmark-skip -x
+```
+
+The full pytest suite (not just the targeted tests) — Sonar refactors
+can perturb behaviour in subtle ways, and the targeted-test selection
+during fixing is intentionally narrow.
+
+If anything fails, surface:
+- the gate command that failed,
+- the failing test names or arch_check messages,
+- a best-effort attribution to the merged item (match failing file
+  paths to the file each item targeted).
+
+**Do not proceed to Step 7 if the gate is red.** The squash commits are
+already on the feature branch — the operator decides whether to revert
+specific commits, fix forward, or push as-is for review.
+
+## Step 7 — re-query Sonar and report delta
+
+Re-run the Step 1 query against SonarCloud:
+
+```
+mcp__sonarqube__search_sonar_issues_in_projects
+  projects=["OpenAfterHours_rwa_calculator"]
+  issueStatuses=["OPEN", "CONFIRMED"]
+  ps=500
+```
+
+Note: the SonarCloud scan only re-runs after a push to a tracked
+branch, so the open-issue count may not have moved yet at this point.
+That is expected — the merged commits are local. Report the delta as
+"local (pre-push)" and remind the operator that the next CI scan after
+push will surface the actual drop.
+
+Also re-query the quality gate:
+
+```
+mcp__sonarqube__get_project_quality_gate_status
+  projectKey="OpenAfterHours_rwa_calculator"
+```
+
+Surface to the operator:
+
+```
+Batch <batch-id> complete.
+  Merged: <count> items (<sum of issue counts> issues addressed locally)
+  Dropped: <count> items (reasons: <list>)
+  Quality gate (pre-push, server-side cache): <status>
+  Next CI scan after push should reflect the local drop.
+```
+
+## Step 8 — cleanup
+
+For every item — including dropped ones — tear down the worktree and
+its branch:
+
+```
+git worktree remove --force ../rwa_calculator-sonar-<slug>
+git branch -D sonar/<batch-id>/<slug>
+```
+
+Sanity check: `git worktree list` should show only the main tree;
+`git branch --list 'sonar/<batch-id>/*'` should be empty.
+
+Delete the state file:
+
+```
+rm .claude/state/sonar-clean-<batch-id>.json
+```
+
+Do **not** push the merge-target branch from this command — pushing is
+the operator's call (they may want to inspect the diff or rebase
+first).
+
+## Constraints
+
+- Cap N at 5 even if the user asks for more.
+- Never proceed past Step 6 if the global gate is red.
+- Do not run the global gate inside any role-agent or reviewer — it
+  runs once at Step 6 on the merged tree.
+- The call graph is exactly one level deep: this orchestrator → one
+  of `engine-implementer` / `reviewer`. The orchestrator drives every
+  wave and every reviewer dispatch directly; sub-agents do not spawn
+  other sub-agents.
+- Hard cap of one revision per item. Two reviewer-`revise` verdicts on
+  the same item drops it. Reviewer-`drop` drops immediately, no
+  revision.
+- All role-agent and reviewer dispatches use `run_in_background: true`
+  with a stable, unique `name`:
+  `sonar-fix-<slug>-r<revision-count>` for fixes,
+  `reviewer-engine-implementer-<slug>-r<revision-count>` for reviews.
+  Foreground dispatch defeats the conversational supervision the state
+  file enables.
+- The state file at `.claude/state/sonar-clean-<batch-id>.json` is
+  authoritative. Read it at the start of every turn before reacting
+  to anything else. Persist via atomic write (`<file>.tmp` then
+  rename). Do not patch the JSON line by line.
+- Operator interjections during the batch are first-class. Common
+  requests: status, drop an item, inspect an output. Honor them
+  before continuing supervision work in the same turn.
+- Hard-excluded files (`engine/pipeline.py`, `contracts/protocols.py`,
+  `contracts/bundles.py`, `engine/aggregator/aggregator.py`) never
+  appear in a multi-item batch — they always run alone, in the main
+  tree, with no worktree machinery (Step 3 and Step 5's merge are both
+  skipped). Step 4's dispatch and reviewer loop are unchanged except
+  the worktree preamble is omitted.
+- Production-only scope: items must have `component` containing
+  `src/rwa_calc/`. Test, workbook, and script issues are out of scope
+  for this command — they are handled by the existing
+  `sonar-project.properties` suppressions or by separate one-off PRs.
+- Do NOT add `# noqa`, `# NOSONAR`, or rule-level suppressions in
+  source files to silence Sonar. Real fixes only; defer if you cannot
+  fix.
+- Do NOT edit `sonar-project.properties` from this command. Suppression
+  changes are a separate decision and a separate PR.

--- a/src/rwa_calc/engine/crm/processor.py
+++ b/src/rwa_calc/engine/crm/processor.py
@@ -58,6 +58,124 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Regulatory citation string (not a regulatory scalar — citation only).
+_CRR_ART_213_217 = "CRR Art. 213-217"
+
+
+def _optional_bool_col(
+    col_name: str,
+    alias: str,
+    available: bool,
+    *,
+    aggregate: str | None = None,
+) -> pl.Expr:
+    """
+    Build a Boolean column expression that falls back to literal False if absent.
+
+    When ``aggregate`` is ``"max"`` (used in group_by aggregations to flag a group
+    if any row carries the bit), apply the aggregation; otherwise return the
+    raw fill_null(False) expression.
+    """
+    if not available:
+        return pl.lit(False).alias(alias)
+    base = pl.col(col_name).fill_null(False)
+    if aggregate == "max":
+        base = base.max()
+    return base.alias(alias)
+
+
+def _build_direct_lookup(
+    exposures: pl.LazyFrame,
+    exposure_ccy_col: str,
+    *,
+    has_floor_col: bool,
+    has_sft_col: bool,
+) -> pl.LazyFrame:
+    """Build the direct (per-exposure) lookup frame."""
+    direct_cols = [
+        pl.col("exposure_reference").alias("_ben_ref_direct"),
+        pl.col("ead_for_crm").alias("_ead_direct"),
+        pl.col(exposure_ccy_col).alias("_currency_direct"),
+        pl.col("maturity_date").alias("_maturity_direct"),
+        _optional_bool_col("has_one_day_maturity_floor", "_floor_direct", has_floor_col),
+        _optional_bool_col("is_sft", "_sft_direct", has_sft_col),
+    ]
+    return exposures.select(direct_cols)
+
+
+def _build_facility_lookup(
+    exposures: pl.LazyFrame,
+    exposure_ccy_col: str,
+    pool_expr: pl.Expr,
+    *,
+    has_parent_col: bool,
+    has_floor_col: bool,
+    has_sft_col: bool,
+) -> pl.LazyFrame:
+    """Build the facility (parent_facility_reference) aggregated lookup frame."""
+    if not has_parent_col:
+        return pl.LazyFrame(
+            schema={
+                "_ben_ref_facility": pl.String,
+                "_ead_facility": pl.Float64,
+                "_ead_facility_airb": pl.Float64,
+                "_ead_facility_non_airb": pl.Float64,
+                "_currency_facility": pl.String,
+                "_maturity_facility": pl.Date,
+                "_floor_facility": pl.Boolean,
+                "_sft_facility": pl.Boolean,
+            }
+        )
+    facility_agg = [
+        pl.col("ead_for_crm").sum().alias("_ead_facility"),
+        pl.col("ead_for_crm").filter(pool_expr).sum().alias("_ead_facility_airb"),
+        pl.col("ead_for_crm").filter(~pool_expr).sum().alias("_ead_facility_non_airb"),
+        pl.col(exposure_ccy_col).first().alias("_currency_facility"),
+        pl.col("maturity_date").first().alias("_maturity_facility"),
+        # Conservative: if ANY exposure in facility has flag, flag whole facility
+        _optional_bool_col(
+            "has_one_day_maturity_floor", "_floor_facility", has_floor_col, aggregate="max"
+        ),
+        _optional_bool_col("is_sft", "_sft_facility", has_sft_col, aggregate="max"),
+    ]
+    return (
+        exposures.filter(pl.col("parent_facility_reference").is_not_null())
+        .group_by("parent_facility_reference")
+        .agg(facility_agg)
+        .with_columns(
+            pl.col("parent_facility_reference").cast(pl.String),
+        )
+        .rename({"parent_facility_reference": "_ben_ref_facility"})
+    )
+
+
+def _build_cp_lookup(
+    exposures: pl.LazyFrame,
+    exposure_ccy_col: str,
+    pool_expr: pl.Expr,
+    *,
+    has_floor_col: bool,
+    has_sft_col: bool,
+) -> pl.LazyFrame:
+    """Build the counterparty-aggregated lookup frame."""
+    cp_agg = [
+        pl.col("ead_for_crm").sum().alias("_ead_cp"),
+        pl.col("ead_for_crm").filter(pool_expr).sum().alias("_ead_cp_airb"),
+        pl.col("ead_for_crm").filter(~pool_expr).sum().alias("_ead_cp_non_airb"),
+        pl.col(exposure_ccy_col).first().alias("_currency_cp"),
+        pl.col("maturity_date").first().alias("_maturity_cp"),
+        # Conservative: if ANY exposure for counterparty has flag, flag whole group
+        _optional_bool_col(
+            "has_one_day_maturity_floor", "_floor_cp", has_floor_col, aggregate="max"
+        ),
+        _optional_bool_col("is_sft", "_sft_cp", has_sft_col, aggregate="max"),
+    ]
+    return (
+        exposures.group_by("counterparty_reference")
+        .agg(cp_agg)
+        .rename({"counterparty_reference": "_ben_ref_cp"})
+    )
+
 
 def _build_exposure_lookups(
     exposures: pl.LazyFrame,
@@ -86,116 +204,47 @@ def _build_exposure_lookups(
         aggregates.
     """
     exp_schema = exposures.collect_schema()
+    schema_names = exp_schema.names()
 
-    # Determine whether has_one_day_maturity_floor is available
-    has_floor_col = "has_one_day_maturity_floor" in exp_schema.names()
-    has_sft_col = "is_sft" in exp_schema.names()
-    has_pool_col = "_is_airb_pool" in exp_schema.names()
+    # Determine whether optional columns are available
+    has_floor_col = "has_one_day_maturity_floor" in schema_names
+    has_sft_col = "is_sft" in schema_names
+    has_pool_col = "_is_airb_pool" in schema_names
+    has_parent_col = "parent_facility_reference" in schema_names
     pool_expr = pl.col("_is_airb_pool").fill_null(False) if has_pool_col else pl.lit(False)
 
     # Graceful fallback for direct unit-test callers that hand-build the
     # exposures frame without going through _initialize_ead.  Production
     # always supplies ead_for_crm; test fixtures with pure on-BS rows can
     # fall back to ead_gross with no semantic change.
-    if "ead_for_crm" not in exp_schema.names():  # arch-exempt: test-fallback default
+    if "ead_for_crm" not in schema_names:  # arch-exempt: test-fallback default
         exposures = exposures.with_columns(pl.col("ead_gross").alias("ead_for_crm"))
 
     # Use pre-FX-conversion currency for downstream Art. 224 H_fx mismatch check.
     # After FX conversion the `currency` column holds the reporting currency, so a
     # raw `currency` join would silently zero the collateral FX haircut (P1.135).
-    exposure_ccy_col = (
-        "original_currency" if "original_currency" in exp_schema.names() else "currency"
-    )
+    exposure_ccy_col = "original_currency" if "original_currency" in schema_names else "currency"
 
     # Direct: one row per exposure.  CRR Art. 223(4) / PS1/26 Art. 223(4):
     # off-BS items must be valued at 100% of nominal for CRM purposes, so
     # all pro-rata bases use ead_for_crm rather than the post-CCF ead_gross.
-    direct_cols = [
-        pl.col("exposure_reference").alias("_ben_ref_direct"),
-        pl.col("ead_for_crm").alias("_ead_direct"),
-        pl.col(exposure_ccy_col).alias("_currency_direct"),
-        pl.col("maturity_date").alias("_maturity_direct"),
-    ]
-    if has_floor_col:
-        direct_cols.append(
-            pl.col("has_one_day_maturity_floor").fill_null(False).alias("_floor_direct")
-        )
-    else:
-        direct_cols.append(pl.lit(False).alias("_floor_direct"))
-    if has_sft_col:
-        direct_cols.append(pl.col("is_sft").fill_null(False).alias("_sft_direct"))
-    else:
-        direct_cols.append(pl.lit(False).alias("_sft_direct"))
-    direct_lookup = exposures.select(direct_cols)
-
-    # Facility: aggregated per parent_facility_reference
-    if "parent_facility_reference" in exp_schema.names():
-        facility_agg = [
-            pl.col("ead_for_crm").sum().alias("_ead_facility"),
-            pl.col("ead_for_crm").filter(pool_expr).sum().alias("_ead_facility_airb"),
-            pl.col("ead_for_crm").filter(~pool_expr).sum().alias("_ead_facility_non_airb"),
-            pl.col(exposure_ccy_col).first().alias("_currency_facility"),
-            pl.col("maturity_date").first().alias("_maturity_facility"),
-        ]
-        if has_floor_col:
-            # Conservative: if ANY exposure in facility has 1-day floor, flag whole facility
-            facility_agg.append(
-                pl.col("has_one_day_maturity_floor").fill_null(False).max().alias("_floor_facility")
-            )
-        else:
-            facility_agg.append(pl.lit(False).alias("_floor_facility"))
-        if has_sft_col:
-            # Conservative: if ANY exposure in facility is_sft, flag whole facility
-            facility_agg.append(pl.col("is_sft").fill_null(False).max().alias("_sft_facility"))
-        else:
-            facility_agg.append(pl.lit(False).alias("_sft_facility"))
-        facility_lookup = (
-            exposures.filter(pl.col("parent_facility_reference").is_not_null())
-            .group_by("parent_facility_reference")
-            .agg(facility_agg)
-            .with_columns(
-                pl.col("parent_facility_reference").cast(pl.String),
-            )
-            .rename({"parent_facility_reference": "_ben_ref_facility"})
-        )
-    else:
-        facility_lookup = pl.LazyFrame(
-            schema={
-                "_ben_ref_facility": pl.String,
-                "_ead_facility": pl.Float64,
-                "_ead_facility_airb": pl.Float64,
-                "_ead_facility_non_airb": pl.Float64,
-                "_currency_facility": pl.String,
-                "_maturity_facility": pl.Date,
-                "_floor_facility": pl.Boolean,
-                "_sft_facility": pl.Boolean,
-            }
-        )
-
-    # Counterparty: aggregated per counterparty_reference
-    cp_agg = [
-        pl.col("ead_for_crm").sum().alias("_ead_cp"),
-        pl.col("ead_for_crm").filter(pool_expr).sum().alias("_ead_cp_airb"),
-        pl.col("ead_for_crm").filter(~pool_expr).sum().alias("_ead_cp_non_airb"),
-        pl.col(exposure_ccy_col).first().alias("_currency_cp"),
-        pl.col("maturity_date").first().alias("_maturity_cp"),
-    ]
-    if has_floor_col:
-        # Conservative: if ANY exposure for counterparty has 1-day floor, flag whole group
-        cp_agg.append(
-            pl.col("has_one_day_maturity_floor").fill_null(False).max().alias("_floor_cp")
-        )
-    else:
-        cp_agg.append(pl.lit(False).alias("_floor_cp"))
-    if has_sft_col:
-        # Conservative: if ANY exposure for counterparty is_sft, flag whole group
-        cp_agg.append(pl.col("is_sft").fill_null(False).max().alias("_sft_cp"))
-    else:
-        cp_agg.append(pl.lit(False).alias("_sft_cp"))
-    cp_lookup = (
-        exposures.group_by("counterparty_reference")
-        .agg(cp_agg)
-        .rename({"counterparty_reference": "_ben_ref_cp"})
+    direct_lookup = _build_direct_lookup(
+        exposures, exposure_ccy_col, has_floor_col=has_floor_col, has_sft_col=has_sft_col
+    )
+    facility_lookup = _build_facility_lookup(
+        exposures,
+        exposure_ccy_col,
+        pool_expr,
+        has_parent_col=has_parent_col,
+        has_floor_col=has_floor_col,
+        has_sft_col=has_sft_col,
+    )
+    cp_lookup = _build_cp_lookup(
+        exposures,
+        exposure_ccy_col,
+        pool_expr,
+        has_floor_col=has_floor_col,
+        has_sft_col=has_sft_col,
     )
 
     return direct_lookup, facility_lookup, cp_lookup
@@ -465,9 +514,6 @@ class CRMProcessor:
         """
         errors: list[CalculationError] = []
 
-        # Start with all exposures
-        exposures = data.all_exposures
-
         # Step 0: PRA Art. 191A(2)(e)(i) two-layer protection look-through.
         # Re-anchors collateral pledged against a guarantee onto the obligor
         # exposure when the bank elects "funded_only" — and suppresses the
@@ -479,40 +525,11 @@ class CRMProcessor:
         )
         errors.extend(look_through_errors)
 
-        # Step 1: Resolve provisions BEFORE CCF (CRR Art. 111(2))
-        # This adds provision_on_drawn, provision_on_nominal, nominal_after_provision
-        # so CCF can use the provision-adjusted nominal amount
-        if has_required_columns(data.provisions, self.PROVISION_REQUIRED_COLUMNS):
-            exposures = self.resolve_provisions(exposures, data.provisions, config)
-
-        # Step 2: Apply CCF to calculate EAD for contingents
-        # Uses nominal_after_provision when available
-        exposures = self._apply_ccf(exposures, config)
-
-        # Step 3: Initialize EAD columns
-        exposures = self._initialize_ead(exposures)
-
-        # Materialise the deep lazy plan (provisions → CCF → init_ead) once.
-        # Without this, _generate_netting_collateral's two-join matching and
-        # apply_collateral's 3 lookup collects each re-execute the full upstream
-        # plan, and the plan depth causes Polars optimizer segfaults.
-        # In streaming mode, spills to disk instead of loading into memory.
-        exposures = materialise_barrier(exposures, config, "crm_post_ead_fanout")
+        # Steps 1-3: provisions -> CCF -> init EAD -> materialise barrier
+        exposures = self._run_ead_pipeline(data, config, "crm_post_ead_fanout")
 
         # Step 3.5: Generate synthetic collateral from netting (CRR Art. 195)
-        netting_collateral = collateral_mod.generate_netting_collateral(exposures)
-        collateral: pl.LazyFrame | None = collateral_lf
-        if netting_collateral is not None:
-            # Track per-exposure netting amount for COREP col 0035
-            exposures = _join_netting_amounts(exposures, netting_collateral)
-            if collateral is not None and has_required_columns(
-                collateral, self.COLLATERAL_REQUIRED_COLUMNS
-            ):
-                collateral = pl.concat([collateral, netting_collateral], how="diagonal")
-            else:
-                collateral = netting_collateral
-        else:
-            exposures = exposures.with_columns(pl.lit(0.0).alias("on_bs_netting_amount"))
+        exposures, collateral = self._merge_netting_collateral(exposures, collateral_lf)
 
         # Step 3.6: Pre-compute FCSM columns if Simple Method is elected
         # Must run BEFORE Comprehensive Method (which is still needed for IRB LGD)
@@ -523,46 +540,9 @@ class CRMProcessor:
         # Step 4: Apply collateral (if available and valid)
         # Under Simple Method, the Comprehensive pipeline still runs for IRB LGD
         # adjustment. SA EAD reduction is undone in Step 4b.
-        collateral_applied = False
-        if has_required_columns(collateral, self.COLLATERAL_REQUIRED_COLUMNS):
-            misdirected = collateral_mod.find_misdirected_airb_model_collateral(
-                exposures, collateral, config, self._is_basel_3_1
-            )
-            for coll_ref, exp_ref in misdirected:
-                errors.append(
-                    crm_warning(
-                        ERROR_AIRB_MODEL_COLLATERAL_MISDIRECTED,
-                        f"Collateral '{coll_ref}' is flagged as is_airb_model_collateral "
-                        f"but is pledged directly to non-AIRB exposure '{exp_ref}'. "
-                        "The flag asserts the collateral is incorporated in the firm's "
-                        "internal LGD model; pledging it to a non-AIRB exposure has no "
-                        "LGD effect and is treated as zero allocation.",
-                        exposure_reference=exp_ref,
-                        regulatory_reference="CRR Art. 181 / Basel 3.1 Art. 169A",
-                    )
-                )
-            exposures = self.apply_collateral(exposures, collateral, config)
-            collateral_applied = True
-        else:
-            if collateral is not None:
-                errors.append(
-                    crm_warning(
-                        ERROR_INELIGIBLE_COLLATERAL,
-                        "Collateral data provided but missing required columns "
-                        f"{self.COLLATERAL_REQUIRED_COLUMNS}; collateral CRM skipped",
-                        regulatory_reference="CRR Art. 223-224",
-                    )
-                )
-            # No collateral: still need to set F-IRB supervisory LGD based on seniority.
-            # Under B31, AIRB Foundation/169B exposures also get formula-based LGD.
-            exposures = collateral_mod.apply_firb_supervisory_lgd_no_collateral(
-                exposures, self._is_basel_3_1, config=config
-            )
-            if use_simple_method:
-                # Add default (zero) FCSM columns when no collateral
-                from rwa_calc.engine.crm.simple_method import _add_default_fcsm_columns
-
-                exposures = _add_default_fcsm_columns(exposures)
+        exposures, collateral_applied = self._apply_collateral_step(
+            exposures, collateral, config, errors, use_simple_method=use_simple_method
+        )
 
         # Step 4b: Under Simple Method, undo SA financial collateral EAD reduction.
         # The Comprehensive pipeline reduced SA EAD by collateral_adjusted_value,
@@ -571,58 +551,10 @@ class CRMProcessor:
             exposures = undo_sa_ead_reduction(exposures)
 
         # Step 4c: Pre-compute life insurance method columns (Art. 232).
-        # Life insurance uses mapped risk weight for SA (not EAD reduction).
-        # IRB LGD handled via the waterfall (LGDS = 40%).
-        # SA EAD is not reduced because life_insurance has
-        # is_eligible_financial_collateral=False — the Comprehensive Method's
-        # eligible-only filter (collateral.py _cv aggregation) already excludes it.
-        if has_required_columns(collateral, self.COLLATERAL_REQUIRED_COLUMNS):
-            exposures = compute_life_insurance_columns(exposures, collateral, config)
-        else:
-            from rwa_calc.engine.crm.life_insurance import _add_default_life_ins_columns
-
-            exposures = _add_default_life_ins_columns(exposures)
+        exposures = self._apply_life_insurance_step(exposures, collateral, config)
 
         # Step 5: Apply guarantees (if available and valid)
-        if (
-            has_required_columns(guarantees_lf, self.GUARANTEE_REQUIRED_COLUMNS)
-            and data.counterparty_lookup is not None
-        ):
-            # Materialise guarantee lookup tables to prevent parquet re-scans.
-            guarantees_df, cp_lookup_df, ri_df = pl.collect_all(
-                [
-                    guarantees_lf,
-                    data.counterparty_lookup.counterparties,
-                    data.counterparty_lookup.rating_inheritance,
-                ]
-            )
-            exposures = self.apply_guarantees(
-                exposures,
-                guarantees_df.lazy(),
-                cp_lookup_df.lazy(),
-                config,
-                ri_df.lazy(),
-            )
-        else:
-            if guarantees_lf is not None:
-                if not has_required_columns(guarantees_lf, self.GUARANTEE_REQUIRED_COLUMNS):
-                    errors.append(
-                        crm_warning(
-                            ERROR_INVALID_GUARANTEE,
-                            "Guarantee data provided but missing required columns "
-                            f"{self.GUARANTEE_REQUIRED_COLUMNS}; guarantee CRM skipped",
-                            regulatory_reference="CRR Art. 213-217",
-                        )
-                    )
-                elif data.counterparty_lookup is None:
-                    errors.append(
-                        crm_warning(
-                            ERROR_INVALID_GUARANTEE,
-                            "Guarantee data provided but counterparty lookup is missing; "
-                            "guarantee CRM skipped",
-                            regulatory_reference="CRR Art. 213-217",
-                        )
-                    )
+        exposures = self._apply_guarantees_step(exposures, guarantees_lf, data, config, errors)
 
         # Step 6: Calculate final EAD after all CRM adjustments
         # Provisions already baked into ead_pre_crm — no double deduction
@@ -682,8 +614,6 @@ class CRMProcessor:
         """
         errors: list[CalculationError] = []
 
-        exposures = data.all_exposures
-
         # Step 0: PRA Art. 191A(2)(e)(i) two-layer protection look-through.
         # Mirrors get_crm_adjusted_bundle so the unified path honours the
         # funded-only election before any other CRM step runs.
@@ -692,61 +622,19 @@ class CRMProcessor:
         )
         errors.extend(look_through_errors)
 
-        # Steps 1-7: Same CRM processing as get_crm_adjusted_bundle
-        if has_required_columns(data.provisions, self.PROVISION_REQUIRED_COLUMNS):
-            exposures = self.resolve_provisions(exposures, data.provisions, config)
-
-        exposures = self._apply_ccf(exposures, config)
-        exposures = self._initialize_ead(exposures)
-
-        # Materialise the deep lazy plan (provisions → CCF → init_ead) once.
-        # Without this, apply_collateral's 3 lookup collects each re-execute
-        # the full upstream plan, and the final collect re-executes it again
-        # (4× total).  Collecting here means all downstream operations
-        # (collateral, guarantees, finalize, audit) work on materialised data.
-        # In streaming mode, spills to disk instead of loading into memory.
-        exposures = materialise_barrier(exposures, config, "crm_post_ead_unified")
+        # Steps 1-3: provisions -> CCF -> init EAD -> materialise barrier
+        exposures = self._run_ead_pipeline(data, config, "crm_post_ead_unified")
 
         # Generate synthetic collateral from netting (CRR Art. 195)
-        netting_collateral = collateral_mod.generate_netting_collateral(exposures)
-        collateral: pl.LazyFrame | None = collateral_lf
-        if netting_collateral is not None:
-            # Track per-exposure netting amount for COREP col 0035
-            exposures = _join_netting_amounts(exposures, netting_collateral)
-            if collateral is not None and has_required_columns(
-                collateral, self.COLLATERAL_REQUIRED_COLUMNS
-            ):
-                collateral = pl.concat([collateral, netting_collateral], how="diagonal")
-            else:
-                collateral = netting_collateral
-        else:
-            exposures = exposures.with_columns(pl.lit(0.0).alias("on_bs_netting_amount"))
+        exposures, collateral = self._merge_netting_collateral(exposures, collateral_lf)
 
-        collateral_applied = False
-        if has_required_columns(collateral, self.COLLATERAL_REQUIRED_COLUMNS):
-            exposures = self.apply_collateral(exposures, collateral, config)
-            collateral_applied = True
-        else:
-            if collateral is not None:
-                errors.append(
-                    crm_warning(
-                        ERROR_INELIGIBLE_COLLATERAL,
-                        "Collateral data provided but missing required columns "
-                        f"{self.COLLATERAL_REQUIRED_COLUMNS}; collateral CRM skipped",
-                        regulatory_reference="CRR Art. 223-224",
-                    )
-                )
-            exposures = collateral_mod.apply_firb_supervisory_lgd_no_collateral(
-                exposures, self._is_basel_3_1, config=config
-            )
+        # Step 4: Apply collateral (unified path — no misdirected-AIRB diagnostic)
+        exposures, collateral_applied = self._apply_collateral_unified_step(
+            exposures, collateral, config, errors
+        )
 
         # Pre-compute life insurance method columns (Art. 232) for SA RW mapping
-        if has_required_columns(collateral, self.COLLATERAL_REQUIRED_COLUMNS):
-            exposures = compute_life_insurance_columns(exposures, collateral, config)
-        else:
-            from rwa_calc.engine.crm.life_insurance import _add_default_life_ins_columns
-
-            exposures = _add_default_life_ins_columns(exposures)
+        exposures = self._apply_life_insurance_step(exposures, collateral, config)
 
         # Materialise after collateral before guarantee processing.
         # Collateral adds 3 lookup joins + haircuts + unified allocation;
@@ -757,44 +645,10 @@ class CRMProcessor:
             has_required_columns(guarantees_lf, self.GUARANTEE_REQUIRED_COLUMNS)
             and data.counterparty_lookup is not None
         ):
-            # Materialise exposures via barrier (disk-spill in streaming mode).
-            # Lookup tables (guarantees, counterparties, rating_inheritance)
-            # are small reference data — collect in-memory via collect_all.
             exposures = materialise_barrier(exposures, config, "crm_pre_guarantee_unified")
-            guarantees_df, cp_lookup_df, ri_df = pl.collect_all(
-                [
-                    guarantees_lf,
-                    data.counterparty_lookup.counterparties,
-                    data.counterparty_lookup.rating_inheritance,
-                ]
-            )
-            exposures = self.apply_guarantees(
-                exposures,
-                guarantees_df.lazy(),
-                cp_lookup_df.lazy(),
-                config,
-                ri_df.lazy(),
-            )
+            exposures = self._apply_guarantees_step(exposures, guarantees_lf, data, config, errors)
         else:
-            if guarantees_lf is not None:
-                if not has_required_columns(guarantees_lf, self.GUARANTEE_REQUIRED_COLUMNS):
-                    errors.append(
-                        crm_warning(
-                            ERROR_INVALID_GUARANTEE,
-                            "Guarantee data provided but missing required columns "
-                            f"{self.GUARANTEE_REQUIRED_COLUMNS}; guarantee CRM skipped",
-                            regulatory_reference="CRR Art. 213-217",
-                        )
-                    )
-                elif data.counterparty_lookup is None:
-                    errors.append(
-                        crm_warning(
-                            ERROR_INVALID_GUARANTEE,
-                            "Guarantee data provided but counterparty lookup is missing; "
-                            "guarantee CRM skipped",
-                            regulatory_reference="CRR Art. 213-217",
-                        )
-                    )
+            self._collect_guarantee_skip_errors(guarantees_lf, data, errors)
             exposures = materialise_barrier(exposures, config, "crm_no_guarantee")
 
         exposures = self._finalize_ead(exposures)
@@ -813,6 +667,224 @@ class CRMProcessor:
             ),
             crm_errors=errors,
         )
+
+    # --- Internal step helpers ---
+
+    def _run_ead_pipeline(
+        self,
+        data: ClassifiedExposuresBundle,
+        config: CalculationConfig,
+        barrier_label: str,
+    ) -> pl.LazyFrame:
+        """Run provisions -> CCF -> init_ead and apply the materialise barrier."""
+        exposures = data.all_exposures
+        # Step 1: Resolve provisions BEFORE CCF (CRR Art. 111(2))
+        # This adds provision_on_drawn, provision_on_nominal, nominal_after_provision
+        # so CCF can use the provision-adjusted nominal amount
+        if has_required_columns(data.provisions, self.PROVISION_REQUIRED_COLUMNS):
+            exposures = self.resolve_provisions(exposures, data.provisions, config)
+        # Step 2: Apply CCF to calculate EAD for contingents
+        # Uses nominal_after_provision when available
+        exposures = self._apply_ccf(exposures, config)
+        # Step 3: Initialize EAD columns
+        exposures = self._initialize_ead(exposures)
+        # Materialise the deep lazy plan once.  Without this, downstream join
+        # collects each re-execute the full upstream plan, and the plan depth
+        # causes Polars optimizer segfaults.  In streaming mode, spills to disk.
+        return materialise_barrier(exposures, config, barrier_label)
+
+    def _merge_netting_collateral(
+        self,
+        exposures: pl.LazyFrame,
+        collateral_lf: pl.LazyFrame | None,
+    ) -> tuple[pl.LazyFrame, pl.LazyFrame | None]:
+        """Generate synthetic netting collateral and merge with input collateral.
+
+        Returns the (possibly joined) exposures frame and the merged collateral.
+        """
+        netting_collateral = collateral_mod.generate_netting_collateral(exposures)
+        collateral: pl.LazyFrame | None = collateral_lf
+        if netting_collateral is None:
+            exposures = exposures.with_columns(pl.lit(0.0).alias("on_bs_netting_amount"))
+            return exposures, collateral
+        # Track per-exposure netting amount for COREP col 0035
+        exposures = _join_netting_amounts(exposures, netting_collateral)
+        if collateral is not None and has_required_columns(
+            collateral, self.COLLATERAL_REQUIRED_COLUMNS
+        ):
+            collateral = pl.concat([collateral, netting_collateral], how="diagonal")
+        else:
+            collateral = netting_collateral
+        return exposures, collateral
+
+    def _apply_collateral_step(
+        self,
+        exposures: pl.LazyFrame,
+        collateral: pl.LazyFrame | None,
+        config: CalculationConfig,
+        errors: list[CalculationError],
+        *,
+        use_simple_method: bool,
+    ) -> tuple[pl.LazyFrame, bool]:
+        """Apply collateral with misdirected-AIRB diagnostics (fan-out path)."""
+        if has_required_columns(collateral, self.COLLATERAL_REQUIRED_COLUMNS):
+            assert collateral is not None  # narrowed by has_required_columns
+            self._record_misdirected_airb_errors(exposures, collateral, config, errors)
+            exposures = self.apply_collateral(exposures, collateral, config)
+            return exposures, True
+        # No (valid) collateral path
+        self._record_missing_collateral_columns(collateral, errors)
+        # No collateral: still need to set F-IRB supervisory LGD based on seniority.
+        # Under B31, AIRB Foundation/169B exposures also get formula-based LGD.
+        exposures = collateral_mod.apply_firb_supervisory_lgd_no_collateral(
+            exposures, self._is_basel_3_1, config=config
+        )
+        if use_simple_method:
+            # Add default (zero) FCSM columns when no collateral
+            from rwa_calc.engine.crm.simple_method import _add_default_fcsm_columns
+
+            exposures = _add_default_fcsm_columns(exposures)
+        return exposures, False
+
+    def _apply_collateral_unified_step(
+        self,
+        exposures: pl.LazyFrame,
+        collateral: pl.LazyFrame | None,
+        config: CalculationConfig,
+        errors: list[CalculationError],
+    ) -> tuple[pl.LazyFrame, bool]:
+        """Apply collateral (unified path — no misdirected diagnostics)."""
+        if has_required_columns(collateral, self.COLLATERAL_REQUIRED_COLUMNS):
+            assert collateral is not None
+            exposures = self.apply_collateral(exposures, collateral, config)
+            return exposures, True
+        self._record_missing_collateral_columns(collateral, errors)
+        exposures = collateral_mod.apply_firb_supervisory_lgd_no_collateral(
+            exposures, self._is_basel_3_1, config=config
+        )
+        return exposures, False
+
+    def _record_misdirected_airb_errors(
+        self,
+        exposures: pl.LazyFrame,
+        collateral: pl.LazyFrame,
+        config: CalculationConfig,
+        errors: list[CalculationError],
+    ) -> None:
+        """Append warnings for AIRB-model-collateral pledged to non-AIRB exposures."""
+        misdirected = collateral_mod.find_misdirected_airb_model_collateral(
+            exposures, collateral, config, self._is_basel_3_1
+        )
+        for coll_ref, exp_ref in misdirected:
+            errors.append(
+                crm_warning(
+                    ERROR_AIRB_MODEL_COLLATERAL_MISDIRECTED,
+                    f"Collateral '{coll_ref}' is flagged as is_airb_model_collateral "
+                    f"but is pledged directly to non-AIRB exposure '{exp_ref}'. "
+                    "The flag asserts the collateral is incorporated in the firm's "
+                    "internal LGD model; pledging it to a non-AIRB exposure has no "
+                    "LGD effect and is treated as zero allocation.",
+                    exposure_reference=exp_ref,
+                    regulatory_reference="CRR Art. 181 / Basel 3.1 Art. 169A",
+                )
+            )
+
+    def _record_missing_collateral_columns(
+        self,
+        collateral: pl.LazyFrame | None,
+        errors: list[CalculationError],
+    ) -> None:
+        """Append a warning when collateral data is present but lacks required columns."""
+        if collateral is None:
+            return
+        errors.append(
+            crm_warning(
+                ERROR_INELIGIBLE_COLLATERAL,
+                "Collateral data provided but missing required columns "
+                f"{self.COLLATERAL_REQUIRED_COLUMNS}; collateral CRM skipped",
+                regulatory_reference="CRR Art. 223-224",
+            )
+        )
+
+    def _apply_life_insurance_step(
+        self,
+        exposures: pl.LazyFrame,
+        collateral: pl.LazyFrame | None,
+        config: CalculationConfig,
+    ) -> pl.LazyFrame:
+        """Pre-compute life insurance method columns (Art. 232).
+
+        Life insurance uses mapped risk weight for SA (not EAD reduction).
+        IRB LGD handled via the waterfall (LGDS = 40%).  SA EAD is not reduced
+        because life_insurance has is_eligible_financial_collateral=False —
+        the Comprehensive Method's eligible-only filter already excludes it.
+        """
+        if has_required_columns(collateral, self.COLLATERAL_REQUIRED_COLUMNS):
+            assert collateral is not None
+            return compute_life_insurance_columns(exposures, collateral, config)
+        from rwa_calc.engine.crm.life_insurance import _add_default_life_ins_columns
+
+        return _add_default_life_ins_columns(exposures)
+
+    def _apply_guarantees_step(
+        self,
+        exposures: pl.LazyFrame,
+        guarantees_lf: pl.LazyFrame | None,
+        data: ClassifiedExposuresBundle,
+        config: CalculationConfig,
+        errors: list[CalculationError],
+    ) -> pl.LazyFrame:
+        """Apply guarantees or record skip warnings if not applicable."""
+        if (
+            has_required_columns(guarantees_lf, self.GUARANTEE_REQUIRED_COLUMNS)
+            and data.counterparty_lookup is not None
+        ):
+            assert guarantees_lf is not None
+            # Materialise guarantee lookup tables to prevent parquet re-scans.
+            guarantees_df, cp_lookup_df, ri_df = pl.collect_all(
+                [
+                    guarantees_lf,
+                    data.counterparty_lookup.counterparties,
+                    data.counterparty_lookup.rating_inheritance,
+                ]
+            )
+            return self.apply_guarantees(
+                exposures,
+                guarantees_df.lazy(),
+                cp_lookup_df.lazy(),
+                config,
+                ri_df.lazy(),
+            )
+        self._collect_guarantee_skip_errors(guarantees_lf, data, errors)
+        return exposures
+
+    def _collect_guarantee_skip_errors(
+        self,
+        guarantees_lf: pl.LazyFrame | None,
+        data: ClassifiedExposuresBundle,
+        errors: list[CalculationError],
+    ) -> None:
+        """Append warnings when guarantee processing is skipped."""
+        if guarantees_lf is None:
+            return
+        if not has_required_columns(guarantees_lf, self.GUARANTEE_REQUIRED_COLUMNS):
+            errors.append(
+                crm_warning(
+                    ERROR_INVALID_GUARANTEE,
+                    "Guarantee data provided but missing required columns "
+                    f"{self.GUARANTEE_REQUIRED_COLUMNS}; guarantee CRM skipped",
+                    regulatory_reference=_CRR_ART_213_217,
+                )
+            )
+        elif data.counterparty_lookup is None:
+            errors.append(
+                crm_warning(
+                    ERROR_INVALID_GUARANTEE,
+                    "Guarantee data provided but counterparty lookup is missing; "
+                    "guarantee CRM skipped",
+                    regulatory_reference=_CRR_ART_213_217,
+                )
+            )
 
     # --- Thin delegation methods ---
 

--- a/src/rwa_calc/engine/hierarchy.py
+++ b/src/rwa_calc/engine/hierarchy.py
@@ -1121,56 +1121,38 @@ class HierarchyResolver:
         waterfall rows, and "_RESIDUAL" for the optional MOF residual row —
         set by ``_expand_mof_facility_undrawn``.
         """
+        col_or_null = _make_col_or_null(facility_cols)
+        col_or_false = _make_col_or_false(facility_cols)
         return [
             (pl.col("facility_reference") + pl.lit("_UNDRAWN") + pl.col("_exposure_suffix")).alias(
                 "exposure_reference"
             ),
             pl.lit("facility_undrawn").alias("exposure_type"),
-            pl.col("product_type")
-            if "product_type" in facility_cols
-            else pl.lit(None).cast(pl.String).alias("product_type"),
-            pl.col("book_code").cast(pl.String, strict=False)
-            if "book_code" in facility_cols
-            else pl.lit(None).cast(pl.String).alias("book_code"),
+            col_or_null("product_type", pl.String),
+            col_or_null("book_code", pl.String, cast=True),
             pl.coalesce(
                 pl.col("share_counterparty_reference"),
                 pl.col("counterparty_reference")
                 if "counterparty_reference" in facility_cols
                 else pl.lit(None).cast(pl.String),
             ).alias("counterparty_reference"),
-            (
-                pl.col("counterparty_reference").alias("original_counterparty_reference")
-                if "counterparty_reference" in facility_cols
-                else pl.lit(None).cast(pl.String).alias("original_counterparty_reference")
+            col_or_null(
+                "counterparty_reference", pl.String, alias="original_counterparty_reference"
             ),
-            pl.col("value_date")
-            if "value_date" in facility_cols
-            else pl.lit(None).cast(pl.Date).alias("value_date"),
-            pl.col("maturity_date")
-            if "maturity_date" in facility_cols
-            else pl.lit(None).cast(pl.Date).alias("maturity_date"),
-            pl.col("currency")
-            if "currency" in facility_cols
-            else pl.lit(None).cast(pl.String).alias("currency"),
+            col_or_null("value_date", pl.Date),
+            col_or_null("maturity_date", pl.Date),
+            col_or_null("currency", pl.String),
             pl.lit(0.0).alias("drawn_amount"),
             pl.lit(0.0).alias("interest"),
             pl.col("undrawn_amount"),
             pl.col("undrawn_amount").alias("nominal_amount"),
-            pl.col("lgd").cast(pl.Float64, strict=False)
-            if "lgd" in facility_cols
-            else pl.lit(None).cast(pl.Float64).alias("lgd"),
-            pl.col("lgd_unsecured").cast(pl.Float64, strict=False)
-            if "lgd_unsecured" in facility_cols
-            else pl.lit(None).cast(pl.Float64).alias("lgd_unsecured"),
-            pl.col("has_sufficient_collateral_data").cast(pl.Boolean, strict=False)
-            if "has_sufficient_collateral_data" in facility_cols
-            else pl.lit(None).cast(pl.Boolean).alias("has_sufficient_collateral_data"),
+            col_or_null("lgd", pl.Float64, cast=True),
+            col_or_null("lgd_unsecured", pl.Float64, cast=True),
+            col_or_null("has_sufficient_collateral_data", pl.Boolean, cast=True),
             pl.col("beel").cast(pl.Float64, strict=False).fill_null(0.0)
             if "beel" in facility_cols
             else pl.lit(0.0).alias("beel"),
-            pl.col("seniority")
-            if "seniority" in facility_cols
-            else pl.lit(None).cast(pl.String).alias("seniority"),
+            col_or_null("seniority", pl.String),
             pl.coalesce(
                 pl.col("mof_risk_type"),
                 pl.col("risk_type")
@@ -1178,60 +1160,26 @@ class HierarchyResolver:
                 else pl.lit(None).cast(pl.String),
             ).alias("risk_type"),
             pl.col("mof_risk_type_source"),
-            pl.col("underlying_risk_type")
-            if "underlying_risk_type" in facility_cols
-            else pl.lit(None).cast(pl.String).alias("underlying_risk_type"),
-            pl.col("ccf_modelled").cast(pl.Float64, strict=False)
-            if "ccf_modelled" in facility_cols
-            else pl.lit(None).cast(pl.Float64).alias("ccf_modelled"),
-            pl.col("ead_modelled").cast(pl.Float64, strict=False)
-            if "ead_modelled" in facility_cols
-            else pl.lit(None).cast(pl.Float64).alias("ead_modelled"),
-            (
-                pl.col("is_short_term_trade_lc").fill_null(False)
-                if "is_short_term_trade_lc" in facility_cols
-                else pl.lit(False).alias("is_short_term_trade_lc")
-            ),
+            col_or_null("underlying_risk_type", pl.String),
+            col_or_null("ccf_modelled", pl.Float64, cast=True),
+            col_or_null("ead_modelled", pl.Float64, cast=True),
+            col_or_false("is_short_term_trade_lc"),
             # CRR Art. 166(8)(d): facility undrawn is a credit line by construction,
             # so default True. An explicit False override flips the row to the
             # Art. 166(10) issued-item bucket (50% MR / 20% MLR). The column is
             # synthesised to True and null-filled by the entry-point normalisation,
             # so we can read it directly here.
             pl.col("is_obs_commitment"),
-            (
-                pl.col("is_payroll_loan").fill_null(False)
-                if "is_payroll_loan" in facility_cols
-                else pl.lit(False).alias("is_payroll_loan")
-            ),
-            (
-                pl.col("is_buy_to_let").fill_null(False)
-                if "is_buy_to_let" in facility_cols
-                else pl.lit(False).alias("is_buy_to_let")
-            ),
+            col_or_false("is_payroll_loan"),
+            col_or_false("is_buy_to_let"),
             # PRA PS1/26 Art. 124(3) / Art. 124K: under-construction flag drives
             # ADC classification derivation in the classifier. Facility-level
             # value flows through to facility_undrawn rows so commitments to
             # development-finance facilities also surface the flag.
-            (
-                pl.col("is_under_construction").fill_null(False)
-                if "is_under_construction" in facility_cols
-                else pl.lit(False).alias("is_under_construction")
-            ),
-            (
-                pl.col("has_one_day_maturity_floor").fill_null(False)
-                if "has_one_day_maturity_floor" in facility_cols
-                else pl.lit(False).alias("has_one_day_maturity_floor")
-            ),
-            (
-                pl.col("is_sft").fill_null(False)
-                if "is_sft" in facility_cols
-                else pl.lit(False).alias("is_sft")
-            ),
-            (
-                pl.col("effective_maturity")
-                if "effective_maturity" in facility_cols
-                else pl.lit(None).cast(pl.Float64).alias("effective_maturity")
-            ),
+            col_or_false("is_under_construction"),
+            col_or_false("has_one_day_maturity_floor"),
+            col_or_false("is_sft"),
+            col_or_null("effective_maturity", pl.Float64),
             pl.lit(False).alias("has_netting_agreement"),
             # QRRE classification fields (CRR Art. 147(5), CRE30.55).
             # Both columns are synthesised to False and null-filled by the
@@ -1244,11 +1192,7 @@ class HierarchyResolver:
                 else pl.lit(None).cast(pl.Float64).alias("facility_limit")
             ),
             # Art. 162(2A)(k): max contractual termination date for revolving M under B31
-            (
-                pl.col("facility_termination_date")
-                if "facility_termination_date" in facility_cols
-                else pl.lit(None).cast(pl.Date).alias("facility_termination_date")
-            ),
+            col_or_null("facility_termination_date", pl.Date),
             # Propagate facility reference for collateral allocation
             # This allows facility-level collateral to be linked to undrawn exposures
             pl.col("facility_reference").alias("source_facility_reference"),
@@ -2157,98 +2101,17 @@ class HierarchyResolver:
         has_fac_ref = "facility_reference" in fac_cols
         exp_schema: set[str] = set()
 
-        if has_fac_ref:
-            # Scratch: facility-side QRRE / limit / termination columns join as
-            # `_fac_*`, get coalesced into their unprefixed exposure-level
-            # counterparts (`is_revolving`, `is_qrre_transactor`, `facility_limit`,
-            # `facility_termination_date`) below, then dropped via `temp_cols`.
-            fac_select = [pl.col("facility_reference").alias("_fac_ref")]
-            if "is_revolving" in fac_cols:
-                fac_select.append(pl.col("is_revolving").fill_null(False).alias("_fac_revolving"))
-            if "is_qrre_transactor" in fac_cols:
-                fac_select.append(
-                    pl.col("is_qrre_transactor").fill_null(False).alias("_fac_transactor")
-                )
-            if "limit" in fac_cols:
-                fac_select.append(pl.col("limit").alias("_fac_limit"))
-            if "facility_termination_date" in fac_cols:
-                fac_select.append(
-                    pl.col("facility_termination_date").alias("_fac_termination_date")
-                )
-
-            fac_lookup = facilities.select(fac_select)
-            exposures = exposures.join(
-                fac_lookup,
-                left_on="parent_facility_reference",
-                right_on="_fac_ref",
-                how="left",
+        if has_fac_ref and facilities is not None:
+            exposures, exp_schema = self._join_facility_qrre_columns(
+                exposures, facilities, fac_cols
             )
-            coalesce_cols = []
-            # Single schema check covers both QRRE coalesce and default columns below
-            exp_schema = set(exposures.collect_schema().names())
-            if "_fac_revolving" in exp_schema:
-                coalesce_cols.append(
-                    pl.coalesce(pl.col("is_revolving"), pl.col("_fac_revolving"))
-                    .fill_null(False)
-                    .alias("is_revolving")
-                    if "is_revolving" in exp_schema
-                    else pl.col("_fac_revolving").fill_null(False).alias("is_revolving")
-                )
-            if "_fac_transactor" in exp_schema:
-                coalesce_cols.append(
-                    pl.coalesce(pl.col("is_qrre_transactor"), pl.col("_fac_transactor"))
-                    .fill_null(False)
-                    .alias("is_qrre_transactor")
-                    if "is_qrre_transactor" in exp_schema
-                    else pl.col("_fac_transactor").fill_null(False).alias("is_qrre_transactor")
-                )
-            if "_fac_limit" in exp_schema:
-                coalesce_cols.append(
-                    pl.coalesce(pl.col("facility_limit"), pl.col("_fac_limit")).alias(
-                        "facility_limit"
-                    )
-                    if "facility_limit" in exp_schema
-                    else pl.col("_fac_limit").alias("facility_limit")
-                )
-            if "_fac_termination_date" in exp_schema:
-                coalesce_cols.append(
-                    pl.coalesce(
-                        pl.col("facility_termination_date"),
-                        pl.col("_fac_termination_date"),
-                    ).alias("facility_termination_date")
-                    if "facility_termination_date" in exp_schema
-                    else pl.col("_fac_termination_date").alias("facility_termination_date")
-                )
-
-            if coalesce_cols:
-                exposures = exposures.with_columns(coalesce_cols)
-            # Drop temporary join columns (we know which exist from fac_cols)
-            temp_cols = []
-            if "is_revolving" in fac_cols:
-                temp_cols.append("_fac_revolving")
-            if "is_qrre_transactor" in fac_cols:
-                temp_cols.append("_fac_transactor")
-            if "limit" in fac_cols:
-                temp_cols.append("_fac_limit")
-            if "facility_termination_date" in fac_cols:
-                temp_cols.append("_fac_termination_date")
-            if temp_cols:
-                exposures = exposures.drop(temp_cols)
 
         # Ensure QRRE columns always exist with safe defaults.
         # After the facility join branch above, these columns may or may not exist
         # depending on the facility data. Reuse exp_schema from the join branch
         # (or check fresh if we skipped the branch entirely).
         qrre_schema = exp_schema if has_fac_ref else set(exposures.collect_schema().names())
-        default_cols = []
-        if "is_revolving" not in qrre_schema:
-            default_cols.append(pl.lit(False).alias("is_revolving"))
-        if "is_qrre_transactor" not in qrre_schema:
-            default_cols.append(pl.lit(False).alias("is_qrre_transactor"))
-        if "facility_limit" not in qrre_schema:
-            default_cols.append(pl.lit(None).cast(pl.Float64).alias("facility_limit"))
-        if default_cols:
-            exposures = exposures.with_columns(default_cols)
+        exposures = _apply_qrre_defaults(exposures, qrre_schema)
 
         # PRA PS1/26 Art. 121(4): the SCRA short-term window extends to self-
         # liquidating trade-finance LCs. The flag lives on the facility row;
@@ -2259,31 +2122,67 @@ class HierarchyResolver:
         # Coalesce preserves any explicit per-row value (e.g. on the synthetic
         # facility_undrawn rows that already carry the flag from their source
         # facility) and only fills nulls from the counterparty-level OR.
-        if "is_short_term_trade_lc" in fac_cols:
-            cp_trade_lc = facilities.group_by("counterparty_reference").agg(
-                pl.col("is_short_term_trade_lc").fill_null(False).any().alias("_cp_trade_lc")
-            )
-            exposures = exposures.join(
-                cp_trade_lc,
-                on="counterparty_reference",
-                how="left",
-            )
-            if "is_short_term_trade_lc" in exposures.collect_schema().names():
-                exposures = exposures.with_columns(
-                    pl.coalesce(
-                        pl.col("is_short_term_trade_lc"),
-                        pl.col("_cp_trade_lc"),
-                    )
-                    .fill_null(False)
-                    .alias("is_short_term_trade_lc")
-                )
-            else:
-                exposures = exposures.with_columns(
-                    pl.col("_cp_trade_lc").fill_null(False).alias("is_short_term_trade_lc")
-                )
-            exposures = exposures.drop("_cp_trade_lc")
+        if "is_short_term_trade_lc" in fac_cols and facilities is not None:
+            exposures = _broadcast_trade_lc_flag(exposures, facilities)
 
         return exposures
+
+    def _join_facility_qrre_columns(
+        self,
+        exposures: pl.LazyFrame,
+        facilities: pl.LazyFrame,
+        fac_cols: set[str],
+    ) -> tuple[pl.LazyFrame, set[str]]:
+        """Join facility-side QRRE / limit / termination columns onto exposures.
+
+        Scratch: facility-side QRRE / limit / termination columns join as
+        ``_fac_*``, get coalesced into their unprefixed exposure-level
+        counterparts (``is_revolving``, ``is_qrre_transactor``, ``facility_limit``,
+        ``facility_termination_date``), then dropped via ``temp_cols``.
+        """
+        # (facility column, scratch alias, exposure-level column, fill-null bool default)
+        fac_specs: tuple[tuple[str, str, str, bool], ...] = (
+            ("is_revolving", "_fac_revolving", "is_revolving", True),
+            ("is_qrre_transactor", "_fac_transactor", "is_qrre_transactor", True),
+            ("limit", "_fac_limit", "facility_limit", False),
+            (
+                "facility_termination_date",
+                "_fac_termination_date",
+                "facility_termination_date",
+                False,
+            ),
+        )
+
+        fac_select: list[pl.Expr] = [pl.col("facility_reference").alias("_fac_ref")]
+        for src_col, alias, _exp_col, fill_false in fac_specs:
+            if src_col in fac_cols:
+                expr = pl.col(src_col)
+                if fill_false:
+                    expr = expr.fill_null(False)
+                fac_select.append(expr.alias(alias))
+
+        exposures = exposures.join(
+            facilities.select(fac_select),
+            left_on="parent_facility_reference",
+            right_on="_fac_ref",
+            how="left",
+        )
+
+        # Single schema check covers both QRRE coalesce and default columns
+        exp_schema = set(exposures.collect_schema().names())
+        coalesce_cols = [
+            _build_qrre_coalesce_expr(alias, exp_col, exp_schema, fill_false)
+            for _src_col, alias, exp_col, fill_false in fac_specs
+            if alias in exp_schema
+        ]
+        if coalesce_cols:
+            exposures = exposures.with_columns(coalesce_cols)
+
+        # Drop temporary join columns (we know which exist from fac_cols)
+        temp_cols = [alias for src_col, alias, _exp_col, _fill in fac_specs if src_col in fac_cols]
+        if temp_cols:
+            exposures = exposures.drop(temp_cols)
+        return exposures, exp_schema
 
     def _attach_counterparty_rating(
         self,
@@ -2363,99 +2262,12 @@ class HierarchyResolver:
         Always returns ``exposures`` augmented with a ``has_short_term_ecai``
         boolean column (False when no override matched).
         """
-        if ratings is None:
+        st_ratings = _prepare_short_term_lookup(ratings)
+        if st_ratings is None:
             return exposures.with_columns(pl.lit(False).alias("has_short_term_ecai"))
-
-        rating_cols = set(ratings.collect_schema().names())
-        if "is_short_term" not in rating_cols:
-            return exposures.with_columns(pl.lit(False).alias("has_short_term_ecai"))
-
-        # Ensure scope columns exist so the downstream filter / join code can
-        # rely on them — legacy ratings parquet files may have only the long-
-        # term schema.
-        scope_defaults: list[pl.Expr] = []
-        if "scope_type" not in rating_cols:
-            scope_defaults.append(pl.lit(None, dtype=pl.String).alias("scope_type"))
-        if "scope_id" not in rating_cols:
-            scope_defaults.append(pl.lit(None, dtype=pl.String).alias("scope_id"))
-        if scope_defaults:
-            ratings = ratings.with_columns(scope_defaults)
-
-        # Filter to candidate short-term rows. Drop rows missing the required
-        # scope tuple — loader-side DQ flags those as DQ-RT-ST1 / DQ-RT-ST2
-        # errors; here we silently ignore them so the pipeline keeps running.
-        st_ratings = ratings.filter(
-            pl.col("is_short_term").fill_null(False)
-            & pl.col("scope_type").is_not_null()
-            & pl.col("scope_id").is_not_null()
-            & pl.col("counterparty_reference").is_not_null()
-        ).select(
-            [
-                pl.col("counterparty_reference").alias("_st_cp"),
-                pl.col("scope_type").alias("_st_scope_type"),
-                pl.col("scope_id").alias("_st_scope_id"),
-                pl.col("cqs").alias("_st_cqs"),
-                pl.col("rating_date").alias("_st_rating_date"),
-            ]
-        )
-
-        # Per-scope best-rating selection: lowest CQS, then latest date.
-        st_ratings = (
-            st_ratings.sort(
-                ["_st_cqs", "_st_rating_date"],
-                descending=[False, True],
-                nulls_last=True,
-            )
-            .group_by(["_st_cp", "_st_scope_type", "_st_scope_id"])
-            .first()
-        )
-
-        # Materialise the small short-term lookup eagerly so the three scope-
-        # specific joins below can re-use it without re-evaluating the sort.
-        st_ratings_df = st_ratings.collect()
-        if st_ratings_df.height == 0:
-            return exposures.with_columns(pl.lit(False).alias("has_short_term_ecai"))
-        st_ratings = st_ratings_df.lazy()
 
         exp_schema = set(exposures.collect_schema().names())
-
-        # Build a unified ``scope_match_key`` per exposure for each scope_type.
-        # An exposure can satisfy multiple scope_types simultaneously (e.g. a
-        # loan exposure also inherits its parent facility's short-term rating);
-        # we left-join three times in priority order and coalesce — loan-level
-        # scope wins over facility-level when both are present.
-        match_branches: list[tuple[str, pl.Expr]] = []
-        # facility scope: any exposure whose parent or root facility id matches
-        if "parent_facility_reference" in exp_schema or "root_facility_reference" in exp_schema:
-            facility_key_expr = pl.coalesce(
-                [
-                    pl.col("parent_facility_reference")
-                    if "parent_facility_reference" in exp_schema
-                    else pl.lit(None, dtype=pl.String),
-                    pl.col("root_facility_reference")
-                    if "root_facility_reference" in exp_schema
-                    else pl.lit(None, dtype=pl.String),
-                ]
-            )
-            match_branches.append(("facility", facility_key_expr))
-        # loan / contingent scope: match by exposure_reference + exposure_type
-        if "exposure_type" in exp_schema and "exposure_reference" in exp_schema:
-            match_branches.append(
-                (
-                    "loan",
-                    pl.when(pl.col("exposure_type") == "loan")
-                    .then(pl.col("exposure_reference"))
-                    .otherwise(pl.lit(None, dtype=pl.String)),
-                )
-            )
-            match_branches.append(
-                (
-                    "contingent",
-                    pl.when(pl.col("exposure_type") == "contingent")
-                    .then(pl.col("exposure_reference"))
-                    .otherwise(pl.lit(None, dtype=pl.String)),
-                )
-            )
+        match_branches = _build_short_term_match_branches(exp_schema)
 
         # Track which scope branches actually produce a match so we can
         # coalesce the resulting cqs in priority order: loan > contingent >
@@ -2583,10 +2395,8 @@ class HierarchyResolver:
             needs_facility_flag = True
         else:
             # Multi-level linking with .over() allocation weights
-            residential_collateral = all_property_collateral.filter(is_residential)
             exposures = self._join_property_collateral_multi_level(
                 exposures,
-                residential_collateral,
                 all_property_collateral,
             )
             needs_facility_flag = False
@@ -2623,7 +2433,6 @@ class HierarchyResolver:
     def _join_property_collateral_multi_level(
         self,
         exposures: pl.LazyFrame,
-        residential_collateral: pl.LazyFrame,
         all_property_collateral: pl.LazyFrame,
     ) -> pl.LazyFrame:
         """
@@ -2635,8 +2444,9 @@ class HierarchyResolver:
 
         Args:
             exposures: Exposures with total_exposure_amount column
-            residential_collateral: Filtered residential property collateral
-            all_property_collateral: All property collateral (residential + commercial)
+            all_property_collateral: All property collateral (residential + commercial);
+                residential rows are filtered inline via ``filter(is_residential)``
+                within the conditional ``group_by`` aggregate.
 
         Returns:
             Exposures with residential_collateral_value, property_collateral_value,
@@ -2896,61 +2706,18 @@ class HierarchyResolver:
         # Requires beneficiary_reference and property_ltv columns
         required_cols = {"beneficiary_reference", "property_ltv"}
         if not has_required_columns(collateral, required_cols):
-            # No valid LTV data available, add null columns — but only for
-            # columns the caller has not already populated on the exposure
-            # row. Loan / contingent fixtures may carry exposure-level
-            # ``ltv`` / ``property_type`` / ``has_income_cover`` /
-            # ``is_qualifying_re`` / ``prior_charge_ltv`` values
-            # (e.g. CRE Art. 126(2)(d) scenarios where the LTV and income-
-            # cover flags live on the loan rather than a collateral row);
-            # overwriting them here would silently break the SA real-estate
-            # branch downstream.
-            existing = set(exposures.collect_schema().names())
-            defaults: list[pl.Expr] = []
-            if "ltv" not in existing:
-                defaults.append(pl.lit(None).cast(pl.Float64).alias("ltv"))
-            if "property_type" not in existing:
-                defaults.append(pl.lit(None).cast(pl.Utf8).alias("property_type"))
-            if "has_income_cover" not in existing:
-                defaults.append(pl.lit(False).alias("has_income_cover"))
-            if "is_qualifying_re" not in existing:
-                defaults.append(pl.lit(None).cast(pl.Boolean).alias("is_qualifying_re"))
-            if "prior_charge_ltv" not in existing:
-                defaults.append(pl.lit(None).cast(pl.Float64).alias("prior_charge_ltv"))
-            return exposures.with_columns(defaults) if defaults else exposures
+            return _add_ltv_defaults_for_missing_collateral(exposures)
 
         # Check which optional columns exist on collateral
         collateral_schema = collateral.collect_schema()
         has_beneficiary_type = "beneficiary_type" in collateral_schema.names()
-        has_property_type = "property_type" in collateral_schema.names()
-        has_income_producing = "is_income_producing" in collateral_schema.names()
-        has_qualifying_re = "is_qualifying_re" in collateral_schema.names()
-        has_prior_charge_ltv = "prior_charge_ltv" in collateral_schema.names()
 
         # Filter for collateral with LTV data
         ltv_collateral = collateral.filter(pl.col("property_ltv").is_not_null())
 
-        # Build the list of columns to select from collateral
-        # Always include beneficiary_reference and property_ltv
-        _prop_type = (
-            pl.col("property_type")
-            if has_property_type
-            else pl.lit(None).cast(pl.Utf8).alias("property_type")
-        )
-        _income_cover = (
-            pl.col("is_income_producing").fill_null(False).alias("has_income_cover")
-            if has_income_producing
-            else pl.lit(False).alias("has_income_cover")
-        )
-        _qualifying_re = (
-            pl.col("is_qualifying_re")
-            if has_qualifying_re
-            else pl.lit(None).cast(pl.Boolean).alias("is_qualifying_re")
-        )
-        _prior_charge_ltv = (
-            pl.col("prior_charge_ltv")
-            if has_prior_charge_ltv
-            else pl.lit(None).cast(pl.Float64).alias("prior_charge_ltv")
+        # Build the optional collateral-column expressions used downstream.
+        _prop_type, _income_cover, _qualifying_re, _prior_charge_ltv = (
+            _build_collateral_ltv_optional_exprs(set(collateral_schema.names()))
         )
 
         if not has_beneficiary_type:
@@ -3091,6 +2858,271 @@ class HierarchyResolver:
             drop_cols.extend(f"{p}_{source_suffix}" for p in prefixes)
 
         return exposures.with_columns(coalesces).drop(drop_cols)
+
+
+def _add_ltv_defaults_for_missing_collateral(exposures: pl.LazyFrame) -> pl.LazyFrame:
+    """Append null/default LTV columns the caller has not already populated.
+
+    Loan / contingent fixtures may carry exposure-level ``ltv`` /
+    ``property_type`` / ``has_income_cover`` / ``is_qualifying_re`` /
+    ``prior_charge_ltv`` values (e.g. CRE Art. 126(2)(d) scenarios where the
+    LTV and income-cover flags live on the loan rather than a collateral row);
+    overwriting them here would silently break the SA real-estate branch
+    downstream.
+    """
+    existing = set(exposures.collect_schema().names())
+    # (output column, default expression)
+    default_specs: tuple[tuple[str, pl.Expr], ...] = (
+        ("ltv", pl.lit(None).cast(pl.Float64).alias("ltv")),
+        ("property_type", pl.lit(None).cast(pl.Utf8).alias("property_type")),
+        ("has_income_cover", pl.lit(False).alias("has_income_cover")),
+        ("is_qualifying_re", pl.lit(None).cast(pl.Boolean).alias("is_qualifying_re")),
+        ("prior_charge_ltv", pl.lit(None).cast(pl.Float64).alias("prior_charge_ltv")),
+    )
+    defaults = [expr for col, expr in default_specs if col not in existing]
+    return exposures.with_columns(defaults) if defaults else exposures
+
+
+def _build_collateral_ltv_optional_exprs(
+    collateral_cols: set[str],
+) -> tuple[pl.Expr, pl.Expr, pl.Expr, pl.Expr]:
+    """Build the four optional collateral expressions used by LTV joins.
+
+    Returns ``(property_type, income_cover, qualifying_re, prior_charge_ltv)``,
+    each falling back to a typed-null (or False for income cover) when the
+    source column is missing from the collateral frame.
+    """
+    prop_type = (
+        pl.col("property_type")
+        if "property_type" in collateral_cols
+        else pl.lit(None).cast(pl.Utf8).alias("property_type")
+    )
+    income_cover = (
+        pl.col("is_income_producing").fill_null(False).alias("has_income_cover")
+        if "is_income_producing" in collateral_cols
+        else pl.lit(False).alias("has_income_cover")
+    )
+    qualifying_re = (
+        pl.col("is_qualifying_re")
+        if "is_qualifying_re" in collateral_cols
+        else pl.lit(None).cast(pl.Boolean).alias("is_qualifying_re")
+    )
+    prior_charge_ltv = (
+        pl.col("prior_charge_ltv")
+        if "prior_charge_ltv" in collateral_cols
+        else pl.lit(None).cast(pl.Float64).alias("prior_charge_ltv")
+    )
+    return prop_type, income_cover, qualifying_re, prior_charge_ltv
+
+
+def _prepare_short_term_lookup(ratings: pl.LazyFrame | None) -> pl.LazyFrame | None:
+    """Filter, sort and materialise the short-term rating lookup.
+
+    Returns ``None`` if no short-term rows are available (i.e. ``ratings`` is
+    ``None``, the frame lacks ``is_short_term``, or the filtered set is empty).
+    The caller treats ``None`` as "no override applies — set
+    ``has_short_term_ecai=False``".
+    """
+    if ratings is None:
+        return None
+
+    rating_cols = set(ratings.collect_schema().names())
+    if "is_short_term" not in rating_cols:
+        return None
+
+    # Ensure scope columns exist so the downstream filter / join code can
+    # rely on them — legacy ratings parquet files may have only the long-
+    # term schema.
+    scope_defaults: list[pl.Expr] = []
+    if "scope_type" not in rating_cols:
+        scope_defaults.append(pl.lit(None, dtype=pl.String).alias("scope_type"))
+    if "scope_id" not in rating_cols:
+        scope_defaults.append(pl.lit(None, dtype=pl.String).alias("scope_id"))
+    if scope_defaults:
+        ratings = ratings.with_columns(scope_defaults)
+
+    # Filter to candidate short-term rows. Drop rows missing the required
+    # scope tuple — loader-side DQ flags those as DQ-RT-ST1 / DQ-RT-ST2
+    # errors; here we silently ignore them so the pipeline keeps running.
+    st_ratings = ratings.filter(
+        pl.col("is_short_term").fill_null(False)
+        & pl.col("scope_type").is_not_null()
+        & pl.col("scope_id").is_not_null()
+        & pl.col("counterparty_reference").is_not_null()
+    ).select(
+        [
+            pl.col("counterparty_reference").alias("_st_cp"),
+            pl.col("scope_type").alias("_st_scope_type"),
+            pl.col("scope_id").alias("_st_scope_id"),
+            pl.col("cqs").alias("_st_cqs"),
+            pl.col("rating_date").alias("_st_rating_date"),
+        ]
+    )
+
+    # Per-scope best-rating selection: lowest CQS, then latest date.
+    st_ratings = (
+        st_ratings.sort(
+            ["_st_cqs", "_st_rating_date"],
+            descending=[False, True],
+            nulls_last=True,
+        )
+        .group_by(["_st_cp", "_st_scope_type", "_st_scope_id"])
+        .first()
+    )
+
+    # Materialise the small short-term lookup eagerly so the three scope-
+    # specific joins below can re-use it without re-evaluating the sort.
+    st_ratings_df = st_ratings.collect()
+    if st_ratings_df.height == 0:
+        return None
+    return st_ratings_df.lazy()
+
+
+def _build_short_term_match_branches(exp_schema: set[str]) -> list[tuple[str, pl.Expr]]:
+    """Build ``(scope_type, key_expression)`` pairs for each available scope.
+
+    An exposure can satisfy multiple scope_types simultaneously (e.g. a loan
+    exposure also inherits its parent facility's short-term rating); the
+    caller left-joins each branch and coalesces in priority order so the most
+    specific scope wins (loan > contingent > facility).
+    """
+    match_branches: list[tuple[str, pl.Expr]] = []
+    # facility scope: any exposure whose parent or root facility id matches
+    has_parent = "parent_facility_reference" in exp_schema
+    has_root = "root_facility_reference" in exp_schema
+    if has_parent or has_root:
+        facility_key_expr = pl.coalesce(
+            [
+                pl.col("parent_facility_reference")
+                if has_parent
+                else pl.lit(None, dtype=pl.String),
+                pl.col("root_facility_reference") if has_root else pl.lit(None, dtype=pl.String),
+            ]
+        )
+        match_branches.append(("facility", facility_key_expr))
+    # loan / contingent scope: match by exposure_reference + exposure_type
+    if "exposure_type" in exp_schema and "exposure_reference" in exp_schema:
+        match_branches.append(
+            (
+                "loan",
+                pl.when(pl.col("exposure_type") == "loan")
+                .then(pl.col("exposure_reference"))
+                .otherwise(pl.lit(None, dtype=pl.String)),
+            )
+        )
+        match_branches.append(
+            (
+                "contingent",
+                pl.when(pl.col("exposure_type") == "contingent")
+                .then(pl.col("exposure_reference"))
+                .otherwise(pl.lit(None, dtype=pl.String)),
+            )
+        )
+    return match_branches
+
+
+def _make_col_or_null(
+    available_cols: set[str],
+):
+    """Return a builder ``(name, dtype, *, cast=False, alias=None) -> pl.Expr``.
+
+    When ``name`` is in ``available_cols`` the expression projects ``pl.col(name)``
+    (optionally ``.cast(dtype, strict=False)``); otherwise it projects a null
+    literal cast to ``dtype``. ``alias`` overrides the output column name when
+    the source name differs from the desired output name.
+    """
+
+    def builder(
+        name: str,
+        dtype: pl.DataType | type[pl.DataType],
+        *,
+        cast: bool = False,
+        alias: str | None = None,
+    ) -> pl.Expr:
+        target = alias or name
+        if name in available_cols:
+            expr = pl.col(name).cast(dtype, strict=False) if cast else pl.col(name)
+            return expr.alias(target)
+        return pl.lit(None).cast(dtype).alias(target)
+
+    return builder
+
+
+def _make_col_or_false(available_cols: set[str]):
+    """Return a builder ``(name) -> pl.Expr`` for boolean flags with False default."""
+
+    def builder(name: str) -> pl.Expr:
+        if name in available_cols:
+            return pl.col(name).fill_null(False).alias(name)
+        return pl.lit(False).alias(name)
+
+    return builder
+
+
+def _build_qrre_coalesce_expr(
+    alias: str,
+    exp_col: str,
+    exp_schema: set[str],
+    fill_false: bool,
+) -> pl.Expr:
+    """Build the coalesce / fallback expression for one QRRE column.
+
+    When ``exp_col`` already exists on the exposures frame, coalesce its value
+    with the joined ``alias`` scratch column; otherwise project the scratch
+    column directly. ``fill_false=True`` applies ``fill_null(False)`` so the
+    output column is non-null boolean.
+    """
+    expr = pl.coalesce(pl.col(exp_col), pl.col(alias)) if exp_col in exp_schema else pl.col(alias)
+    if fill_false:
+        expr = expr.fill_null(False)
+    return expr.alias(exp_col)
+
+
+def _apply_qrre_defaults(exposures: pl.LazyFrame, qrre_schema: set[str]) -> pl.LazyFrame:
+    """Ensure ``is_revolving``, ``is_qrre_transactor`` and ``facility_limit`` exist."""
+    default_specs: tuple[tuple[str, pl.Expr], ...] = (
+        ("is_revolving", pl.lit(False).alias("is_revolving")),
+        ("is_qrre_transactor", pl.lit(False).alias("is_qrre_transactor")),
+        ("facility_limit", pl.lit(None).cast(pl.Float64).alias("facility_limit")),
+    )
+    default_cols = [expr for col, expr in default_specs if col not in qrre_schema]
+    if default_cols:
+        exposures = exposures.with_columns(default_cols)
+    return exposures
+
+
+def _broadcast_trade_lc_flag(
+    exposures: pl.LazyFrame,
+    facilities: pl.LazyFrame,
+) -> pl.LazyFrame:
+    """OR-aggregate ``is_short_term_trade_lc`` per counterparty and broadcast.
+
+    Coalesces with any explicit per-row value already on the exposures frame
+    (e.g. synthetic facility_undrawn rows carrying the flag from their source
+    facility) and only fills nulls from the counterparty-level OR.
+    """
+    cp_trade_lc = facilities.group_by("counterparty_reference").agg(
+        pl.col("is_short_term_trade_lc").fill_null(False).any().alias("_cp_trade_lc")
+    )
+    exposures = exposures.join(
+        cp_trade_lc,
+        on="counterparty_reference",
+        how="left",
+    )
+    if "is_short_term_trade_lc" in exposures.collect_schema().names():
+        exposures = exposures.with_columns(
+            pl.coalesce(
+                pl.col("is_short_term_trade_lc"),
+                pl.col("_cp_trade_lc"),
+            )
+            .fill_null(False)
+            .alias("is_short_term_trade_lc")
+        )
+    else:
+        exposures = exposures.with_columns(
+            pl.col("_cp_trade_lc").fill_null(False).alias("is_short_term_trade_lc")
+        )
+    return exposures.drop("_cp_trade_lc")
 
 
 def _resolve_to_root_facility(

--- a/src/rwa_calc/engine/irb/namespace.py
+++ b/src/rwa_calc/engine/irb/namespace.py
@@ -68,6 +68,170 @@ if TYPE_CHECKING:
 
 
 # =============================================================================
+# MODULE CONSTANTS
+# =============================================================================
+
+# Repeated audit-string fragment (S1192).
+_AUDIT_LGD_LABEL = "%, LGD="
+
+# Art. 162(3) carve-out: one-day maturity floor expressed in years.
+_ONE_DAY_YEARS = 1.0 / 365.0
+
+
+# =============================================================================
+# PRIVATE MATURITY HELPERS (used by prepare_columns)
+# =============================================================================
+
+
+def _maturity_base_expr(config: CalculationConfig, names: set[str]) -> pl.Expr:
+    """Build the base maturity expression from maturity_date/termination/default."""
+    if "maturity_date" not in names:
+        return pl.lit(2.5)
+
+    maturity_from_date = (
+        pl.when(pl.col("maturity_date").is_not_null())
+        .then(_exact_fractional_years_expr(config.reporting_date, "maturity_date").clip(1.0, 5.0))
+        .otherwise(pl.lit(2.5))
+    )
+
+    if config.is_basel_3_1 and "facility_termination_date" in names and "is_revolving" in names:
+        # B31 Art. 162(2A)(k): revolving + non-null termination date → use termination date
+        maturity_from_termination = (
+            pl.when(pl.col("facility_termination_date").is_not_null())
+            .then(
+                _exact_fractional_years_expr(
+                    config.reporting_date, "facility_termination_date"
+                ).clip(1.0, 5.0)
+            )
+            .otherwise(maturity_from_date)
+        )
+        return (
+            pl.when(pl.col("is_revolving").fill_null(False))
+            .then(maturity_from_termination)
+            .otherwise(maturity_from_date)
+        )
+
+    return maturity_from_date
+
+
+def _apply_firb_sft_supervisory_maturity(
+    maturity_expr: pl.Expr, config: CalculationConfig, names: set[str]
+) -> pl.Expr:
+    """CRR Art. 162(1): F-IRB fixed supervisory maturity for repo-style SFTs (0.5y).
+
+    B31 deleted Art. 162(1); under B31 all IRB firms calculate M per Art. 162(2A).
+    """
+    if not (config.is_crr and "is_sft" in names):
+        return maturity_expr
+    return (
+        pl.when((pl.col("approach") == ApproachType.FIRB.value) & pl.col("is_sft").fill_null(False))
+        .then(pl.lit(0.5))
+        .otherwise(maturity_expr)
+    )
+
+
+def _effective_one_day_floor_flag(config: CalculationConfig, names: set[str]) -> pl.Expr:
+    """Compose the Art. 162(3) one-day maturity floor flag.
+
+    Per CRR Art. 162(3) second sub-paragraph point (b), self-liquidating short-term
+    trade-finance transactions with residual maturity <= 1y are eligible for the
+    one-day maturity floor. The engine derives ``has_one_day_maturity_floor=True``
+    from ``is_short_term_trade_lc=True`` under CRR. An explicit caller-supplied
+    True is preserved by ORing the derived flag onto the input column.
+    """
+    input_floor_flag = (
+        pl.col("has_one_day_maturity_floor").fill_null(False)
+        if "has_one_day_maturity_floor" in names
+        else pl.lit(False)
+    )
+    if not (config.is_crr and "is_short_term_trade_lc" in names and "maturity_date" in names):
+        return input_floor_flag
+
+    residual_years = (
+        pl.when(pl.col("maturity_date").is_not_null())
+        .then(_exact_fractional_years_expr(config.reporting_date, "maturity_date"))
+        .otherwise(pl.lit(None, dtype=pl.Float64))
+    )
+    derived_floor_flag = (
+        pl.col("is_short_term_trade_lc").fill_null(False)
+        & residual_years.is_not_null()
+        & (residual_years <= 1.0)
+    )
+    return input_floor_flag | derived_floor_flag
+
+
+def _build_maturity_exprs(config: CalculationConfig, names: set[str]) -> list[pl.Expr]:
+    """Build the full maturity priority chain as a list of aliased expressions.
+
+    Returns two expressions: ``maturity`` and ``has_one_day_maturity_floor``.
+    See ``IRBLazyFrame.prepare_columns`` for the priority chain documentation.
+    """
+    maturity_expr = _maturity_base_expr(config, names)
+    maturity_expr = _apply_firb_sft_supervisory_maturity(maturity_expr, config, names)
+
+    effective_floor_flag = _effective_one_day_floor_flag(config, names)
+    maturity_expr = (
+        pl.when(effective_floor_flag).then(pl.lit(_ONE_DAY_YEARS)).otherwise(maturity_expr)
+    )
+
+    # Explicit firm-supplied effective_maturity — highest priority.
+    # Clipped to [1 day, 5 years]; nulls fall through to the chain above.
+    if "effective_maturity" in names:
+        maturity_expr = (
+            pl.when(pl.col("effective_maturity").is_not_null())
+            .then(pl.col("effective_maturity").clip(_ONE_DAY_YEARS, 5.0))
+            .otherwise(maturity_expr)
+        )
+
+    return [
+        maturity_expr.alias("maturity"),
+        # Persist the derived flag so downstream consumers (formulas.py
+        # _maturity_adjustment_expr_from_pd) see the carve-out.
+        effective_floor_flag.alias("has_one_day_maturity_floor"),
+    ]
+
+
+# =============================================================================
+# PRIVATE LGD-FLOOR HELPER (used by apply_all_formulas)
+# =============================================================================
+
+
+def _lgd_floored_expr(config: CalculationConfig, schema_names: set[str], lgd_col: str) -> pl.Expr:
+    """Build the ``lgd_floored`` expression for ``apply_all_formulas``.
+
+    CRR has no LGD floor. Basel 3.1 applies per-collateral-type floors to
+    A-IRB only (F-IRB supervisory LGDs are regulatory values — not floored,
+    per CRE30.41).
+    """
+    if not config.is_basel_3_1:
+        return pl.col(lgd_col).alias("lgd_floored")
+
+    has_seniority = "seniority" in schema_names
+    has_exposure_class = "exposure_class" in schema_names
+    if "collateral_type" in schema_names:
+        lgd_floor_expr = _lgd_floor_expression_with_collateral(
+            config,
+            has_seniority=has_seniority,
+            has_exposure_class=has_exposure_class,
+        )
+    else:
+        lgd_floor_expr = _lgd_floor_expression(
+            config,
+            has_seniority=has_seniority,
+            has_exposure_class=has_exposure_class,
+        )
+    # Art. 164(4)(c) blended floor for retail with mixed collateral
+    if "crm_alloc_financial" in schema_names and has_exposure_class:
+        blended_expr = _lgd_floor_blended_expression(config)
+        lgd_floor_expr = (
+            pl.when(blended_expr.is_not_null()).then(blended_expr).otherwise(lgd_floor_expr)
+        )
+    is_airb = pl.col("is_airb").fill_null(False) if "is_airb" in schema_names else pl.lit(False)
+    floored_lgd = pl.max_horizontal(pl.col(lgd_col), lgd_floor_expr)
+    return pl.when(is_airb).then(floored_lgd).otherwise(pl.col(lgd_col)).alias("lgd_floored")
+
+
+# =============================================================================
 # LAZYFRAME NAMESPACE
 # =============================================================================
 
@@ -292,100 +456,7 @@ class IRBLazyFrame:
         # CRR F-IRB SFT supervisory M = 0.5y (Art. 162(1)) is applied to the base
         # chain (4/3) but is superseded by the two explicit overrides above.
         if "maturity" not in names:
-            if "maturity_date" in names:
-                maturity_from_date = (
-                    pl.when(pl.col("maturity_date").is_not_null())
-                    .then(
-                        _exact_fractional_years_expr(config.reporting_date, "maturity_date").clip(
-                            1.0, 5.0
-                        )
-                    )
-                    .otherwise(pl.lit(2.5))
-                )
-                has_termination = "facility_termination_date" in names
-                has_revolving = "is_revolving" in names
-                if config.is_basel_3_1 and has_termination and has_revolving:
-                    # Revolving + non-null termination date → use termination date
-                    maturity_from_termination = (
-                        pl.when(pl.col("facility_termination_date").is_not_null())
-                        .then(
-                            _exact_fractional_years_expr(
-                                config.reporting_date, "facility_termination_date"
-                            ).clip(1.0, 5.0)
-                        )
-                        .otherwise(maturity_from_date)
-                    )
-                    maturity_expr = (
-                        pl.when(pl.col("is_revolving").fill_null(False))
-                        .then(maturity_from_termination)
-                        .otherwise(maturity_from_date)
-                    )
-                else:
-                    maturity_expr = maturity_from_date
-            else:
-                maturity_expr = pl.lit(2.5)
-
-            # CRR Art. 162(1): F-IRB fixed supervisory maturity for repo-style SFTs.
-            # Repurchase / securities / commodities lending or borrowing → M = 0.5y.
-            # B31 deleted Art. 162(1); under B31 all IRB firms calculate M per Art. 162(2A).
-            if config.is_crr and "is_sft" in names:
-                maturity_expr = (
-                    pl.when(
-                        (pl.col("approach") == ApproachType.FIRB.value)
-                        & pl.col("is_sft").fill_null(False)
-                    )
-                    .then(pl.lit(0.5))
-                    .otherwise(maturity_expr)
-                )
-
-            # Art. 162(3) 1-day M floor for daily-margined SFTs/derivatives,
-            # margin lending, and short-term self-liquidating trade transactions.
-            #
-            # Per CRR Art. 162(3) second sub-paragraph point (b), self-liquidating
-            # short-term trade-finance transactions with residual maturity <= 1y
-            # are eligible for the one-day maturity floor.  The engine derives
-            # has_one_day_maturity_floor=True from is_short_term_trade_lc=True
-            # under CRR (PS1/26 wording differs and is intentionally out of scope
-            # here).  An explicit caller-supplied True is preserved by ORing the
-            # derived flag onto the input column.
-            one_day_years = 1.0 / 365.0
-            input_floor_flag = (
-                pl.col("has_one_day_maturity_floor").fill_null(False)
-                if "has_one_day_maturity_floor" in names
-                else pl.lit(False)
-            )
-            if config.is_crr and "is_short_term_trade_lc" in names and "maturity_date" in names:
-                residual_years = (
-                    pl.when(pl.col("maturity_date").is_not_null())
-                    .then(_exact_fractional_years_expr(config.reporting_date, "maturity_date"))
-                    .otherwise(pl.lit(None, dtype=pl.Float64))
-                )
-                derived_floor_flag = (
-                    pl.col("is_short_term_trade_lc").fill_null(False)
-                    & residual_years.is_not_null()
-                    & (residual_years <= 1.0)
-                )
-                effective_floor_flag = input_floor_flag | derived_floor_flag
-            else:
-                effective_floor_flag = input_floor_flag
-
-            maturity_expr = (
-                pl.when(effective_floor_flag).then(pl.lit(one_day_years)).otherwise(maturity_expr)
-            )
-
-            # Explicit firm-supplied effective_maturity — highest priority.
-            # Clipped to [1 day, 5 years]; nulls fall through to the chain above.
-            if "effective_maturity" in names:
-                maturity_expr = (
-                    pl.when(pl.col("effective_maturity").is_not_null())
-                    .then(pl.col("effective_maturity").clip(one_day_years, 5.0))
-                    .otherwise(maturity_expr)
-                )
-
-            exprs.append(maturity_expr.alias("maturity"))
-            # Persist the derived flag so downstream consumers (formulas.py
-            # _maturity_adjustment_expr_from_pd, line 709) see the carve-out.
-            exprs.append(effective_floor_flag.alias("has_one_day_maturity_floor"))
+            exprs.extend(_build_maturity_exprs(config, names))
 
         # Turnover for SME correlation adjustment
         if "turnover_m" not in names:
@@ -753,38 +824,7 @@ class IRBLazyFrame:
         # LGD floor (CRR: none, Basel 3.1: per-collateral-type for A-IRB only)
         # F-IRB supervisory LGDs are regulatory values — don't floor them (CRE30.41)
         lgd_col = "lgd_input" if "lgd_input" in schema_names else "lgd"
-        if config.is_basel_3_1:
-            has_collateral_type = "collateral_type" in schema_names
-            has_seniority = "seniority" in schema_names
-            has_exposure_class = "exposure_class" in schema_names
-            has_alloc = "crm_alloc_financial" in schema_names
-            if has_collateral_type:
-                lgd_floor_expr = _lgd_floor_expression_with_collateral(
-                    config,
-                    has_seniority=has_seniority,
-                    has_exposure_class=has_exposure_class,
-                )
-            else:
-                lgd_floor_expr = _lgd_floor_expression(
-                    config,
-                    has_seniority=has_seniority,
-                    has_exposure_class=has_exposure_class,
-                )
-            # Art. 164(4)(c) blended floor for retail with mixed collateral
-            if has_alloc and has_exposure_class:
-                blended_expr = _lgd_floor_blended_expression(config)
-                lgd_floor_expr = (
-                    pl.when(blended_expr.is_not_null()).then(blended_expr).otherwise(lgd_floor_expr)
-                )
-            is_airb = (
-                pl.col("is_airb").fill_null(False) if "is_airb" in schema_names else pl.lit(False)
-            )
-            floored_lgd = pl.max_horizontal(pl.col(lgd_col), lgd_floor_expr)
-            batch1.append(
-                pl.when(is_airb).then(floored_lgd).otherwise(pl.col(lgd_col)).alias("lgd_floored")
-            )
-        else:
-            batch1.append(pl.col(lgd_col).alias("lgd_floored"))
+        batch1.append(_lgd_floored_expr(config, schema_names, lgd_col))
 
         lf = lf.with_columns(batch1)
 
@@ -914,7 +954,7 @@ class IRBLazyFrame:
                         [
                             pl.lit("IRB DEFAULTED A-IRB: K=max(0, LGD-BEEL)="),
                             (pl.col("k") * 100).round(3).cast(pl.String),
-                            pl.lit("%, LGD="),
+                            pl.lit(_AUDIT_LGD_LABEL),
                             (pl.col("lgd_floored") * 100).round(1).cast(pl.String),
                             pl.lit("%, BEEL="),
                             (pl.col("beel").fill_null(0.0) * 100).round(1).cast(pl.String)
@@ -932,7 +972,7 @@ class IRBLazyFrame:
                 [
                     pl.lit("IRB: PD="),
                     (pl.col("pd_floored") * 100).round(2).cast(pl.String),
-                    pl.lit("%, LGD="),
+                    pl.lit(_AUDIT_LGD_LABEL),
                     (pl.col("lgd_floored") * 100).round(1).cast(pl.String),
                     pl.lit("%, R="),
                     (pl.col("correlation") * 100).round(2).cast(pl.String),
@@ -960,7 +1000,7 @@ class IRBLazyFrame:
                     [
                         pl.lit("IRB: PD="),
                         (pl.col("pd_floored") * 100).round(2).cast(pl.String),
-                        pl.lit("%, LGD="),
+                        pl.lit(_AUDIT_LGD_LABEL),
                         (pl.col("lgd_floored") * 100).round(1).cast(pl.String),
                         pl.lit("%, R="),
                         (pl.col("correlation") * 100).round(2).cast(pl.String),


### PR DESCRIPTION
## Summary
  - Adds new `/sonar-clean` slash command — parallel-worktree orchestrator that picks top N non-conflicting files from the SonarQube
  backlog and drives them through `engine-implementer` + `reviewer`. Production-only (`src/rwa_calc/`), hard-excludes shared engine files.
  - Clears 13 SonarQube issues across 3 files via the new pipeline (batch `20260517-1010`):
    - `engine/hierarchy.py` — 6 issues (S3776 cognitive complexity, S2259 None-attribute access, S1172 unused param); 9 private helpers
  extracted.
    - `engine/crm/processor.py` — 4 issues (S3776, S1192 duplicate literal); `_run_ead_pipeline` + 7 step helpers + 3 module-level
  builders extracted; introduces private `_CRR_ART_213_217` constant.
    - `engine/irb/namespace.py` — 3 issues (S3776, S1192); maturity + LGD-floor expression helpers extracted; introduces
  `_AUDIT_LGD_LABEL` and `_ONE_DAY_YEARS` constants.
  - Two S1172 `config` parameter removals deferred in `irb/namespace.py` — `classify_approach` and `calculate_expected_loss` are
  registered Polars namespace methods called positionally across `src/` and `tests/`.

  ## Scope guarantees
  - No regulatory scalars touched (risk weights, LGDs, CCFs, floors).
  - No public API changes — `CRMProcessor`, `create_crm_processor`, hierarchy resolver, and IRB namespace surface all unchanged.
  - Pure refactor: extract method, extract constant, remove dead param.

  ## Test plan
  - [x] `uv run pytest tests/ --benchmark-skip` — full suite green
  - [x] `uv run python scripts/arch_check.py` — architecture gate green (incl. watchfire citation index)
  - [x] `uv run ruff check src/rwa_calc/engine/{hierarchy,crm/processor,irb/namespace}.py`
  - [x] `uv run ty check src/rwa_calc/engine/{hierarchy,crm/processor,irb/namespace}.py`
  - [x] SonarQube re-scan confirms the 13 issues cleared and no new findings introduced