### PR TITLE
fix(sonar): resolve 4 security hotspots — ReDoS regexes + pin pypi-publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,7 +77,7 @@ jobs:
           path: dist/
 
       - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/
 
@@ -96,4 +96,4 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/scripts/_deploy_changelog.py
+++ b/scripts/_deploy_changelog.py
@@ -47,23 +47,26 @@ def promote_unreleased(content: str, new_version: str, *, today: str | None = No
     if f"## [{new_version}]" in content:
         return content
 
-    pattern = re.compile(
-        r"## \[Unreleased\]\s*\n(?P<body>.*?)\n---\n",
-        re.DOTALL,
-    )
-    match = pattern.search(content)
+    header = "## [Unreleased]"
+    terminator = "\n---\n"
+    start = content.find(header)
+    body_start = content.find("\n", start) if start != -1 else -1
+    term_idx = content.find(terminator, body_start) if body_start != -1 else -1
 
-    if match is None:
+    if start == -1 or term_idx == -1:
         return _insert_fallback_version(content, new_version, today)
 
-    sections = _parse_subsections(match.group("body"))
+    body = content[body_start + 1 : term_idx]
+    end = term_idx + len(terminator)
+
+    sections = _parse_subsections(body)
     real_sections = _drop_placeholders(sections)
     new_version_body = _format_subsections(real_sections) or FALLBACK_SUBSECTIONS
 
     new_block = f"## [{new_version}] - {today}\n\n{new_version_body}---\n"
     replacement = f"{EMPTY_UNRELEASED_BLOCK}\n{new_block}"
 
-    return content[: match.start()] + replacement + content[match.end() :]
+    return content[:start] + replacement + content[end:]
 
 
 def update_version_table(
@@ -90,9 +93,8 @@ def _parse_subsections(body: str) -> dict[str, list[str]]:
     current: str | None = None
 
     for line in body.split("\n"):
-        header = re.match(r"^###\s+(.+?)\s*$", line)
-        if header:
-            current = header.group(1)
+        if line.startswith("###") and line[3:4].isspace():
+            current = line[3:].strip()
             sections.setdefault(current, [])
             continue
         if current is None:


### PR DESCRIPTION
Resolves the 4 open SonarQube security hotspots (none in `src/rwa_calc/` production code). 

## Changes

  **ReDoS — MEDIUM, `python:S5852`** (`scripts/_deploy_changelog.py`)
  - `promote_unreleased`: DOTALL `.*?` regex → `str.find()` slicing.
  - `_parse_subsections`: `^###\s+(.+?)\s*$` → `startswith` + `strip`.
  - Both parse the repo's own changelog (trusted input). Behaviour-preserving: `promote_unreleased`
  output on the real changelog is byte-identical to the regex version; existing tests (7) pass.
  `import re` retained (still used by unflagged `update_version_table`).

  **Unpinned action — LOW, `githubactions:S7637`** (`.github/workflows/publish.yml:80,99`)
  - `pypa/gh-action-pypi-publish@release/v1` → `@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0`,
  matching the repo's existing `setup-uv@<sha> # vX` convention.

  ## Verification
  - `tests/unit/test_deploy_changelog.py` — 7 passed
  - `ty check` — clean
  - `promote_unreleased` byte-identical to pre-change output
  - `publish.yml` parses as valid YAML
  - No suppressions. ruff formatting deferred to CI.