### PR TITLE
chore(loop): add CCR-only build mode (Tier 8) to loop.sh

### DIFF
--- a/.claude/commands/next-items.md
+++ b/.claude/commands/next-items.md
@@ -1,6 +1,6 @@
 ---
-description: Pick top N non-conflicting items from IMPLEMENTATION_PLAN.md and drive them through the four-wave pipeline (scenario-architect → fixture-builder → test-writer → engine-implementer) per item, with a reviewer gate between every wave and one revision retry per wave per item. Agents run in the background so the operator can chat with the orchestrator mid-batch. Default N=3, capped at 5. Hard-excludes items that touch shared engine files.
-argument-hint: [N]
+description: Pick top N non-conflicting items from IMPLEMENTATION_PLAN.md and drive them through the four-wave pipeline (scenario-architect → fixture-builder → test-writer → engine-implementer) per item, with a reviewer gate between every wave and one revision retry per wave per item. Agents run in the background so the operator can chat with the orchestrator mid-batch. Default N=3, capped at 5. Hard-excludes items that touch shared engine files. An optional scope arg (e.g. `ccr` / `tier8`) restricts selection to a single tier.
+argument-hint: [N] [scope]
 ---
 
 You are draining `IMPLEMENTATION_PLAN.md` in batches. Each item runs
@@ -17,8 +17,18 @@ you squash-merge each surviving worktree branch back into the
 invoking this command), run the global validation gate **once** on
 the merged tree, then tick the plan and clean up the worktrees.
 
-Parse `$ARGUMENTS` as integer **N** (default 3, cap 5). If
-`$ARGUMENTS` is empty or not an integer, use 3.
+Parse `$ARGUMENTS` as an integer **N** (default 3, cap 5) optionally
+followed by a **scope** token. The integer is N (if absent or not an
+integer, use 3). Any non-integer token is the scope:
+
+- `ccr`, `tier8`, or `P8` → **CCR scope**: select only Tier 8
+  (Counterparty Credit Risk, `P8.*`) items. See Step 1.
+- absent or anything else → **default scope**: the normal tier walk
+  in Step 1.
+
+Examples: `/next-items` → N=3 default scope; `/next-items 2` → N=2
+default scope; `/next-items 3 ccr` → N=3 CCR scope; `/next-items ccr`
+→ N=3 CCR scope.
 
 ## Core architecture
 
@@ -36,7 +46,21 @@ is supplementary.
 
 ## Step 1 — pick a batch
 
-Read `IMPLEMENTATION_PLAN.md`. Walk tiers in order:
+Read `IMPLEMENTATION_PLAN.md`.
+
+**If the scope is `ccr`** (from `$ARGUMENTS`, see above): consider
+**only Tier 8 — Counterparty Credit Risk (CCR) Integration**. Pick
+the highest-priority unchecked (`[ ]`) `P8.*` items in plan order,
+skipping anything explicitly marked `DEFERRED v2.0` / Phase 10. Do
+**not** fall through to any other tier — if Tier 8 has no eligible
+unchecked items left, report "no CCR work to do" and stop. Everything
+else in this command (worktrees, four-wave pipeline, reviewer loop,
+hard exclusions, merge, gate, tick) is unchanged. Note that many CCR
+items touch shared files (`engine/pipeline.py`, `contracts/bundles.py`,
+`contracts/protocols.py`, `engine/registry.py`) and so will be forced
+single-stream by the hard-exclusion rule below — that is expected.
+
+**Otherwise (default scope)**, walk tiers in order:
 
 1. Tier 1: Calculation Correctness
 2. Tier 2: Test Coverage Gaps
