### PR TITLE
chore(sonar): suppress S6549 path-construction findings on the local-…

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -30,7 +30,18 @@ sonar.cpd.exclusions=tests/**
 #   e5: S5332 (clear-text protocol) — the UI launcher opens/logs the local
 #        loopback URL (http://127.0.0.1:8000). The server binds to localhost
 #        only and has no TLS; HTTPS is not applicable to a local dev server.
-sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5
+#   e6/e7: S6549 (path constructed from user-controlled data) — the loader's
+#        ``base_path`` and the reconciliation ``legacy_file`` are the data
+#        directory / legacy-output file the OPERATOR points the tool at. This
+#        is a local, single-process tool (api/rest.py design notes: "the
+#        local ... tool the UI ships as"; server binds localhost-only, cf.
+#        e5), not a multi-tenant service serving untrusted paths — the path
+#        IS the trust root, so there is no enclosing directory to confine it
+#        within, and forcing a fixed root would break the tool's purpose
+#        (operator chooses an arbitrary local data directory). If the REST
+#        API is ever exposed to untrusted callers this MUST be revisited with
+#        a real containment root + traversal rejection.
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7
 sonar.issue.ignore.multicriteria.e1.ruleKey=python:S101
 sonar.issue.ignore.multicriteria.e1.resourceKey=tests/**/*.py
 sonar.issue.ignore.multicriteria.e2.ruleKey=python:S125
@@ -41,3 +52,7 @@ sonar.issue.ignore.multicriteria.e4.ruleKey=python:S1244
 sonar.issue.ignore.multicriteria.e4.resourceKey=tests/**/*.py
 sonar.issue.ignore.multicriteria.e5.ruleKey=python:S5332
 sonar.issue.ignore.multicriteria.e5.resourceKey=src/rwa_calc/ui/app/main.py
+sonar.issue.ignore.multicriteria.e6.ruleKey=pythonsecurity:S6549
+sonar.issue.ignore.multicriteria.e6.resourceKey=src/rwa_calc/engine/loader.py
+sonar.issue.ignore.multicriteria.e7.ruleKey=pythonsecurity:S6549
+sonar.issue.ignore.multicriteria.e7.resourceKey=src/rwa_calc/api/reconciliation.py


### PR DESCRIPTION
…tool data paths (e6/e7)

The three pythonsecurity:S6549 "path constructed from user-controlled data" vulnerabilities (engine/loader.py:684,747 base_path; api/reconciliation.py:183 legacy_file) are false positives for this application's documented threat model: a local, single-process operator tool (api/rest.py: "the local ... tool the UI ships as"; server binds localhost-only, same rationale as the existing e5 clear-text suppression). The data directory / legacy file are the paths the operator points the tool at — the path IS the trust root, so there is no enclosing directory to confine within, and forcing a fixed root would break the tool's core "choose your data directory" purpose. Suppressed via the established sonar.issue.ignore.multicriteria pattern (matches e1-e5), with a justification noting this must be revisited with a real containment root if the REST API is ever exposed to untrusted callers.
