### PR TITLE
fix(ui): report grid becomes the card — no more overflow look on wide templates

### DIFF
--- a/docs/appendix/changelog.md
+++ b/docs/appendix/changelog.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (Next release changes will go here)
 
 ### Changed
-- (Next release changes will go here)
+- **The report-template grid no longer looks like it overflows its card.** The previous format double-framed the grid — a scroll pane with a near-invisible border inside a padded panel — so on wide templates (C 07.00's 28 columns, C 08.02's 49) columns were chopped mid-digit at an edge that read as accidental clipping, and on tall templates the pane's horizontal scrollbar sat below the fold, leaving no visible way to reach the remaining columns. The grid card is now itself the window: a header strip (template title, sheet, column count, and the template/sheet picker folded in as a slim toolbar — reclaiming ~200px of page chrome) over a scroll pane sitting flush inside the card frame, so columns clip exactly at the card border like a freeze pane. The pane is fitted to the viewport remainder (`report-grid.js`, with a CSS fallback), keeping its horizontal scrollbar on screen at all times, and pane scrollbars are now thin and visible on the dark canvas. Frozen headers, row labels, cell keys, drill-down links and the null-vs-zero distinction are unchanged.
 
 ---
 

--- a/src/rwa_calc/ui/app/static/app.css
+++ b/src/rwa_calc/ui/app/static/app.css
@@ -261,28 +261,59 @@ table.data td.num a.cell-link:hover { color: var(--oah-orange-bright); text-deco
 
 /* ---------- Report-template grid ----------------------------------------
    Regulatory templates are wide — up to 49 value columns (C 08.02 under Basel
-   3.1) — and are read on desktop. Three things make that usable:
+   3.1) — and are read on desktop. The format is a framed spreadsheet window:
 
    1. `container--wide` lets the report pages use the full viewport instead of
       the 1100px reading measure (which is right for prose, wrong for a return).
-   2. `grid-wrap` is a bounded scroll pane, so `position: sticky` actually has a
+   2. The grid card (`panel--grid`) IS the window: a header strip (title +
+      picker toolbar) over a scroll pane sitting flush inside the card frame.
+      Columns clip exactly at the card border — a freeze-pane edge — rather
+      than at an invisible inner border that reads as the table overflowing
+      the card.
+   3. `grid-wrap` is a bounded scroll pane, so `position: sticky` actually has a
       scrollport to stick to: the header band and the row labels stay put while
       the columns scroll under them (the freeze-pane a reader expects of a
-      return). Without the height cap the wrapper never scrolls internally and
-      the sticky header simply scrolls away with the page.
-   3. Compact density + tabular numerals fit ~30% more columns and keep digits
-      aligned column-wise.                                                    */
+      return). The height cap also keeps the pane's own horizontal scrollbar on
+      screen — report-grid.js trues it up to the actual viewport remainder;
+      without it the scrollbar lands below the fold and a wide return reads as
+      clipped with no way to reach the remaining columns.
+   4. Compact density + tabular numerals fit ~30% more columns and keep digits
+      aligned column-wise; thin styled scrollbars keep the scroll affordance
+      visible on the dark canvas.                                            */
 
-.container--wide { max-width: none; }
+/* Full width, and a slim bottom margin: the grid pane is fitted to the viewport
+   (report-grid.js), so the prose page's 64px tail would only re-introduce page
+   scroll and push the pane's horizontal scrollbar off screen. */
+.container--wide { max-width: none; padding-bottom: 24px; }
 /* Prose keeps a readable measure even when the grid goes full-bleed. */
 .container--wide .page-intro { max-width: 900px; }
 
 .grid-wrap {
   overflow: auto;
-  max-height: calc(100vh - 260px);
-  border: 1px solid rgba(216,222,233,0.10);
-  border-radius: 12px;
+  /* Fallback height; report-grid.js fits the pane to the real viewport remainder. */
+  max-height: calc(100vh - 300px);
+  max-height: calc(100dvh - 300px);
+  scrollbar-width: thin;
+  scrollbar-color: var(--oah-slate-600) var(--oah-slate-850);
 }
