### PR TITLE
fix(scripts): validate CLI input before subprocess argv (SonarQube hardening)

### DIFF
--- a/docs/appendix/changelog.md
+++ b/docs/appendix/changelog.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - (Next release changes will go here)
 
+### Security
+- **Developer scripts validate operator CLI input before it reaches `subprocess` argv (SonarQube subprocess hardening).** A new `scripts/_validate.py` provides fail-fast validators — `validate_semver` (strict `N.N.N`), `validate_git_ref` (safe-commitish allowlist that rejects leading `-`, `..`, `@{`, trailing `.lock`/`/`, and whitespace), and `validate_iso_date` — wired in at the argparse boundary of `deploy.py` (the `version` positional), `worktree.py` (the `--from` base ref; the worktree `name` was already validated), and `profile_memory.py` (the `--date` flag, validated in the parent before the worker `Popen`). All call sites already used the argv-list form (never `shell=True`), so this is defence-in-depth: a malformed or hostile argument is now rejected with a clear error before any command is built. Covered by `tests/unit/test_validate.py`.
+
 ---
 
 ## [0.3.1] - 2026-06-18

--- a/scripts/_validate.py
+++ b/scripts/_validate.py
@@ -1,0 +1,68 @@
+"""
+CLI-input validators shared across the developer scripts.
+
+Several scripts (deploy.py, worktree.py, profile_memory.py) interpolate
+operator-supplied CLI arguments into ``subprocess`` argv lists (git tags, git
+refs, a reporting date passed to a worker process). Every such call already uses
+the argv-list form (never ``shell=True``), so there is no shell to inject into —
+but a malformed or hostile argument can still be mis-parsed by the invoked tool
+(e.g. a leading ``-`` read as an option, or a non-semver string that silently
+fails an in-file version rewrite).
+
+These validators run at the argparse boundary, closest to the untrusted source,
+and reject bad input *before* any command is built. They follow the
+``worktree.py:_validate_name`` convention: raise ``SystemExit`` with an
+``error: ...`` message (fast-fail, non-zero exit, no traceback) and return the
+validated value so the dataflow from source to subprocess sink passes visibly
+through the sanitizer.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import date
+
+# Strict release semver (N.N.N). Pre-release / build suffixes are intentionally
+# rejected: deploy.bump_version only ever emits N.N.N and every VERSION_FILES
+# pattern matches \d+\.\d+\.\d+, so a suffixed version would silently fail the
+# in-file rewrite anyway.
+SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
+
+# Safe git commitish allowlist: a leading alphanumeric, then alphanumerics plus
+# the ref punctuation git permits (. _ / -). Excludes a leading '-' (option
+# injection), whitespace, and the ref metacharacters '~^:?*[]' and backslash.
+# Accepts HEAD, master, origin/main, v0.3.1, and full/short SHAs.
+GIT_REF_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]*$")
+
+
+def validate_semver(value: str) -> str:
+    """Return ``value`` if it is a strict N.N.N version, else exit with an error."""
+    if not SEMVER_RE.match(value):
+        raise SystemExit(f"error: invalid version {value!r}. Expected N.N.N (e.g. 0.3.2).")
+    return value
+
+
+def validate_git_ref(value: str) -> str:
+    """Return ``value`` if it is a safe git ref, else exit with an error."""
+    if (
+        not GIT_REF_RE.match(value)
+        or ".." in value
+        or "@{" in value
+        or value.endswith((".lock", "/"))
+    ):
+        raise SystemExit(
+            f"error: invalid git ref {value!r}. "
+            f"Use letters, digits, and . _ / - (e.g. HEAD, master, origin/main)."
+        )
+    return value
+
+
+def validate_iso_date(value: str) -> str:
+    """Return ``value`` if it is an ISO-8601 date (YYYY-MM-DD), else exit with an error."""
+    try:
+        date.fromisoformat(value)
+    except ValueError as exc:
+        raise SystemExit(
+            f"error: invalid reporting date {value!r}. Expected ISO YYYY-MM-DD (e.g. 2026-01-01)."
+        ) from exc
+    return value

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -33,6 +33,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent))
 
 from _deploy_changelog import promote_unreleased, update_version_table  # noqa: E402
+from _validate import validate_semver  # noqa: E402
 
 # Project root (parent of scripts directory)
 PROJECT_ROOT = Path(__file__).parent.parent
@@ -245,7 +246,7 @@ def resolve_new_version(args: argparse.Namespace, current_version: str) -> str |
     if args.bump:
         return bump_version(current_version, args.bump)
     if args.version:
-        return args.version
+        return validate_semver(args.version)
     # Default to patch bump
     return bump_version(current_version, "patch")
 

--- a/scripts/profile_memory.py
+++ b/scripts/profile_memory.py
@@ -41,6 +41,11 @@ from datetime import date
 from pathlib import Path
 from typing import Any
 
+# Make the sibling helper importable when this script is invoked directly.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _validate import validate_iso_date  # noqa: E402
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 DEFAULT_ROWS = 100_000
@@ -336,7 +341,11 @@ def _parse_args() -> argparse.Namespace:
     # Internal flags used for the per-mode worker subprocess.
     parser.add_argument("--worker-mode", choices=list(MODES), default=None, help=argparse.SUPPRESS)
     parser.add_argument("--result-json", type=str, default=None, help=argparse.SUPPRESS)
-    return parser.parse_args()
+    args = parser.parse_args()
+    # Validate the free-form reporting date in the PARENT, before it is placed on
+    # the worker's argv (the worker's own date.fromisoformat runs after the spawn).
+    args.date = validate_iso_date(args.date)
+    return args
 
 
 if __name__ == "__main__":

--- a/scripts/worktree.py
+++ b/scripts/worktree.py
@@ -30,6 +30,11 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Make the sibling helper importable when this script is invoked directly.
+sys.path.insert(0, str(Path(__file__).parent))
+
+from _validate import validate_git_ref  # noqa: E402
+
 PROJECT_ROOT = Path(__file__).parent.parent
 BRANCH_PREFIX = "wt/"
 WORKTREE_PATH_PREFIX = "rwa_calculator-"
@@ -88,6 +93,7 @@ def main(argv: list[str] | None = None) -> int:
 
 def cmd_create(name: str, base_ref: str, force: bool) -> int:
     _validate_name(name)
+    base_ref = validate_git_ref(base_ref)
     branch = _branch_for(name)
     worktree_path = _worktree_path_for(name)
 

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -1,0 +1,78 @@
+"""Unit tests for the CLI-input validators shared by the developer scripts.
+
+These guard the ``subprocess`` argv interpolation points in deploy.py,
+worktree.py, and profile_memory.py: a valid value is returned unchanged, an
+invalid one fails fast via ``SystemExit`` before any command is built.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from _validate import (  # noqa: E402  # ty: ignore[unresolved-import]
+    validate_git_ref,
+    validate_iso_date,
+    validate_semver,
+)
+
+
+class TestValidateSemver:
+    @pytest.mark.parametrize("value", ["0.3.2", "1.0.0", "10.20.30"])
+    def test_accepts_strict_semver(self, value: str) -> None:
+        assert validate_semver(value) == value
+
+    @pytest.mark.parametrize(
+        "value",
+        ["1.2", "0.3.2-rc1", "v0.3.2", "0.3.2 ", "0.3.2; rm -rf /", "--bump"],
+    )
+    def test_rejects_non_semver(self, value: str) -> None:
+        with pytest.raises(SystemExit):
+            validate_semver(value)
+
+
+class TestValidateGitRef:
+    @pytest.mark.parametrize(
+        "value",
+        ["HEAD", "master", "origin/main", "v0.3.1", "feature/x-1", "a1b2c3d"],
+    )
+    def test_accepts_safe_ref(self, value: str) -> None:
+        assert validate_git_ref(value) == value
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "--upload-pack=evil",  # leading dash → option injection
+            "-evil",
+            "a..b",  # range expression
+            "HEAD@{1}",  # reflog selector
+            "main.lock",  # trailing .lock
+            "feature/",  # trailing slash
+            "a b",  # whitespace
+            "a~1",  # ancestry metachar
+            "",  # empty
+        ],
+    )
+    def test_rejects_unsafe_ref(self, value: str) -> None:
+        with pytest.raises(SystemExit):
+            validate_git_ref(value)
+
+
+class TestValidateIsoDate:
+    @pytest.mark.parametrize("value", ["2026-01-01", "2026-12-31"])
+    def test_accepts_iso_date(self, value: str) -> None:
+        assert validate_iso_date(value) == value
+
+    @pytest.mark.parametrize(
+        "value",
+        ["2026-13-40", "01/01/2026", "not-a-date", "2026-01-01; rm -rf /", ""],
+    )
+    def test_rejects_non_iso_date(self, value: str) -> None:
+        with pytest.raises(SystemExit):
+            validate_iso_date(value)