@@ -45,6 +69,8 @@ Read `IMPLEMENTATION_PLAN.md`. Walk tiers in order:
 5. (skip Tier 5: Documentation — that's `/next-docs` territory)
 6. Tier 6: Code Quality
 7. (skip Tier 7: Future / v2.0)
+8. (skip Tier 8: CCR — only reached via the `ccr` scope above)
+9. (skip Tier 9 and beyond unless promoted into Tiers 1–6)
 
 For each candidate item, infer its expected change footprint by
 reading the bullet's `Ref:` field, the cited file paths, and the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,6 +186,7 @@ Orchestration lives in slash commands, not in agents. Each `loop.sh` mode maps t
 | `loop.sh` mode | Prompt file | Default command | Strict-serial alternative |
 |---|---|---|---|
 | `loop.sh` (build) | `PROMPT_build.md` | `/next-items 3` | `/next-scenario` |
+| `loop.sh ccr` | `PROMPT_ccr.md` | `/next-items 3 ccr` | `/implement-scenario <P8.x>` |
 | `loop.sh plan` | `PROMPT_plan.md` | `/refresh-plan` | — |
 | `loop.sh docs_build` | `PROMPT_docs_build.md` | `/next-docs 3` | `/next-doc` |
 | `loop.sh docs_plan` | `PROMPT_docs_plan.md` | `/refresh-docs-plan` | — |

--- a/PROMPT_ccr.md
+++ b/PROMPT_ccr.md
@@ -1,0 +1,73 @@
+Run `/next-items 3 ccr`.
+
+That single slash command drives the whole `loop.sh ccr`
+iteration as a parallel batch **scoped to Counterparty Credit Risk
+only**:
+
+- it picks up to 3 non-conflicting unchecked items from **Tier 8 —
+  Counterparty Credit Risk (CCR) Integration** (`P8.*`) in
+  `IMPLEMENTATION_PLAN.md`, in plan order, skipping anything marked
+  `DEFERRED v2.0` / Phase 10. It does **not** consider any other tier,
+- runs the four agent stages as four parallel waves
+  (scenario-architect → fixture-builder → test-writer →
+  engine-implementer), with N items in flight per wave and a reviewer
+  gate between every wave,
+- runs the global validation gate
+  (`uv run python scripts/arch_check.py && uv run ruff check src/ && uv run ruff format --check src/ && uv run ty src/ && uv run pytest tests/contracts/ --benchmark-skip -q`)
+  exactly once at the end of the engine-implementer wave —
+  per-agent gate runs are forbidden because they would
+  N×-redundantly churn ruff/format on each other's edits,
+- on green: commits each item separately, then ticks the items off
+  `IMPLEMENTATION_PLAN.md` in one final
+  `chore(plan): tick N CCR items` commit and pushes.
+
+Expect frequent single-stream downgrades: many CCR items touch shared
+files (`engine/pipeline.py`, `engine/registry.py`,
+`contracts/protocols.py`, `contracts/bundles.py`,
+`engine/aggregator/aggregator.py`) and are forced single-stream by the
+orchestrator — that's deliberate and not a bug. The CCR stage adds new
+bundles and wires a new pipeline stage, so a degrade to N=1 is normal.
+
+If you want strict-serial behaviour (one item per iteration), run
+`/implement-scenario <P8.x>` directly on a specific CCR item.
+
+After `/next-items 3 ccr` returns, do these housekeeping items in the
+top-level session (not via a sub-agent):
+
+1. If the change is user-facing, append a one-line entry to
+   `docs/appendix/changelog.md`. Capture the **why** — regulatory
+   citation (CRR Art. 274–282 / PRA PS1/26) and which test pins the
+   behaviour — not just the **what**.
+2. If the validation gate is green and the new test passes, create a
+   git tag. If no tag exists yet start at `0.0.0`; otherwise bump the
+   patch version (`0.0.0` → `0.0.1`).
+3. If `/next-items 3 ccr` reported Tier 8 has no eligible unchecked
+   items left, stop the loop and surface that to the operator. Do not
+   invent work, do not fall through to other tiers, and do not
+   silently promote any `DEFERRED v2.0` / Phase 10 item.
+4. If `/next-items 3 ccr` reported the global validation gate was red,
+   **no commits will have been made**. Do not retry blindly;
+   inspect the failure attribution, fix forward in the next
+   iteration, and rerun the loop manually.
+
+## Hard constraints
+
+- CCR scope is absolute: this loop only ever touches Tier 8 `P8.*`
+  items. If you believe a non-CCR fix is required to land a CCR item,
+  document it as a new bullet in `IMPLEMENTATION_PLAN.md` rather than
+  silently doing it here.
+- Single sources of truth. No migrations, no adapters, no parallel
+  re-implementations. If unrelated tests fail during the iteration,
+  resolve them as part of this increment or document them in
+  `IMPLEMENTATION_PLAN.md`.
+- No placeholders or stubs. Implement functionality completely.
+- Keep `AGENTS.md` operational only — status notes belong in
+  `IMPLEMENTATION_PLAN.md`.
+- Do not bypass agent file ownership. fixture-builder owns
+  `tests/fixtures/`, test-writer owns
+  `tests/{unit,acceptance,contracts,integration}/`,
+  engine-implementer owns `src/rwa_calc/`, plan-curator owns the two
+  root plan files. Anything else is a top-level edit.
+- Add extra logging if needed to debug, following the rules in
+  `CLAUDE.md` § Logging — never `print()`, never f-strings in log
+  calls, never `logging.basicConfig()`.

--- a/loop.sh
+++ b/loop.sh
@@ -5,6 +5,8 @@
 #   ./loop.sh 20           # Build mode, max 20 iterations
 #   ./loop.sh plan         # Plan mode, 2 iterations (default)
 #   ./loop.sh plan 5       # Plan mode, max 5 iterations
+#   ./loop.sh ccr          # CCR-only build (Tier 8), 2 iterations (default)
+#   ./loop.sh ccr 10       # CCR-only build, max 10 iterations
 
 # Parse arguments
 if [[ "$1" = "plan" ]]; then
@@ -21,6 +23,11 @@ elif [[ "$1" = "docs_build" ]]; then
     # Doc build mode
     MODE="build"
     PROMPT_FILE="PROMPT_docs_build.md"
+    MAX_ITERATIONS=${2:-2}
+elif [[ "$1" = "ccr" ]]; then
+    # CCR build mode — drains Tier 8 (Counterparty Credit Risk) only
+    MODE="build"
+    PROMPT_FILE="PROMPT_ccr.md"
     MAX_ITERATIONS=${2:-2}
 elif [[ "$1" = "build_next" ]]; then
     # build mode


### PR DESCRIPTION
## What

Adds a `ccr` mode to `loop.sh` that drains **only** the Counterparty Credit Risk backlog (Tier 8, `P8.*`) from `IMPLEMENTATION_PLAN.md`.

```bash
./loop.sh ccr        # CCR-only build, 2 iterations (default)
./loop.sh ccr 10     # CCR-only build, up to 10 iterations
```

## Why

`/next-items` hard-coded its tier walk to Tiers 1, 2, 3, 4, 6 and explicitly skipped 5 and 7 — **Tier 8 was never in the walk**, so no existing loop could ever pick a CCR item. This unlocks them without disturbing the default backlog drain.

## How

- **`.claude/commands/next-items.md`** — added an optional `scope` arg. `ccr` / `tier8` / `P8` → Tier 8 only; absent → the existing Tier 1‑2‑3‑4‑6 walk, **unchanged** (non-breaking, single source of truth — no forked command). Updated frontmatter (`argument-hint: [N] [scope]`), `$ARGUMENTS` parsing, and Step 1.
- **`PROMPT_ccr.md`** (new) — headless prompt that runs `/next-items 3 ccr` with CCR-flavoured housekeeping (changelog cites CRR Art. 274–282 / PS1/26; stop when Tier 8 is drained; never promote `DEFERRED v2.0`).
- **`loop.sh`** — new `ccr` mode → `PROMPT_ccr.md`, plus usage comments.
- **`CLAUDE.md`** — added the `loop.sh ccr` row to the mode table.

## Notes

- Default `/next-items` behaviour is byte-for-byte unchanged; the scope arg is purely additive.
- Expect frequent single-stream (N=1) downgrades: the CCR stage adds new bundles and wires a new pipeline stage, so many `P8.*` items touch hard-excluded shared files (`engine/pipeline.py`, `contracts/bundles.py`, …) and are forced single-stream by the orchestrator — by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)