### PR TITLE
feat(config): register collateral_links in the data-source registry

### DIFF
--- a/docs/appendix/changelog.md
+++ b/docs/appendix/changelog.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- (Next release changes will go here)
+- **`collateral_links` is now auto-discovered from the standard data layout via the data-source registry.** The optional `collateral_links` input (the M:N collateral-to-beneficiary mapping shipped in v0.2.20, `COLLATERAL_LINK_SCHEMA`) was fully wired through `DataSourceConfig.from_registry()` and `_build_bundle` in `engine/loader.py`, but had no entry in the `DATA_SOURCES` registry (`config/data_sources.py`) — so `get_p("collateral_links")` always resolved to `None` and the table was never picked up from the conventional layout; a caller had to set `collateral_links_file` by hand. A new `DataSourceFile(id="collateral_links", relative_path=Path("collateral/collateral_links"), OPTIONAL)` entry (mirroring the sibling `collateral` source) now lets `DataSourceConfig.from_registry()` resolve `collateral_links_file` to `collateral/collateral_links.parquet` (or `.csv`) automatically, exactly like every other optional input. Purely additive and behaviour-preserving — firms with no `collateral_links` table still take the single-beneficiary path (loader returns `None` gracefully when the file is absent). Pinned by `tests/unit/config/test_data_sources_collateral_links.py` (7 tests: registry entry presence, relative path, OPTIONAL requirement, parquet appears in `get_optional`, `from_registry` parquet/csv population, description). Ref: CRR Art. 230-231.
 
 ### Changed
 - (Next release changes will go here)

--- a/src/rwa_calc/config/data_sources.py
+++ b/src/rwa_calc/config/data_sources.py
@@ -82,6 +82,15 @@ DATA_SOURCES = [
         description="Collateral and security details",
     ),
     DataSourceFile(
+        id="collateral_links",
+        relative_path=Path("collateral/collateral_links"),
+        requirement=RequirementLevel.OPTIONAL,
+        description=(
+            "M:N mapping of collateral items to beneficiary exposures for "
+            "substitution / sequential allocation (CRR Art. 230-231)."
+        ),
+    ),
+    DataSourceFile(
         id="guarantee",
         relative_path=Path("guarantee/guarantee"),
         requirement=RequirementLevel.OPTIONAL,

--- a/tests/unit/config/test_data_sources_collateral_links.py
+++ b/tests/unit/config/test_data_sources_collateral_links.py
@@ -1,0 +1,117 @@
+"""Unit tests for DataSourceRegistry collateral_links entry.
+
+Asserts that the registry contains a DataSourceFile for collateral links and that
+DataSourceConfig.from_registry() populates the collateral_links_file field, so the
+M:N collateral-to-beneficiary mapping is auto-discovered from the standard data
+layout like every other optional input.
+
+References:
+- CRR Art. 230-231: collateral substitution / sequential allocation
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rwa_calc.config.data_sources import DataSourceFile, DataSourceRegistry, RequirementLevel
+from rwa_calc.engine.loader import DataSourceConfig
+
+
+class TestDataSourceRegistryCollateralLinks:
+    """Tests for collateral_links entry in DataSourceRegistry."""
+
+    def test_registry_contains_collateral_links_entry(self) -> None:
+        """DataSourceRegistry should contain an entry with id 'collateral_links'."""
+        # Arrange
+        registry = DataSourceRegistry()
+
+        # Act
+        source = registry.get_by_id("collateral_links")
+
+        # Assert
+        assert source is not None, (
+            "Expected 'collateral_links' entry in DataSourceRegistry, got None"
+        )
+        assert isinstance(source, DataSourceFile)
+
+    def test_collateral_links_relative_path(self) -> None:
+        """collateral_links entry should have relative_path of 'collateral/collateral_links'."""
+        # Arrange
+        registry = DataSourceRegistry()
+
+        # Act
+        source = registry.get_by_id("collateral_links")
+
+        # Assert
+        assert source is not None
+        assert source.relative_path == Path("collateral/collateral_links"), (
+            f"Expected relative_path=Path('collateral/collateral_links'), "
+            f"got {source.relative_path!r}"
+        )
+
+    def test_collateral_links_requirement_is_optional(self) -> None:
+        """collateral_links entry should have requirement level OPTIONAL."""
+        # Arrange
+        registry = DataSourceRegistry()
+
+        # Act
+        source = registry.get_by_id("collateral_links")
+
+        # Assert
+        assert source is not None
+        assert source.requirement is RequirementLevel.OPTIONAL, (
+            f"Expected RequirementLevel.OPTIONAL, got {source.requirement!r}"
+        )
+
+    def test_collateral_links_parquet_path_in_optional_list(self) -> None:
+        """collateral/collateral_links.parquet should appear in get_optional('parquet')."""
+        # Arrange
+        registry = DataSourceRegistry()
+
+        # Act
+        optional_paths = registry.get_optional("parquet")
+
+        # Assert
+        assert Path("collateral/collateral_links.parquet") in optional_paths, (
+            f"Expected Path('collateral/collateral_links.parquet') in optional parquet paths, "
+            f"got: {optional_paths}"
+        )
+
+    def test_from_registry_parquet_populates_collateral_links_file(self) -> None:
+        """from_registry() should set collateral_links_file to collateral/collateral_links.parquet."""
+        # Arrange / Act
+        config = DataSourceConfig.from_registry()
+
+        # Assert
+        assert config.collateral_links_file == Path("collateral/collateral_links.parquet"), (
+            f"Expected collateral_links_file=Path('collateral/collateral_links.parquet'), "
+            f"got {config.collateral_links_file!r}"
+        )
+
+    def test_from_registry_csv_populates_collateral_links_file(self) -> None:
+        """from_registry(extension='csv') should set collateral_links_file to the .csv path."""
+        # Arrange / Act
+        config = DataSourceConfig.from_registry(extension="csv")
+
+        # Assert
+        assert config.collateral_links_file == Path("collateral/collateral_links.csv"), (
+            f"Expected collateral_links_file=Path('collateral/collateral_links.csv'), "
+            f"got {config.collateral_links_file!r}"
+        )
+
+    def test_collateral_links_description_mentions_collateral(self) -> None:
+        """collateral_links entry should have a non-None description mentioning 'collateral'."""
+        # Arrange
+        registry = DataSourceRegistry()
+
+        # Act
+        source = registry.get_by_id("collateral_links")
+
+        # Assert
+        assert source is not None
+        assert source.description is not None, (
+            "Expected a non-None description for collateral_links"
+        )
+        assert "collateral" in source.description.lower(), (
+            f"Expected 'collateral' in description (case-insensitive), got {source.description!r}"
+        )


### PR DESCRIPTION
Add a DataSourceFile entry for the optional collateral_links input so it is
auto-discovered from the standard data layout, like every other input.

The loader was already fully wired (DataSourceConfig.collateral_links_file,
from_registry's get_p("collateral_links"), and the _build_bundle _opt load),
but DATA_SOURCES had no matching entry, so the registry lookup always returned
None and the M:N collateral-to-beneficiary mapping (CRR Art. 230-231) was never
picked up unless a caller set collateral_links_file by hand.

Purely additive: from_registry() now resolves collateral_links_file to
collateral/collateral_links.parquet (or .csv); corpora with no table still take
the single-beneficiary path.

https://claude.ai/code/session_011Qb2tXr9rWeXLgoiC8GMwj