### PR TITLE
Show a "Create exports" step on the calculator progress stepper

### DIFF
--- a/docs/appendix/changelog.md
+++ b/docs/appendix/changelog.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (Next release changes will go here)
 
 ### Changed
-- (Next release changes will go here)
+- **The calculator progress stepper now shows a "Create exports" step when a run writes export files, so the end-of-run wait is labelled instead of looking like a hang.** When an output folder + formats are chosen, the calculator writes the selected exports (Parquet/CSV/Excel/COREP/Pillar III) *after* the pipeline finishes — a step that has no registry stage, so the stepper's spinner previously parked on the last pipeline stage (or appeared to "circle" with everything ticked) while the workbook(s) wrote, with no indication of what was happening. The stepper now appends a synthetic **Create exports** step (mirroring the reconciliation stepper's "Reconcile & summarise" tail): the spinner parks on it honestly while the files write, and it ticks off when they are done. The step is shown only when the run actually writes exports (`Job.writes_exports`); a plain run with no output folder ends at the aggregator as before. The reported `total_stages` (the registry pipeline count) is unchanged — the export step is a UI-only tail. Covered by extended `tests/integration/test_ui_app.py` assertions (the step renders and ticks for an export-writing run, and is absent otherwise).
 
 ---
 

--- a/src/rwa_calc/ui/app/main.py
+++ b/src/rwa_calc/ui/app/main.py
@@ -54,6 +54,8 @@ from rwa_calc.ui.app.calculator_state import (
 )
 from rwa_calc.ui.app.output_writer import write_selected_formats
 from rwa_calc.ui.app.progress import (
+    EXPORT_STAGE_NAME,
+    EXPORT_STAGE_SEQUENCE,
     RECON_STAGE_NAME,
     RECON_STAGE_SEQUENCE,
     STAGE_INDEX,
@@ -310,8 +312,10 @@ def _register_pages(app: FastAPI) -> None:
 
         # Run off the request thread so the browser gets a live, stage-by-stage
         # stepper instead of a frozen tab. The job_id doubles as the eventual
-        # results id (see _calculation_worker -> register_run_with_id).
-        job = create_job()
+        # results id (see _calculation_worker -> register_run_with_id). A run with
+        # an output folder + formats writes exports after calculate(), so the
+        # stepper shows the trailing "Create exports" step.
+        job = create_job(writes_exports=bool(output_folder.strip() and formats))
         submit_job(
             job,
             _calculation_worker(
@@ -328,12 +332,16 @@ def _register_pages(app: FastAPI) -> None:
 
     @app.get("/calculating/{job_id}", response_class=HTMLResponse)
     def calculating(request: Request, job_id: str) -> HTMLResponse:
-        if get_job(job_id) is None:
+        job = get_job(job_id)
+        if job is None:
             return _not_found(request, "That calculation has expired or does not exist.")
+        # Show the trailing "Create exports" step only when this run writes exports,
+        # so the spinner has a labelled step to park on while the files write.
+        stages = EXPORT_STAGE_SEQUENCE if job.writes_exports else STAGE_SEQUENCE
         return templates.TemplateResponse(
             request=request,
             name="calculating.html",
-            context=_nav({"job_id": job_id, "stages": STAGE_SEQUENCE}),
+            context=_nav({"job_id": job_id, "stages": stages}),
         )
 
     @app.get("/jobs/{job_id}")
@@ -773,6 +781,10 @@ def _calculation_worker(
             _EXPORT_OUTCOMES[job.job_id] = write_selected_formats(
                 response, Path(output_folder).expanduser(), formats, run_id=job.job_id
             )
+            # Tick the trailing "Create exports" step (the stepper parked on it
+            # while the files wrote). Marked only when exports actually ran, to
+            # match the conditional step shown by the /calculating page.
+            job.mark_stage(EXPORT_STAGE_NAME)
         save_calculator_state(
             CalculatorFormState(
                 data_path=data_path,

--- a/src/rwa_calc/ui/app/progress.py
+++ b/src/rwa_calc/ui/app/progress.py
@@ -107,6 +107,20 @@ RECON_STAGE_SEQUENCE: tuple[StageInfo, ...] = (
     StageInfo(name=RECON_STAGE_NAME, label="Reconcile & summarise", heavy=False),
 )
 
+# A calculation can optionally write the selected export formats to a folder
+# AFTER calculate() returns (see ui.app.main._calculation_worker). That write is
+# a plain function, not a registry stage, so when a run has exports configured the
+# worker marks this synthetic tail step DIRECTLY once the files are written — so
+# the stepper parks honestly on "Create exports" instead of appearing to hang on
+# the last pipeline stage while the workbook(s)/files write. Shown only when the
+# run actually writes exports (Job.writes_exports); a plain run ends at the
+# aggregator with no trailing step.
+EXPORT_STAGE_NAME = "write_exports"
+EXPORT_STAGE_SEQUENCE: tuple[StageInfo, ...] = (
+    *STAGE_SEQUENCE,
+    StageInfo(name=EXPORT_STAGE_NAME, label="Create exports", heavy=False),
+)
+
 
 # =============================================================================
 # Job state
@@ -132,6 +146,10 @@ class Job:
     """
 
     job_id: str
+    # Whether this run writes export files after calculate() returns. Drives the
+    # trailing "Create exports" step on the stepper; set once at creation, read by
+    # the /calculating page render. Plain immutable flag, no lock needed.
+    writes_exports: bool = False
     _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
     _completed: list[str] = field(default_factory=list, repr=False)
     _status: str = "running"
@@ -176,9 +194,13 @@ _JOBS: dict[str, Job] = {}
 _JOBS_LOCK = threading.Lock()
 
 
-def create_job() -> Job:
-    """Create and register a fresh running job; return it."""
-    job = Job(job_id=uuid.uuid4().hex)
+def create_job(*, writes_exports: bool = False) -> Job:
+    """Create and register a fresh running job; return it.
+
+    ``writes_exports`` marks a run that will write export files after the
+    pipeline finishes, so the stepper shows the trailing "Create exports" step.
+    """
+    job = Job(job_id=uuid.uuid4().hex, writes_exports=writes_exports)
     with _JOBS_LOCK:
         _JOBS[job.job_id] = job
     return job

--- a/tests/integration/test_ui_app.py
+++ b/tests/integration/test_ui_app.py
@@ -90,6 +90,8 @@ def test_calculate_dispatches_job_then_results_become_available(
     assert "Calculating" in pending.text
     assert 'data-stage="calculators"' in pending.text
     assert "/static/calculating.js" in pending.text
+    # No output folder was given, so there is no trailing "Create exports" step.
+    assert 'data-stage="write_exports"' not in pending.text
 
     # The job finishes in the background; results are served under the job_id
     status = _wait_for_job(client, job_id)
@@ -177,13 +179,20 @@ def test_calculate_with_output_folder_writes_files(
         },
         follow_redirects=False,
     )
-    run_id = resp.headers["location"].rsplit("/", 1)[1]
+    location = resp.headers["location"]
+    run_id = location.rsplit("/", 1)[1]
+    # The stepper shows a trailing "Create exports" step for an export-writing run.
+    stepper = client.get(location).text
+    assert 'data-stage="write_exports"' in stepper
+    assert "Create exports" in stepper
     status = _wait_for_job(client, run_id)
 
-    # Assert — file on disk, stage count unchanged (write is outside STAGE_SEQUENCE),
-    # and the results page reports what was written.
+    # Assert — file on disk, stage count unchanged (the export write is a synthetic
+    # tail step, not a registry stage), and the results page reports what was written.
     assert status["status"] == "done"
     assert status["total_stages"] == 10
+    # The trailing export step is ticked off once the files are written.
+    assert "write_exports" in status["completed"]
     assert (out / f"rwa_export_{run_id}" / "results.parquet").exists()
     assert "Wrote" in client.get(f"/results/{run_id}").text
 


### PR DESCRIPTION
## Summary

When a calculation has an output folder + formats selected, the calculator writes the chosen exports (Parquet/CSV/Excel/COREP/Pillar III) **after** the pipeline finishes. That write isn't a registry stage, so the live stepper's spinner parked on the last pipeline stage — or appeared to "circle" with every step already ticked — while the workbook(s) wrote, with no indication of what was happening. On a large portfolio (or several workbook formats) that end-of-run wait looked like a hang.

## Change

The stepper now appends a synthetic **Create exports** step, mirroring the reconciliation stepper's existing "Reconcile & summarise" tail:

- The spinner parks honestly on **Create exports** while the files write, then it ticks off when the write completes.
- Shown **only when the run actually writes exports** (`Job.writes_exports`, set at job creation from the output-folder + formats inputs). A plain run with no output folder ends at the aggregator exactly as before — no misleading step.
- The reported `total_stages` (the registry pipeline stage count) is **unchanged** — the export step is a UI-only tail, marked directly by the worker (`job.mark_stage(EXPORT_STAGE_NAME)`) after `write_selected_formats`, just like the recon tail.

Mechanically this reuses the existing pattern in `ui/app/progress.py`: a new `EXPORT_STAGE_SEQUENCE` (= pipeline stages + the synthetic step) and a `writes_exports` flag on `Job`; the `/calculating/{job_id}` page renders the export sequence when the flag is set; the SSE/poll client already ticks by stage **name**, so the synthetic step needs no client change.

## Tests

`tests/integration/test_ui_app.py` extended: an export-writing run renders `data-stage="write_exports"` / "Create exports" and the step appears in the job's `completed` list once finished; a run with no output folder does **not** show the step. Full UI suite (24) + reconciliation UI suite (32) pass; `ruff` / `ty` / `scripts/arch_check.py` clean.

## Notes

- Independent of #416 / #417 / #418 — branched off `master`; only overlap is the changelog.

