### PR TITLE
fix(sonar): resolve 5 reliability findings — S8519 list()[0] + S3923 …

### DIFF
--- a/src/rwa_calc/engine/ccr/sft_fccm.py
+++ b/src/rwa_calc/engine/ccr/sft_fccm.py
@@ -306,7 +306,7 @@ def _compute_exposure_haircut(
     """
     base = _lookup_haircut_unscaled(collateral_type, cqs, residual_maturity_years)
     if base is None or base == 0.0:
-        return 0.0 if base is not None else 0.0
+        return 0.0
     return scale_haircut_for_liquidation_period(base, LIQUIDATION_PERIOD_REPO)
 
 

--- a/tests/unit/crm/test_collateral_sequential_fill.py
+++ b/tests/unit/crm/test_collateral_sequential_fill.py
@@ -74,7 +74,7 @@ def _create_bundle(
     collateral_data: dict,
 ) -> ClassifiedExposuresBundle:
     """Build a ClassifiedExposuresBundle with F-IRB exposures and collateral."""
-    n = len(list(exposures_data.values())[0])
+    n = len(next(iter(exposures_data.values())))
     defaults = {
         "exposure_type": ["loan"] * n,
         "nominal_amount": [0.0] * n,
@@ -100,7 +100,7 @@ def _create_bundle(
     if "parent_facility_reference" in exposures.collect_schema().names():
         exposures = exposures.with_columns(pl.col("parent_facility_reference").cast(pl.String))
 
-    coll_n = len(list(collateral_data.values())[0])
+    coll_n = len(next(iter(collateral_data.values())))
     coll_defaults = {
         "issuer_type": [""] * coll_n,
         "issuer_cqs": [1] * coll_n,

--- a/tests/unit/test_irb_lgd_collateral.py
+++ b/tests/unit/test_irb_lgd_collateral.py
@@ -57,7 +57,7 @@ def create_classified_bundle(
     Adds required columns with defaults if not provided.
     """
     # Add default columns required by CRM processor
-    n = len(list(exposures_data.values())[0])
+    n = len(next(iter(exposures_data.values())))
     defaults = {
         "exposure_type": ["loan"] * n,
         "nominal_amount": [0.0] * n,
@@ -88,7 +88,7 @@ def create_classified_bundle(
     collateral = None
     if collateral_data:
         # Add default collateral columns required by haircut calculator
-        coll_n = len(list(collateral_data.values())[0])
+        coll_n = len(next(iter(collateral_data.values())))
         coll_defaults = {
             "issuer_type": [""] * coll_n,  # Empty string instead of None for type consistency
             "issuer_cqs": [1] * coll_n,  # Default CQS


### PR DESCRIPTION
…dead ternary

- tests/unit/crm/test_collateral_sequential_fill.py: replace len(list(d.values())[0]) with len(next(iter(d.values()))) (S8519 x2)
- tests/unit/test_irb_lgd_collateral.py: same pattern (S8519 x2)
- src/rwa_calc/engine/ccr/sft_fccm.py: collapse provably-dead ternary `0.0 if base is not None else 0.0` to `return 0.0` (S3923); accepted S1244 float-equality on the if-condition left untouched

All changes behaviour-preserving. arch_check green; affected pytest green.

