### PR TITLE
fix(types): satisfy repo-wide `ty check` on SFT test files

### DIFF
--- a/tests/contracts/test_config.py
+++ b/tests/contracts/test_config.py
@@ -219,7 +219,7 @@ class TestSFTConfig:
         config = SFTConfig()
 
         with pytest.raises(dataclasses.FrozenInstanceError):
-            config.method = "var"  # type: ignore[misc]
+            config.method = "var"  # ty: ignore[invalid-assignment]
 
     def test_sftconfig_accepts_reserved_var_method(self):
         """SFTConfig(method='var') constructs (reserved, unimplemented literal)."""

--- a/tests/contracts/test_sft_bundles_contract.py
+++ b/tests/contracts/test_sft_bundles_contract.py
@@ -72,7 +72,8 @@ def test_leaf_bundle_is_frozen_dataclass(class_name: str) -> None:
     """Each SFT leaf bundle must be a frozen dataclass."""
     cls = _get(class_name)
     assert dataclasses.is_dataclass(cls), f"'{class_name}' must be a @dataclass"
-    assert cls.__dataclass_params__.frozen is True, f"'{class_name}' must be frozen"
+    params = cls.__dataclass_params__  # ty: ignore[unresolved-attribute]
+    assert params.frozen is True, f"'{class_name}' must be frozen"
 
 
 @pytest.mark.parametrize("class_name, lf_field, _brand", _LEAF_SPECS)
@@ -145,7 +146,8 @@ def test_raw_sft_bundle_is_frozen_dataclass() -> None:
     """RawSFTBundle must be a frozen dataclass."""
     cls = _get("RawSFTBundle")
     assert dataclasses.is_dataclass(cls)
-    assert cls.__dataclass_params__.frozen is True
+    params = cls.__dataclass_params__  # ty: ignore[unresolved-attribute]
+    assert params.frozen is True
 
 
 def test_raw_sft_bundle_field_set_and_order() -> None:

--- a/tests/contracts/test_sft_method_fail_loud.py
+++ b/tests/contracts/test_sft_method_fail_loud.py
@@ -51,7 +51,7 @@ def _config(sft_method: str) -> CalculationConfig:
     return CalculationConfig.crr(
         reporting_date=_REPORTING_DATE,
         permission_mode=PermissionMode.STANDARDISED,
-        sft_method=sft_method,  # type: ignore[arg-type]
+        sft_method=sft_method,  # ty: ignore[invalid-argument-type]
     )
 
 

--- a/tests/integration/test_sft_stage_dark_launch.py
+++ b/tests/integration/test_sft_stage_dark_launch.py
@@ -37,6 +37,7 @@ from datetime import date
 import polars as pl
 import pytest
 
+from rwa_calc.contracts.bundles import RawDataBundle
 from rwa_calc.contracts.config import CalculationConfig
 from rwa_calc.contracts.edges import sealed_edge_of
 from rwa_calc.domain.enums import PermissionMode
@@ -67,7 +68,7 @@ _EXPECTED_RISK_WEIGHT: float = 0.50
 _A11_EAD_LOWER_BOUND: float = 60_000_000.0
 
 
-def _make_sft_data_bundle(sft_bundle) -> object:
+def _make_sft_data_bundle(sft_bundle) -> RawDataBundle:
     """Assemble a RawDataBundle with a populated ``raw.sft`` (no ``raw.ccr``)."""
     return make_raw_bundle(
         counterparties=_build_cp_inst_001_counterparty(),


### PR DESCRIPTION
## Summary

A repo-wide `uvx ty check` reported **6 diagnostics**, all in SFT-related test files. CI only runs `ty check src/rwa_calc/` (the `tests/` tree is outside its ty scope), so these test-only errors were never gated and had accumulated on `master`. This brings the **whole-repo** `ty check` to green.

**Root cause:** the tests used mypy-style `# type: ignore[<code>]` comments (`misc`, `arg-type`) whose codes `ty` does not recognise, so the underlying diagnostics were never actually suppressed — plus two genuine inference gaps.

## Fixes

| File | Error | Fix |
|------|-------|-----|
| `test_config.py` | `invalid-assignment` (deliberate frozen-assignment test) | `# type: ignore[misc]` → `# ty: ignore[invalid-assignment]` |
| `test_sft_method_fail_loud.py` | `invalid-argument-type` (intentional invalid `sft_method` str) | `# type: ignore[arg-type]` → `# ty: ignore[invalid-argument-type]` |
| `test_sft_bundles_contract.py` (×2) | `unresolved-attribute` on `cls.__dataclass_params__` (unmodelled on `type`) | hoist to a local with `# ty: ignore[unresolved-attribute]` (kept off the `assert` line to stay ≤100 chars; `getattr` avoided — bugbear `B009`) |
| `test_sft_stage_dark_launch.py` (×2 call sites) | `invalid-argument-type` into `run_with_data` | `_make_sft_data_bundle` was annotated `-> object` though it returns `make_raw_bundle(...) -> RawDataBundle`; corrected the annotation |

## Testing

- `uvx ty check` (repo-wide) → **All checks passed!**
- `ruff check` on the 4 files → clean
- The 4 files' **62 tests** remain green
- No runtime behaviour change (annotations / comments only)

Separate from the reporting-headers PR (#420) since these are unrelated pre-existing test-type fixes.

