### PR TITLE
refactor(ccf): move regulatory CCF scalars to data/tables/ccf.py

### DIFF
--- a/src/rwa_calc/data/schemas.py
+++ b/src/rwa_calc/data/schemas.py
@@ -818,6 +818,26 @@ VALID_SCRA_GRADES = {"A", "A_ENHANCED", "B", "C"}
 
 VALID_RISK_TYPES_INPUT = {"FR", "FRC", "MR", "OC", "MLR", "LR"}
 
+# Lowercase synonyms accepted on input for the risk_type column. Maps every
+# permitted spelling (short code or full name) to its canonical uppercase
+# form in VALID_RISK_TYPES_INPUT. Consumed by the CCF builders in
+# data/tables/ccf.py so risk_type matching is case-insensitive and accepts
+# both "FR" and "full_risk" style inputs.
+RISK_TYPE_SYNONYMS: dict[str, str] = {
+    "fr": "FR",
+    "full_risk": "FR",
+    "frc": "FRC",
+    "full_risk_commitment": "FRC",
+    "mr": "MR",
+    "medium_risk": "MR",
+    "oc": "OC",
+    "other_commit": "OC",
+    "mlr": "MLR",
+    "medium_low_risk": "MLR",
+    "lr": "LR",
+    "low_risk": "LR",
+}
+
 VALID_BS_TYPES = {"ONB", "OFB"}
 
 VALID_CHILD_TYPES = {"facility", "loan", "contingent"}