+
+/* The grid card: no inner padding — the pane fills the frame edge to edge. */
+.panel--grid { padding: 0; overflow: hidden; }
+.grid-head {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  gap: 12px 24px; flex-wrap: wrap;
+  padding: 14px 18px;
+  border-bottom: 1px solid rgba(216,222,233,0.12);
+}
+.grid-head h3 { margin: 0; }
+
+/* The template picker as a slim toolbar (lives in the grid card's header
+   strip; also rendered standalone in a plain panel when nothing is selected). */
+.grid-toolbar { display: flex; align-items: flex-end; gap: 12px; flex-wrap: wrap; }
+.grid-toolbar .field { margin: 0; }
+.grid-toolbar .field label { margin-bottom: 4px; font-size: 12px; }
+.grid-toolbar .field select { width: auto; min-width: 160px; padding: 7px 10px; font-size: 13px; }
+.grid-toolbar .btn { padding: 8px 14px; font-size: 13px; }
 /* separate borders: `collapse` drops cell borders under position: sticky */
 table.data.grid { border-collapse: separate; border-spacing: 0; width: auto; min-width: 100%; font-size: 12px; }
 table.data.grid th, table.data.grid td {

--- a/src/rwa_calc/ui/app/static/report-grid.js
+++ b/src/rwa_calc/ui/app/static/report-grid.js
@@ -1,0 +1,31 @@
+/* Fit the report grid's scroll pane to the viewport.
+
+   The pane (`.grid-wrap`) is the last element on the templates page: sizing it
+   to the space below its top edge keeps its own horizontal scrollbar on screen
+   — on a 49-column return that scrollbar IS the affordance that more columns
+   exist. The stylesheet carries a static fallback (`max-height:
+   calc(100dvh - 300px)`); this trues it up to the real remainder, whatever the
+   header chrome above the grid actually takes. `max-height` (not `height`) so
+   short templates stay short. */
+(function () {
+  "use strict";
+
+  var MIN_PANE_PX = 320;
+  /* Clears what follows the pane — the grid card's 16px bottom margin plus the
+     container's 24px bottom padding — so the fitted page needs no scrollbar. */
+  var BOTTOM_MARGIN_PX = 44;
+
+  function fit() {
+    var wrap = document.querySelector(".grid-wrap");
+    if (!wrap) {
+      return;
+    }
+    var top = wrap.getBoundingClientRect().top;
+    var height = Math.max(MIN_PANE_PX, window.innerHeight - top - BOTTOM_MARGIN_PX);
+    wrap.style.maxHeight = height + "px";
+  }
+
+  window.addEventListener("resize", fit);
+  window.addEventListener("load", fit); /* re-fit once fonts have settled */
+  fit();
+})();

--- a/src/rwa_calc/ui/app/templates/report_templates.html
+++ b/src/rwa_calc/ui/app/templates/report_templates.html
@@ -3,59 +3,56 @@
 {% block container_mod %}container--wide{% endblock %}
 
 {% block content %}
+{% macro template_picker() %}
+<form class="grid-toolbar" method="get" action="/results/{{ page.run_id }}/templates">
+  <div class="field">
+    <label for="template">Template</label>
+    <select id="template" name="template" onchange="this.form.sheet.value=''; this.form.submit()">
+      {% for family, label in [("corep", "COREP"), ("pillar3", "Pillar III")] %}
+      <optgroup label="{{ label }}">
+        {% for info in page.templates if info.family == family %}
+        <option value="{{ info.id }}"{% if page.selected and info.id == page.selected.id %} selected{% endif %}>{{ info.title }}</option>
+        {% endfor %}
+      </optgroup>
+      {% endfor %}
+    </select>
+  </div>
+  {% if page.selected and page.selected.sheets %}
+  <div class="field">
+    <label for="sheet">{{ page.selected.sheet_label or "Sheet" }}</label>
+    <select id="sheet" name="sheet" onchange="this.form.submit()">
+      {% for key in page.selected.sheets %}
+      <option value="{{ key }}"{% if key == page.sheet %} selected{% endif %}>{{ key }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  {% else %}
+  <input type="hidden" name="sheet" value="">
+  {% endif %}
+  <button class="btn btn-ghost" type="submit">Show</button>
+</form>
+{% endmacro %}
+
 <div class="page-intro">
   <p class="muted"><a href="/results/{{ page.run_id }}">← Back to results</a></p>
   <h1>Report templates <span class="muted mono">· {{ page.framework }}</span></h1>
+  {% if page.templates %}
+  <p class="muted">The COREP and Pillar III templates generated from this run, exactly as they export.
+  A blank cell (<span class="mono">—</span>) is an empty or not-reported cell, which is <em>not</em>
+  the same as a reported <span class="mono">0</span>.{% if page.selected and page.has_lineage %}
+  Click any cell to see which exposures and rules produced it.{% endif %}</p>
+  {% endif %}
 </div>
 
 {% if not page.templates %}
 <div class="callout info">This run produced no report templates.</div>
-{% else %}
-<div class="page-intro">
-  <p class="muted">The COREP and Pillar III templates generated from this run, exactly as they export.
-  Cells are shown as the generator produced them — a blank cell (<span class="mono">—</span>) is an
-  empty or not-reported cell, which is <em>not</em> the same as a reported <span class="mono">0</span>.</p>
-  {% if page.selected and page.has_lineage %}
-  <p class="muted">Click any cell to see which exposures and rules produced it.</p>
-  {% endif %}
-
-  <form class="form" method="get" action="/results/{{ page.run_id }}/templates">
-    <div class="field-row">
-      <div class="field">
-        <label for="template">Template</label>
-        <select id="template" name="template" onchange="this.form.sheet.value=''; this.form.submit()">
-          {% for family, label in [("corep", "COREP"), ("pillar3", "Pillar III")] %}
-          <optgroup label="{{ label }}">
-            {% for info in page.templates if info.family == family %}
-            <option value="{{ info.id }}"{% if page.selected and info.id == page.selected.id %} selected{% endif %}>{{ info.title }}</option>
-            {% endfor %}
-          </optgroup>
-          {% endfor %}
-        </select>
-      </div>
-      {% if page.selected and page.selected.sheets %}
-      <div class="field">
-        <label for="sheet">{{ page.selected.sheet_label or "Sheet" }}</label>
-        <select id="sheet" name="sheet" onchange="this.form.submit()">
-          {% for key in page.selected.sheets %}
-          <option value="{{ key }}"{% if key == page.sheet %} selected{% endif %}>{{ key }}</option>
-          {% endfor %}
-        </select>
-      </div>
-      {% else %}
-      <input type="hidden" name="sheet" value="">
-      {% endif %}
-      <div class="field">
-        <button class="btn btn-ghost" type="submit">Show</button>
-      </div>
-    </div>
-  </form>
-</div>
-
-{% if page.selected %}
-<div class="panel">
-  <h3>{{ page.selected.title }}{% if page.sheet %} <span class="muted mono">· {{ page.sheet }}</span>{% endif %}
-    <span class="muted">· {{ page.columns | length }} columns</span></h3>
+{% elif page.selected %}
+<div class="panel panel--grid">
+  <div class="grid-head">
+    <h3>{{ page.selected.title }}{% if page.sheet %} <span class="muted mono">· {{ page.sheet }}</span>{% endif %}
+      <span class="muted">· {{ page.columns | length }} columns</span></h3>
+    {{ template_picker() }}
+  </div>
   <div class="grid-wrap">
     <table class="data grid" data-template="{{ page.selected.id }}" data-sheet="{{ page.sheet or '' }}">
       <thead>
@@ -93,7 +90,13 @@
   </div>
 </div>
 {% else %}
+<div class="panel">
+  {{ template_picker() }}
+</div>
 <div class="callout info">That template is not available for this run.</div>
 {% endif %}
-{% endif %}
+{% endblock %}
+
+{% block scripts %}
+<script defer src="/static/report-grid.js"></script>
 {% endblock %}


### PR DESCRIPTION
## Problem

On the report-templates page, wide COREP templates looked like they were **overflowing the card**:

- The grid was a scroll pane with a near-invisible border *inside* a padded panel card (double frame), so on C 07.00 (28 columns) / C 08.02 (49 columns) the columns were chopped mid-digit at an edge that read as accidental clipping rather than a scroll window.
- On tall templates the pane's horizontal scrollbar landed **below the fold** (the intro + picker form pushed the grid top to ~450px while the CSS height cap assumed ~260px), so the on-screen result was clipped columns with no scrollbar visible anywhere and no apparent way to reach the remaining columns.

## Change

The grid card is now itself the window:

- **`report_templates.html`** — the card gets a header strip (template title · sheet · column count) with the template/sheet picker folded in as a slim toolbar, replacing the separate form card and reclaiming ~200px of page chrome. The scroll pane sits flush inside the card frame, so columns clip exactly at the card border like a spreadsheet freeze pane. When no template is selected the picker still renders standalone above the callout.
- **`app.css`** — new `panel--grid` / `grid-head` / `grid-toolbar` rules; the pane gains thin, visible scrollbars (`scrollbar-width`/`scrollbar-color`); `container--wide` drops its 64px prose tail to 24px so the fitted page needs no scrollbar of its own.
- **`static/report-grid.js`** (new, ~20 lines) — fits the pane's `max-height` to the actual viewport remainder on load/resize so the horizontal scrollbar is always on screen; the stylesheet keeps a `calc(100dvh - 300px)` no-JS fallback. `max-height`, not `height`, so short templates (C 02.00, one-row C 08.02 sheets) stay short.

Frozen header band, frozen row labels, cell keys, lineage drill-down links and the null-vs-zero rendering are unchanged.

## Verification

- Drove the real app headlessly (Basel 3.1 run over `tests/fixtures`) and screenshotted C 07.00, C 08.02 and C 02.00 at 1600×900 and 1280×768: no page-level scrollbar, pane's horizontal scrollbar visible on the first screen, grid clipping exactly at the card frame, sticky headers/row labels intact.
- Smoke-tested the unknown-template branch (picker + callout, HTTP 200) and confirmed the picker's auto-submit is untouched by `busy-overlay.js` (it only acts on `data-busy-overlay` forms).
- `uv run pytest tests/unit/ui tests/integration/test_ui_app.py` — **203 passed**, including the grid-styles contract tests.
- Changelog entry added under Unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)