### PR DESCRIPTION
## Context

SonarQube flags 7 `subprocess` call sites with its AI/agent-safety rule:
> *LLMs running this code with faulty CLI arguments can escape from shell sandboxes. Refactor this code to validate untrusted data before passing them to OS commands.*

All 7 sites already use the **argv-list form** (never `shell=True`), so there is no classic shell-injection vector. Of the 7, only **3 carry free-form operator input** that actually reaches a command — this PR hardens those three (Lever A). The remaining 4 sites use hardcoded constants or already-validated inputs and are intentionally unchanged (handled separately as residual suppression once the SonarQube re-run confirms the rule key).

## Changes

**New `scripts/_validate.py`** — fail-fast validators that reject bad input *before* any command is built and `return` the value so the source→sink dataflow passes through a sanitizer:
- `validate_semver` — strict `N.N.N`
- `validate_git_ref` — safe-commitish allowlist (rejects leading `-`/option-injection, `..`, `@{`, trailing `.lock`/`/`, whitespace)
- `validate_iso_date` — `date.fromisoformat`

**Wired in at the argparse boundary:**

| File | Input hardened |
|---|---|
| `scripts/deploy.py` | `version` positional → `validate_semver` in `resolve_new_version` |
| `scripts/worktree.py` | `--from` base ref → `validate_git_ref` in `cmd_create` (the worktree `name` was already validated by `NAME_PATTERN`) |
| `scripts/profile_memory.py` | `--date` → `validate_iso_date` after `parse_args`, in the **parent** before the worker `Popen` |

Plus `tests/unit/test_validate.py` (30 parametrized cases) and a `Security` changelog entry.

## Verification

- **Tests:** 38 pass (`test_validate` + `test_deploy_changelog`).
- **End-to-end fast-fail:** `deploy.py '0.3.2; rm -rf /'` → `error:` exit 1; `--from=--upload-pack=evil` and `a..b` → rejected; `--date '2026-13-40'` → rejected before any spawn; good paths (`--dry-run`, `worktree list`) → exit 0.
- **Gate:** `ruff check` ✓, `ruff format --check` ✓, `scripts/arch_check.py` ✓.

## Follow-up (not in this PR)

After merge + a SonarQube re-run, the residual constant/already-validated sites (`generate_citation_matrix.py`, `ui/app/main.py`, `tests/contracts/test_builder_conformance.py`, and the version-derived `run_command` in `deploy.py`) get suppressed via the project's existing house-style mechanism (`sonar-project.properties` `multicriteria` for `python:*` Issues, platform "Accepted" for `pythonsecurity:*` taint rules, or Review→Safe for a Security Hotspot) — depending on the exact rule key the re-run reports.