--- a/src/rwa_calc/data/tables/ccf.py
+++ b/src/rwa_calc/data/tables/ccf.py
@@ -1,0 +1,213 @@
+"""
+Credit Conversion Factor (CCF) tables — CRR Art. 111 / 166 and PRA PS1/26 Table A1.
+
+Canonical home for the SA and F-IRB CCF percentages used by
+``engine/ccf.py`` to convert off-balance-sheet nominal amounts into
+credit-equivalent EAD. Framework selection happens at the call site via
+``CalculationConfig`` or the ``is_basel_3_1`` flag on the builder
+helpers — there is exactly one source of truth for every regulatory
+scalar in this domain.
+
+Tables (canonical dicts, keyed by the uppercase values in
+``data.schemas.VALID_RISK_TYPES_INPUT``):
+
+- ``SA_CCF_CRR``: CRR Art. 111 SA mapping (FR/FRC=100%, MR=50%,
+  OC=50%, MLR=20%, LR=0%). The OC=50% value is the conservative
+  default; ``engine.ccf._compute_ccf`` overrides it to 20% when
+  remaining maturity ≤ ``OC_SHORT_MATURITY_THRESHOLD_DAYS`` per
+  Art. 111 (OC mapped to MLR for short maturities).
+- ``SA_CCF_B31``: PRA PS1/26 Art. 111 Table A1 overrides — OC=40%
+  (Row 5) and LR/UCC=10% (Row 6); other rows reuse CRR values.
+- ``FIRB_OBS_FALLBACK``: CRR Art. 166(10) issued-OBS fallback
+  mapping (FR=100%, MR/OC=50%, MLR=20%, LR=0%).
+
+Module-level constants:
+
+- ``FIRB_TRADE_LC_CCF``: Art. 166(8)(b) short-term trade LC carve-out
+- ``FIRB_CREDIT_LINE_CCF``: Art. 166(8)(d) credit lines / NIFs / RUFs
+- ``SA_CCF_DEFAULT``: MR-equivalent unrecognised fallback
+- ``OC_SHORT_MATURITY_CCF`` / ``OC_SHORT_MATURITY_THRESHOLD_DAYS``:
+  CRR Art. 111 OC short-maturity override
+
+Builder functions return Polars expressions that consume a risk_type
+column and produce a Float64 CCF column. Decimal → float conversion
+happens in the builder; the source-of-truth tables stay Decimal.
+
+References:
+    - CRR Art. 111: SA CCF categories (FR / MR / MLR / LR)
+    - CRR Art. 166(8): F-IRB bespoke CCFs (UCC, trade LCs, credit lines)
+    - CRR Art. 166(10): F-IRB residual fallback for issued OBS items
+    - PRA PS1/26 Art. 111 Table A1: Basel 3.1 SA CCF schedule
+    - PRA PS1/26 Art. 166C: Basel 3.1 F-IRB uses SA CCFs
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import polars as pl
+from watchfire import cites
+
+from rwa_calc.data.schemas import RISK_TYPE_SYNONYMS
+
+# =============================================================================
+# SA CCF TABLES (CRR Art. 111 / PRA PS1/26 Art. 111 Table A1)
+# =============================================================================
+
+# CRR Art. 111 SA CCFs. OC=0.50 is the >1yr conservative default; the
+# engine overrides to OC_SHORT_MATURITY_CCF when remaining maturity
+# ≤ OC_SHORT_MATURITY_THRESHOLD_DAYS.
+SA_CCF_CRR: dict[str, Decimal] = {
+    "FR": Decimal("1.00"),
+    "FRC": Decimal("1.00"),
+    "MR": Decimal("0.50"),
+    "OC": Decimal("0.50"),
+    "MLR": Decimal("0.20"),
+    "LR": Decimal("0.00"),
+}
+
+# PRA PS1/26 Art. 111 Table A1: OC=0.40 (Row 5 — new category),
+# LR/UCC=0.10 (Row 6). FR/FRC/MR/MLR unchanged from CRR.
+SA_CCF_B31: dict[str, Decimal] = {
+    "FR": Decimal("1.00"),
+    "FRC": Decimal("1.00"),
+    "MR": Decimal("0.50"),
+    "OC": Decimal("0.40"),
+    "MLR": Decimal("0.20"),
+    "LR": Decimal("0.10"),
+}
+
+# CRR Art. 166(10) F-IRB residual fallback for issued OBS items not in
+# scope of Art. 166(8). Selected by the engine when
+# ``is_obs_commitment=False``.
+FIRB_OBS_FALLBACK: dict[str, Decimal] = {
+    "FR": Decimal("1.00"),
+    "FRC": Decimal("1.00"),
+    "MR": Decimal("0.50"),
+    "OC": Decimal("0.50"),
+    "MLR": Decimal("0.20"),
+    "LR": Decimal("0.00"),
+}
+
+# Art. 166(8)(b): short-term trade LC arising from movement of goods.
+FIRB_TRADE_LC_CCF: Decimal = Decimal("0.20")
+
+# Art. 166(8)(d): credit lines / NIFs / RUFs (is_obs_commitment=True).
+FIRB_CREDIT_LINE_CCF: Decimal = Decimal("0.75")
+
+# Conservative MR-equivalent fallback for unrecognised risk_type values.
+SA_CCF_DEFAULT: Decimal = Decimal("0.50")
+
+# CRR Art. 111: "other commitments" mapped to MLR (20%) when remaining
+# maturity ≤ 1 year. Both the CCF and the threshold are regulatory.
+OC_SHORT_MATURITY_CCF: Decimal = Decimal("0.20")
+OC_SHORT_MATURITY_THRESHOLD_DAYS: int = 365
+
+
+# =============================================================================
+# BUILDER HELPERS
+# =============================================================================
+
+
+def _normalize_risk_type(risk_type_col: str) -> pl.Expr:
+    """Lowercase and canonicalise a risk_type column to the uppercase keys.
+
+    Maps every spelling accepted on input (short code or full name) to
+    its canonical uppercase form via RISK_TYPE_SYNONYMS. Unrecognised
+    values pass through uppercased so the builders' ``otherwise()``
+    branch picks them up. The cast to ``pl.Utf8`` accommodates frames
+    where the column is null-typed (e.g. a literal ``[None]`` column).
+    """
+    casted = pl.col(risk_type_col).cast(pl.Utf8, strict=False).fill_null("")
+    lowered = casted.str.to_lowercase()
+    return lowered.replace_strict(RISK_TYPE_SYNONYMS, default=casted.str.to_uppercase())
+
+
+@cites("CRR Art. 111")
+def build_sa_ccf_expr(
+    risk_type_col: str = "risk_type",
+    is_basel_3_1: bool = False,
+) -> pl.Expr:
+    """Build a Polars expression that maps risk_type to SA CCFs.
+
+    Args:
+        risk_type_col: Name of the risk_type column on the frame.
+        is_basel_3_1: Select PRA PS1/26 Table A1 when True, CRR Art. 111
+            when False.
+
+    Returns:
+        Float64 Polars expression evaluating to the SA CCF.
+    """
+    table = SA_CCF_B31 if is_basel_3_1 else SA_CCF_CRR
+    canonical = _normalize_risk_type(risk_type_col)
+    return (
+        pl.when(canonical == "FR")
+        .then(pl.lit(float(table["FR"])))
+        .when(canonical == "FRC")
+        .then(pl.lit(float(table["FRC"])))
+        .when(canonical == "MR")
+        .then(pl.lit(float(table["MR"])))
+        .when(canonical == "OC")
+        .then(pl.lit(float(table["OC"])))
+        .when(canonical == "MLR")
+        .then(pl.lit(float(table["MLR"])))
+        .when(canonical == "LR")
+        .then(pl.lit(float(table["LR"])))
+        .otherwise(pl.lit(float(SA_CCF_DEFAULT)))
+    )
+
+
+@cites("CRR Art. 166")
+def build_firb_ccf_expr(risk_type_col: str = "risk_type") -> pl.Expr:
+    """Build a Polars expression for CRR F-IRB CCFs (Art. 166(8) + (10)).
+
+    Implements both F-IRB CCF clauses of CRR Article 166:
+
+    Art. 166(8) bespoke CCFs (selected when ``is_obs_commitment=True``
+    and matching the listed commitment type):
+        (a) UCC credit lines (LR risk_type) -> 0%
+        (b) Short-term trade LCs (MLR + is_short_term_trade_lc) -> 20%
+        (d) Other credit lines / NIFs / RUFs (MR/MLR/OC commitments) -> 75%
+
+    Art. 166(10) residual fallback (selected when
+    ``is_obs_commitment=False``):
+        (a) Full risk -> 100%; (b) Medium-risk -> 50%;
+        (c) Medium/low-risk -> 20%; (d) Low-risk -> 0%.
+
+    FR/FRC and LR converge to the same value under either path, so they
+    are handled before the commitment/issued split. The Art. 166(8)(b)
+    trade-LC carve-out wins over the issued/commitment split.
+
+    Args:
+        risk_type_col: Name of the risk_type column on the frame.
+
+    Returns:
+        Float64 Polars expression evaluating to the F-IRB CCF.
+    """
+    canonical = _normalize_risk_type(risk_type_col)
+    is_commitment = pl.col("is_obs_commitment").fill_null(True)
+    is_trade_lc = pl.col("is_short_term_trade_lc").fill_null(False)
+    is_mlr = canonical == "MLR"
+    is_mr_or_oc = canonical.is_in(["MR", "OC"])
+    return (
+        # FR/FRC -> 100% under both Art. 166(8) general and Art. 166(10)(a)
+        pl.when(canonical.is_in(["FR", "FRC"]))
+        .then(pl.lit(float(FIRB_OBS_FALLBACK["FR"])))
+        # LR -> 0% under both Art. 166(8)(a) and Art. 166(10)(d)
+        .when(canonical == "LR")
+        .then(pl.lit(float(FIRB_OBS_FALLBACK["LR"])))
+        # Art. 166(8)(b): short-term trade LC carve-out wins over both buckets
+        .when(is_mlr & is_trade_lc)
+        .then(pl.lit(float(FIRB_TRADE_LC_CCF)))
+        # Art. 166(8)(d): credit lines / NIFs / RUFs -> 75%
+        .when(is_commitment & (is_mr_or_oc | is_mlr))
+        .then(pl.lit(float(FIRB_CREDIT_LINE_CCF)))
+        # Art. 166(10)(b): MR / OC issued items -> 50%
+        .when(is_mr_or_oc)
+        .then(pl.lit(float(FIRB_OBS_FALLBACK["MR"])))
+        # Art. 166(10)(c): MLR issued items -> 20%
+        .when(is_mlr)
+        .then(pl.lit(float(FIRB_OBS_FALLBACK["MLR"])))
+        # Conservative MR-equivalent fallback for unrecognised risk_type values
+        .otherwise(pl.lit(float(SA_CCF_DEFAULT)))
+    )

--- a/src/rwa_calc/engine/ccf.py
+++ b/src/rwa_calc/engine/ccf.py
@@ -48,6 +48,12 @@ from typing import TYPE_CHECKING
 import polars as pl
 from watchfire import cites
 
+from rwa_calc.data.tables.ccf import (
+    OC_SHORT_MATURITY_CCF,
+    OC_SHORT_MATURITY_THRESHOLD_DAYS,
+    build_firb_ccf_expr,
+    build_sa_ccf_expr,
+)
 from rwa_calc.domain.enums import ApproachType
 
 if TYPE_CHECKING:
@@ -85,105 +91,23 @@ def sa_ccf_expression(
     risk_type_col: str = "risk_type",
     is_basel_3_1: bool = False,
 ) -> pl.Expr:
+    """Polars expression mapping risk_type to SA CCFs.
+
+    Thin wrapper over ``data.tables.ccf.build_sa_ccf_expr``. The values
+    themselves (CRR Art. 111 and PRA PS1/26 Table A1) live in the data
+    layer; this wrapper preserves the historical engine-side import path
+    and citation attribution.
     """
-    Return a Polars expression that maps risk_type to SA CCFs.
-
-    CRR (Art. 111):
-    - FR / full_risk: 100% (Row 1 — credit substitutes, guarantees)
-    - FRC / full_risk_commitment: 100% (Row 2 — repos, factoring, forward deposits)
-    - MR / medium_risk: 50%
-    - MLR / medium_low_risk: 20%
-    - OC / other_commit: 50% conservative default (CRR: 50% if >1yr, 20% if <=1yr)
-    - LR / low_risk: 0%
-
-    Basel 3.1 (PRA Art. 111 Table A1):
-    - FRC / full_risk_commitment: 100% (Row 2 — certain drawdown commitments)
-    - OC / other_commit: 40% (new category — Row 5)
-    - LR (unconditionally cancellable): 10% (Row 6)
-
-    Args:
-        risk_type_col: Name of the risk_type column (default "risk_type")
-        is_basel_3_1: Whether to apply Basel 3.1 CCF values
-
-    Returns:
-        Polars expression resolving to Float64 SA CCF values
-    """
-    normalized = pl.col(risk_type_col).fill_null("").str.to_lowercase()
-    # Basel 3.1: SA UCC/LR gets 10% instead of 0% (PRA Art. 111 Table A1 Row 6)
-    lr_ccf = 0.10 if is_basel_3_1 else 0.0
-    # Basel 3.1: "Other commitments" gets 40% (Table A1 Row 5); CRR: 50%
-    # conservative default (maturity-dependent override to 20% in _compute_ccf
-    # for <=1yr). Under CRR, OC mapped to MR (50%) or MLR (20%) by maturity.
-    oc_ccf = 0.40 if is_basel_3_1 else 0.50
-    return (
-        pl.when(normalized.is_in(["fr", "full_risk", "frc", "full_risk_commitment"]))
-        .then(pl.lit(1.0))
-        .when(normalized.is_in(["mr", "medium_risk"]))
-        .then(pl.lit(0.5))
-        .when(normalized.is_in(["oc", "other_commit"]))
-        .then(pl.lit(oc_ccf))
-        .when(normalized.is_in(["mlr", "medium_low_risk"]))
-        .then(pl.lit(0.2))
-        .when(normalized.is_in(["lr", "low_risk"]))
-        .then(pl.lit(lr_ccf))
-        .otherwise(pl.lit(0.5))  # Default to MR (50%) for SA
-    )
+    return build_sa_ccf_expr(risk_type_col, is_basel_3_1)
 
 
 @cites("CRR Art. 166")
 def _firb_ccf_for_col(risk_type_col: str = "risk_type") -> pl.Expr:
