### PR TITLE
docs: fix install command to `uv add rwa-calc`, drop redundant app install box

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ A high-performance Risk-Weighted Assets (RWA) calculator for UK CR & CCR, suppor
 
 ## Installation
 
-*Install using pip*
-```bash
-pip install rwa-calc
-```
-**Or with uv**
+**Install with uv** (recommended)
 ```bash
 uv add rwa-calc
+```
+*Or with pip*
+```bash
+pip install rwa-calc
 ```
 
 The web UI and REST API ship with the base package — no extra required.
@@ -58,7 +58,7 @@ for the model permissions schema.
 Basel 3.1 comparison) plus a REST API and an editable Marimo workbench:
 
 ```bash
-pip install rwa-calc
+uv add rwa-calc
 rwa-ui
 # Open http://localhost:8000 in your browser (REST API + OpenAPI at /docs)
 ```

--- a/docs/appendix/changelog.md
+++ b/docs/appendix/changelog.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (Next release changes will go here)
 
 ### Changed
-- (Next release changes will go here)
+- **Docs now show `uv add rwa-calc` as the primary install command, fixing a wrong PyPI package name.** The docs landing hero (`docs/overrides/main.html`) advertised `pip install rwa-calculator` — the wrong package name (the project publishes as `rwa-calc`, not `rwa-calculator`) — so the copy-to-clipboard command would have failed. It now reads `uv add rwa-calc`. The getting-started, quickstart and interactive-UI guides are realigned to lead with `uv add rwa-calc` (pip shown as the secondary option), reflecting uv as the recommended package manager. Docs only — no calculation impact.
+- **Removed the `pip install rwa-calculator` box from the app landing page (`src/rwa_calc/ui/app/templates/landing.html`).** Anyone viewing the app's landing page is already running the app locally and has therefore already installed it, so the install command was redundant. The box remains on the *docs* landing page (`docs/overrides/main.html`), where visitors may not yet have installed the package. UI presentation only — no calculation impact.
 
 ---
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -12,31 +12,21 @@ This guide covers how to install the UK Credit Risk RWA Calculator and its depen
 
 The simplest way to install the calculator:
 
-=== "pip"
-
-    ```bash
-    pip install rwa-calc
-    ```
-
 === "uv"
 
     ```bash
     uv add rwa-calc
     ```
 
-### Optional Dependencies
-
-The calculator provides several optional dependency groups:
-
 === "pip"
 
     ```bash
-    # UI support (Marimo web interface)
-    pip install rwa-calc[ui]
-
-    # Everything (ui and dev dependencies)
-    pip install rwa-calc[all]
+    pip install rwa-calc
     ```
+
+### Optional Dependencies
+
+The calculator provides several optional dependency groups:
 
 === "uv"
 
@@ -48,6 +38,16 @@ The calculator provides several optional dependency groups:
     uv add rwa-calc[all]
     ```
 
+=== "pip"
+
+    ```bash
+    # UI support (Marimo web interface)
+    pip install rwa-calc[ui]
+
+    # Everything (ui and dev dependencies)
+    pip install rwa-calc[all]
+    ```
+
 | Extra | Description |
 |-------|-------------|
 | `ui` | Interactive web UI via Marimo for exploration and testing |
@@ -57,7 +57,7 @@ The calculator provides several optional dependency groups:
 !!! tip "Recommended Installation"
     For most users, we recommend installing with `ui` for the interactive web interface:
     ```bash
-    pip install rwa-calc[ui]
+    uv add rwa-calc[ui]
     ```
 
 ---

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -20,9 +20,9 @@ The fastest way to get started is the web-based interface.
 ### Step 1: Install
 
 ```bash
-pip install rwa-calc
-# Or with uv
 uv add rwa-calc
+# Or with pip
+pip install rwa-calc
 ```
 
 The UI dependencies ship with the base package — no extra is required.

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -82,12 +82,12 @@
 
           <div class="install">
             <span class="prompt">$</span>
-            <code>pip install rwa-calculator</code>
+            <code>uv add rwa-calc</code>
             <button
               class="copy-btn"
               type="button"
               aria-label="Copy install command"
-              onclick="var b=this;navigator.clipboard&amp;&amp;navigator.clipboard.writeText('pip install rwa-calculator').then(function(){b.classList.add('is-copied');setTimeout(function(){b.classList.remove('is-copied');},1400);});">
+              onclick="var b=this;navigator.clipboard&amp;&amp;navigator.clipboard.writeText('uv add rwa-calc').then(function(){b.classList.add('is-copied');setTimeout(function(){b.classList.remove('is-copied');},1400);});">
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
             </button>
           </div>

--- a/docs/user-guide/interactive-ui.md
+++ b/docs/user-guide/interactive-ui.md
@@ -9,7 +9,7 @@ step is required and it bundles cleanly for local distribution.
 ## Prerequisites
 
 ```bash
-pip install rwa-calc      # or: uv add rwa-calc
+uv add rwa-calc      # or: pip install rwa-calc
 ```
 
 The UI dependencies (FastAPI, Uvicorn, Jinja, Marimo) ship with the base

--- a/src/rwa_calc/ui/app/templates/landing.html
+++ b/src/rwa_calc/ui/app/templates/landing.html
@@ -69,18 +69,6 @@
         </a>
       </div>
 
-      <div class="install">
-        <span class="prompt">$</span>
-        <code>pip install rwa-calculator</code>
-        <button
-          class="copy-btn"
-          type="button"
-          aria-label="Copy install command"
-          onclick="var b=this;navigator.clipboard&amp;&amp;navigator.clipboard.writeText('pip install rwa-calculator').then(function(){b.classList.add('is-copied');setTimeout(function(){b.classList.remove('is-copied');},1400);});">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-        </button>
-      </div>
-
       <div class="meta-row">
         <div class="meta">
           <div class="meta-num">50&ndash;100&times;</div>


### PR DESCRIPTION
## What

- **Fixes a wrong PyPI package name in the docs.** The docs landing hero (`docs/overrides/main.html`) advertised `pip install rwa-calculator` — but the project publishes as **`rwa-calc`** (`pyproject.toml`), so the copy-to-clipboard command would have failed. It now reads `uv add rwa-calc`.
- **Leads with `uv add` across user-facing install instructions** (uv as the recommended package manager; pip kept as the secondary option):
  - `docs/getting-started/quickstart.md`
  - `docs/getting-started/installation.md` — reordered the `uv` / `pip` tabs so uv is first, and the "Recommended Installation" tip now uses `uv add rwa-calc[ui]`
  - `docs/user-guide/interactive-ui.md`
  - `README.md`
- **Removes the install box from the *app* landing page** (`src/rwa_calc/ui/app/templates/landing.html`). Anyone viewing the app's landing page is already running the app locally and has therefore installed it, so the install command was redundant. The box remains on the *docs* landing page, where visitors may not yet have installed the package.

## Why

The advertised install command was both the wrong package name and pip-first; this makes the documented path actually work and consistently recommend uv.

## Scope

Docs / UI presentation only — **no calculation impact**. Changelog updated under `[Unreleased]`.