-    """Return CRR F-IRB CCF expression for a given risk_type column.
+    """Polars expression for CRR F-IRB CCFs (Art. 166(8) + (10)).
 
-    Implements both F-IRB CCF clauses of CRR Article 166:
-
-    Art. 166(8) bespoke CCFs (selected when ``is_obs_commitment=True`` and
-    matching the listed commitment type):
-        (a) UCC credit lines (LR risk_type) -> 0%
-        (b) Short-term trade LCs (MLR + is_short_term_trade_lc) -> 20%
-        (d) Other credit lines / NIFs / RUFs (MR/MLR/OC commitments) -> 75%
-
-    Art. 166(10) residual fallback (selected when ``is_obs_commitment=False``,
-    i.e. the row is an issued OBS item not in scope of Art. 166(8)):
-        (a) Full risk -> 100%; (b) Medium-risk -> 50%;
-        (c) Medium/low-risk -> 20%; (d) Low-risk -> 0%.
-
-    FR / FRC and LR converge to the same value under either path, so they are
-    handled before the commitment/issued split. The Art. 166(8)(b) trade-LC
-    carve-out also wins over the issued/commitment split (it is more specific
-    than either Art. 166(8)(d) or Art. 166(10)(c)).
-
-    This helper is reused by Art. 111(1)(c) commitment-to-issue lower-of via
-    ``underlying_risk_type``; in that path the underlying item is treated as
-    a commitment (the historical default) because no separate
-    ``underlying_is_obs_commitment`` column exists.
+    Thin wrapper over ``data.tables.ccf.build_firb_ccf_expr``.
     """
-    normalized = pl.col(risk_type_col).fill_null("").str.to_lowercase()
-    is_commitment = pl.col("is_obs_commitment").fill_null(True)
-    is_trade_lc = pl.col("is_short_term_trade_lc").fill_null(False)
-    is_mlr = normalized.is_in(["mlr", "medium_low_risk"])
-    is_mr_or_oc = normalized.is_in(["mr", "medium_risk", "oc", "other_commit"])
-    return (
-        # FR / FRC -> 100% under both Art. 166(8) general and Art. 166(10)(a)
-        pl.when(normalized.is_in(["fr", "full_risk", "frc", "full_risk_commitment"]))
-        .then(pl.lit(1.0))
-        # LR -> 0% under both Art. 166(8)(a) and Art. 166(10)(d)
-        .when(normalized.is_in(["lr", "low_risk"]))
-        .then(pl.lit(0.0))
-        # Art. 166(8)(b): short-term trade LC carve-out wins over both buckets
-        .when(is_mlr & is_trade_lc)
-        .then(pl.lit(0.2))
-        # Art. 166(8)(d): credit lines / NIFs / RUFs -> 75%
-        .when(is_commitment & (is_mr_or_oc | is_mlr))
-        .then(pl.lit(0.75))
-        # Art. 166(10)(b): MR / OC issued items -> 50%
-        .when(is_mr_or_oc)
-        .then(pl.lit(0.5))
-        # Art. 166(10)(c): MLR issued items -> 20%
-        .when(is_mlr)
-        .then(pl.lit(0.2))
-        # Conservative MR-equivalent fallback for unrecognised risk_type values
-        .otherwise(pl.lit(0.5))
-    )
+    return build_firb_ccf_expr(risk_type_col)
 
 
 class CCFCalculator:
@@ -363,11 +287,11 @@ class CCFCalculator:
                     (
                         pl.col("maturity_date").cast(pl.Date) - pl.lit(config.reporting_date)
                     ).dt.total_days()
-                    <= 365
+                    <= OC_SHORT_MATURITY_THRESHOLD_DAYS
                 )
                 exposures = exposures.with_columns(
                     pl.when(is_oc & is_short_maturity)
-                    .then(pl.lit(0.2))
+                    .then(pl.lit(float(OC_SHORT_MATURITY_CCF)))
                     .otherwise(pl.col("_sa_ccf_from_risk_type"))
                     .alias("_sa_ccf_from_risk_type"),
                 )
@@ -403,6 +327,7 @@ class CCFCalculator:
             # facilities whose SA CCF is not 100% (Table A1 Row 2 carve-out).
             # Non-revolving A-IRB must use SA CCFs from Table A1.
             # Revolving with SA CCF < 100%: own CCF with 50% SA floor (CRE32.27).
+            # TODO: move CRE32.27 0.5 floor multiplier to data/tables/airb_floors.py
             airb_revolving_ccf = pl.max_horizontal(
                 ccf_modelled_expr.fill_null(pl.col("_sa_ccf_from_risk_type")),
                 pl.col("_sa_ccf_from_risk_type") * 0.5,
@@ -472,6 +397,7 @@ class CCFCalculator:
             # Floor (b): facility-level EAD floor for Art. 166D(3) single-EAD approach
             # EAD >= on-BS EAD + 50% x (nominal x SA_CCF)
             # Under B31, F-IRB CCFs = SA CCFs (Art. 166C)
+            # TODO: move Art. 166D(5)(b) 0.5 floor multiplier to data/tables/airb_floors.py
             floor_b = (
                 pl.col("on_bs_for_ead")
                 + pl.col("nominal_after_provision") * pl.col("_sa_ccf_from_risk_type") * 0.5

--- a/tests/contracts/test_ccf_tables.py
+++ b/tests/contracts/test_ccf_tables.py
@@ -1,0 +1,184 @@
+"""Contract tests for CCF regulatory scalars living in the data layer.
+
+These tests close the convention gap that ``scripts/arch_check.py`` check 5
+cannot see: the AST checker only flags module-level UPPER_SNAKE_CASE
+assignments, but inline ``pl.lit(<float>)`` calls inside function bodies
+are equally a violation of the "regulatory values live in
+``src/rwa_calc/data/tables/``" rule documented in ``CLAUDE.md``.
+
+Two layers of assertion:
+
+1. The values in ``data/tables/ccf.py`` match the regulatory tables
+   (CRR Art. 111, PRA PS1/26 Table A1, CRR Art. 166(8)/(10)). One
+   assertion per row — documentation-as-test.
+2. ``engine/ccf.py`` does not declare any new CCF percentages inline:
+   every ``pl.lit(<float>)`` whose value appears in any CCF table must
+   come via an import from ``data/tables/ccf.py``. The two A-IRB floor
+   multipliers (CRE32.27 and Art. 166D(5)(b), both 0.5) are documented
+   exceptions pending relocation to a future ``airb_floors.py``.
+"""
+
+from __future__ import annotations
+
+import ast
+from decimal import Decimal
+from pathlib import Path
+
+from rwa_calc.data.tables.ccf import (
+    FIRB_CREDIT_LINE_CCF,
+    FIRB_OBS_FALLBACK,
+    FIRB_TRADE_LC_CCF,
+    OC_SHORT_MATURITY_CCF,
+    OC_SHORT_MATURITY_THRESHOLD_DAYS,
+    SA_CCF_B31,
+    SA_CCF_CRR,
+    SA_CCF_DEFAULT,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ENGINE_CCF = REPO_ROOT / "src" / "rwa_calc" / "engine" / "ccf.py"
+
+
+# =============================================================================
+# Layer 1 — table values match the regulatory schedules
+# =============================================================================
+
+
+def test_sa_ccf_crr_matches_art_111() -> None:
+    """CRR Art. 111: FR/FRC=100%, MR=50%, OC=50% (>1yr default), MLR=20%, LR=0%."""
+    assert {
+        "FR": Decimal("1.00"),
+        "FRC": Decimal("1.00"),
+        "MR": Decimal("0.50"),
+        "OC": Decimal("0.50"),
+        "MLR": Decimal("0.20"),
+        "LR": Decimal("0.00"),
+    } == SA_CCF_CRR
+
+
+def test_sa_ccf_b31_matches_pra_table_a1() -> None:
+    """PRA PS1/26 Art. 111 Table A1: OC=40% (Row 5), LR/UCC=10% (Row 6)."""
+    assert {
+        "FR": Decimal("1.00"),
+        "FRC": Decimal("1.00"),
+        "MR": Decimal("0.50"),
+        "OC": Decimal("0.40"),
+        "MLR": Decimal("0.20"),
+        "LR": Decimal("0.10"),
+    } == SA_CCF_B31
+
+
+def test_firb_obs_fallback_matches_art_166_10() -> None:
+    """CRR Art. 166(10): FR=100%, MR/OC=50%, MLR=20%, LR=0%."""
+    assert {
+        "FR": Decimal("1.00"),
+        "FRC": Decimal("1.00"),
+        "MR": Decimal("0.50"),
+        "OC": Decimal("0.50"),
+        "MLR": Decimal("0.20"),
+        "LR": Decimal("0.00"),
+    } == FIRB_OBS_FALLBACK
+
+
+def test_firb_bespoke_ccfs_match_art_166_8() -> None:
+    """CRR Art. 166(8): trade LC=20% (8)(b), credit lines=75% (8)(d)."""
+    assert Decimal("0.20") == FIRB_TRADE_LC_CCF
+    assert Decimal("0.75") == FIRB_CREDIT_LINE_CCF
+
+
+def test_sa_ccf_default_is_mr_equivalent() -> None:
+    """Unrecognised risk_type falls back to MR-equivalent 50% (conservative)."""
+    assert Decimal("0.50") == SA_CCF_DEFAULT
+
+
+def test_oc_short_maturity_override_matches_art_111() -> None:
+    """CRR Art. 111: OC mapped to MLR (20%) when remaining maturity <= 1yr."""
+    assert Decimal("0.20") == OC_SHORT_MATURITY_CCF
+    assert OC_SHORT_MATURITY_THRESHOLD_DAYS == 365
+
+
+# =============================================================================
+# Layer 2 — no inline pl.lit(<ccf>) literals in engine/ccf.py
+# =============================================================================
+
+# Values that show up as CCFs in the data layer but are also universally
+# common as column defaults (``interest=0.0``, ``provision=0.0``),
+# nominal-is-zero guards (``then(pl.lit(0.0))``), or A-IRB floor multipliers
+# (``* 0.5`` for CRE32.27 / Art. 166D(5)(b), tracked by TODOs in
+# ``engine/ccf.py`` pending relocation to ``data/tables/airb_floors.py``).
+# Excluded from the inline-literal scan because a hit on these values is
+# overwhelmingly likely to be structural, not a regulatory CCF. The
+# distinctive CCF values (0.10, 0.20, 0.40, 0.75) have no such structural
+# overlap and are checked strictly.
+_STRUCTURAL_OR_DEFERRED_VALUES: set[float] = {0.0, 0.5, 1.0}
+
+
+def _distinctive_ccf_values() -> set[float]:
+    """CCF percentages with no plausible non-regulatory interpretation."""
+    values: set[Decimal] = set()
+    for table in (SA_CCF_CRR, SA_CCF_B31, FIRB_OBS_FALLBACK):
+        values.update(table.values())
+    values.update(
+        {
+            FIRB_TRADE_LC_CCF,
+            FIRB_CREDIT_LINE_CCF,
+            SA_CCF_DEFAULT,
+            OC_SHORT_MATURITY_CCF,
+        }
+    )
+    return {float(v) for v in values} - _STRUCTURAL_OR_DEFERRED_VALUES
+
+
+def _iter_pl_lit_numeric_args(tree: ast.AST):
+    """Yield (lineno, float_value) for every ``pl.lit(<numeric literal>)`` call.
+
+    Excludes bool literals (``pl.lit(True)`` / ``pl.lit(False)``) because
+    ``bool`` is a subclass of ``int`` in Python and would otherwise be
+    coerced to 1.0 / 0.0 by ``float()``.
+    """
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (
+            isinstance(func, ast.Attribute)
+            and func.attr == "lit"
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "pl"
+        ):
+            continue
+        if not node.args:
+            continue
+        arg = node.args[0]
+        if (
+            isinstance(arg, ast.Constant)
+            and isinstance(arg.value, int | float)
+            and not isinstance(arg.value, bool)
+        ):
+            yield node.lineno, float(arg.value)
+
+
+def test_engine_ccf_module_has_no_inline_ccf_literals() -> None:
+    """No ``pl.lit(<float>)`` in engine/ccf.py should match a distinctive CCF.
+
+    Any new CCF percentage introduced into the engine must come via an
+    import from ``data/tables/ccf.py`` (e.g.
+    ``pl.lit(float(SA_CCF_DEFAULT))``). The scan is limited to values
+    without a plausible structural alternative — 0.0, 0.5, and 1.0 are
+    excluded because they routinely appear as column defaults, mathematical
+    zero guards, and A-IRB floor multipliers (the latter tracked by
+    ``TODO: move ... to data/tables/airb_floors.py`` comments in
+    ``engine/ccf.py``).
+    """
+    tree = ast.parse(ENGINE_CCF.read_text(encoding="utf-8"))
+    bad: set[float] = _distinctive_ccf_values()
+    violations = [
+        f"  engine/ccf.py:{lineno}: pl.lit({value!r}) matches a regulatory "
+        f"CCF table value — import from data/tables/ccf.py instead"
+        for lineno, value in _iter_pl_lit_numeric_args(tree)
+        if value in bad
+    ]
+    assert not violations, (
+        "Inline pl.lit(<ccf>) literal in engine/ccf.py — every regulatory "
+        "CCF percentage must be sourced from data/tables/ccf.py:\n" + "\n".join(violations)
+    )


### PR DESCRIPTION
## Summary

`src/rwa_calc/engine/ccf.py` was declaring regulatory CCF percentages inline (CRR Art. 111 / 166 and PRA PS1/26 Table A1), which violates the data/engine separation rule in `CLAUDE.md`:

> Regulatory values (risk weights, LGDs, CCFs, floors, scaling factors) live in `src/rwa_calc/data/tables/*.py`. `engine/**` imports these — it must not declare its own regulatory scalars or string-enum collections at module scope.

The literals slipped past `scripts/arch_check.py` check 5 only because the AST checker matches **module-level** `UPPER_SNAKE_CASE` assignments, not in-function `pl.lit(0.75)` calls. The spirit of the rule was still violated.

This PR brings `engine/ccf.py` into compliance.

## What changed

- **New `src/rwa_calc/data/tables/ccf.py`** — canonical home for `SA_CCF_CRR`, `SA_CCF_B31`, `FIRB_OBS_FALLBACK` dicts plus `FIRB_TRADE_LC_CCF`, `FIRB_CREDIT_LINE_CCF`, `SA_CCF_DEFAULT`, `OC_SHORT_MATURITY_CCF` and `OC_SHORT_MATURITY_THRESHOLD_DAYS` constants. Exposes `build_sa_ccf_expr` / `build_firb_ccf_expr` builders that mirror the pattern in `crr_risk_weights.py:232`.
- **`src/rwa_calc/engine/ccf.py`** — `sa_ccf_expression` and `_firb_ccf_for_col` collapse to thin one-line wrappers that forward to the new builders. Signatures preserved (the four import sites in `engine/hierarchy.py`, `engine/crm/guarantees.py`, and the test file are untouched). The OC short-maturity `0.2` and `365`-day literals in `_compute_ccf` now import the new constants.
- **`src/rwa_calc/data/schemas.py`** — adds `RISK_TYPE_SYNONYMS`, a lowercase→canonical alias map next to `VALID_RISK_TYPES_INPUT`, so risk_type normalisation is centralised instead of duplicated inline.
- **`tests/contracts/test_ccf_tables.py`** (new) — six tests asserting every CCF table value matches its regulatory schedule, plus an AST contract test that flags any new inline `pl.lit(<float>)` matching a distinctive CCF percentage (0.10 / 0.20 / 0.40 / 0.75). Closes the gap `arch_check.py` check 5 can't see.

## Out of scope (intentionally deferred)

The two A-IRB `0.5` floor multipliers in `engine/ccf.py` — CRE32.27 (own-CCF floored at 50 % of SA CCF) and Art. 166D(5)(b) (facility-level EAD floor) — are **floor multipliers, not CCFs**, and don't fit cohesively in the CCF table file. They've been annotated with `TODO: move ... to data/tables/airb_floors.py` comments and are pending a future PR.

## Test plan

- [x] `uv run python scripts/arch_check.py` — passes with no new entry in `REGULATORY_SCALAR_ALLOWLIST`.
- [x] `uv run ruff check` + `uv run ruff format --check` on all touched files — clean.
- [x] `uv run ty check` — clean.
- [x] `uv run pytest tests/unit/test_ccf.py` — 162 existing CCF-behaviour tests pass unchanged (the wrapper preserves the signature and values, including the case-insensitive synonym matching).
- [x] `uv run pytest tests/contracts/` — 154 contract tests pass, including the 7 new ones in `test_ccf_tables.py`.
- [x] `uv run pytest tests/ -m 'not slow and not stress'` — **6273 passed, 2 skipped** in 110s.

---
_Generated by [Claude Code](https://claude.ai/code/session_011MotuGqbMVhFVKKeBtqYQ4)_