### PR TITLE
perf(crm): linear re_split error dedup + CRM018 rolled up to one count warning

### DIFF
--- a/docs/appendix/changelog.md
+++ b/docs/appendix/changelog.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - (Next release changes will go here)
 
+### Fixed
+- **The "Real-estate split" stage no longer stalls for minutes on portfolios with unattested equity collateral — the error-channel dedup is linear again, and CRM018 is one rolled-up warning instead of one per row.** The P1.271 listing gate (v0.3.14) conservatively rules equity collateral with unknown index membership / listing ineligible, and emitted a CRM018 warning per gated row — 13k+ warnings on a 100k-exposure book when the attestation columns are unpopulated. The re_split stage adapter dedups splitter errors against the CRM channel with a list-membership scan that is O(N×M) in the two lists, which the flood turned quadratic: ~11s of a ~20s pipeline run at 100k scale, surfacing in the rwa-ui stepper as the "Real-estate split" step hanging (reported in the field as c.40s → 5min+, run abandoned). Fixed at both ends: the dedup builds a set of the prior CRM errors once (frozen-dataclass equality preserved via hashing — identical semantics, linear cost), and `_record_non_main_index_equity_ineligible` rolls CRM018 up to a single count-carrying warning per run, following the splitter's RE002–RE004 per-cause idiom. Measured at 100k (CRR): re_splitter 11,080ms → 254ms, total run 19.9s → 8.1s, error channel 13,361 → 4 entries. The gate itself (value zeroing + eligibility clearing) is untouched — RWA outputs are identical; only warning cardinality and wall time change. Ref: CRR/PS1-26 Art. 197(1)(f)/198(1)(a).
+
 ---
 
 ## [0.3.15] - 2026-07-20

--- a/src/rwa_calc/engine/crm/collateral.py
+++ b/src/rwa_calc/engine/crm/collateral.py
@@ -766,39 +766,36 @@ def _record_non_main_index_equity_ineligible(
     collateral: pl.LazyFrame,
     errors: list[CalculationError],
 ) -> None:
-    """Append one CRM018 warning per non-main-index equity collateral row ruled
-    ineligible by the CRR/PS1-26 Art. 197(1)(f)/198(1)(a) listing gate.
+    """Append ONE rolled-up CRM018 warning counting the equity collateral rows
+    ruled ineligible by the CRR/PS1-26 Art. 197(1)(f)/198(1)(a) listing gate.
 
     The gate itself (value zeroing + is_eligible_financial_collateral clearing) is
     applied in ``HaircutCalculator.apply_haircuts``; this re-derives the SAME
     shared predicate on the post-haircut frame purely to emit the data-quality
-    warning. Targeted collect of the gated rows only — the accepted emission idiom
-    (P1.264); the collateral table is a small dimension frame. Reusing the one
+    warning. Rolled up to a per-cause count (the splitter's RE002-RE004 idiom):
+    portfolios with unattested index/listing flags gate thousands of rows, and
+    per-row emission floods the error channel — 13k+ warnings at 100k-exposure
+    scale made the re_split stage's error dedup quadratic. Reusing the one
     predicate keeps the warning from drifting from the zeroed number.
     """
     names = collateral.collect_schema().names()
     gate = non_main_index_equity_ineligible_expr(names)
-    select_cols: list[pl.Expr] = [gate.alias("_gated")]
-    select_cols.extend(
-        pl.col(c) for c in ("collateral_reference", "beneficiary_reference") if c in names
-    )
-    gated = collateral.filter(gate).select(select_cols).collect()
-    for row in gated.iter_rows(named=True):
-        coll_ref = row.get("collateral_reference")
-        ben_ref = row.get("beneficiary_reference")
-        errors.append(
-            crm_warning(
-                ERROR_NON_MAIN_INDEX_EQUITY_INELIGIBLE,
-                f"Equity collateral '{coll_ref}' securing exposure '{ben_ref}' is "
-                f"neither included in a main index (Art. 197(1)(f)) nor attested "
-                f"listed on a recognised exchange (Art. 198(1)(a); is_main_index and "
-                f"is_listed are both False/unset), so it is ineligible financial "
-                f"collateral; its value is zeroed and it is excluded from credit "
-                f"risk mitigation.",
-                exposure_reference=ben_ref,
-                regulatory_reference="CRR/PS1-26 Art. 197(1)(f)/198(1)(a)",
-            )
+    count_df = collateral.select(gate.cast(pl.UInt32).sum().alias("gated")).collect()
+    count = int(count_df.item() or 0) if count_df.height > 0 else 0
+    if count <= 0:
+        return
+    errors.append(
+        crm_warning(
+            ERROR_NON_MAIN_INDEX_EQUITY_INELIGIBLE,
+            f"{count} equity collateral row(s) are neither included in a main "
+            f"index (Art. 197(1)(f)) nor attested listed on a recognised "
+            f"exchange (Art. 198(1)(a); is_main_index and is_listed both "
+            f"False/unset), so they are ineligible financial collateral; their "
+            f"values are zeroed and they are excluded from credit risk "
+            f"mitigation.",
+            regulatory_reference="CRR/PS1-26 Art. 197(1)(f)/198(1)(a)",
         )
+    )
 
 
 def _record_credit_linked_note_not_own_issued(

--- a/src/rwa_calc/engine/stages/re_split/stage.py
+++ b/src/rwa_calc/engine/stages/re_split/stage.py
@@ -80,10 +80,13 @@ def run(
 
     # Splitter accumulates errors into the CRM bucket so existing error
     # reporting continues to capture them; skip duplicates already
-    # accounted for upstream by the CRM stage (frozen-dataclass equality).
+    # accounted for upstream by the CRM stage (frozen-dataclass equality,
+    # via set membership: the CRM channel can carry thousands of per-row
+    # warnings, and a list scan here is quadratic in that count).
     # Unified error channel: NEW splitter errors (RE*) reach the result
     # verbatim — original code/severity/category preserved, never PIPELINE_*.
-    new_errors = [error for error in result.crm_errors if error not in crm_adjusted.crm_errors]
+    prior_errors = set(crm_adjusted.crm_errors)
+    new_errors = [error for error in result.crm_errors if error not in prior_errors]
     ctx = append_stage_errors(ctx, *new_errors)
 
     # Opt-in audit cache: per-parent secured/residual split reconciliation.

--- a/tests/unit/crm/test_crm018_rollup.py
+++ b/tests/unit/crm/test_crm018_rollup.py
@@ -1,0 +1,108 @@
+"""
+CRM018 rollup: one per-cause count warning, not one warning per gated row.
+
+Why this matters:
+    The P1.271 listing gate (CRR/PS1-26 Art. 197(1)(f)/198(1)(a)) rules equity
+    collateral with unknown index membership / listing ineligible. On real
+    portfolios that is thousands of rows; emitting one CRM018 per row floods
+    the error channel (13k+ warnings at 100k-exposure scale) and turned the
+    re_split stage's error dedup quadratic (~11s of a ~20s run). CRM018 now
+    rolls up to a single count-carrying warning per run, following the
+    splitter's RE002-RE004 idiom.
+
+References:
+    CRR Art. 197(1)(f): main-index equities eligible under all methods.
+    CRR Art. 198(1)(a): non-main-index equities eligible only if listed.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+from rwa_calc.contracts.errors import (
+    ERROR_NON_MAIN_INDEX_EQUITY_INELIGIBLE,
+    CalculationError,
+    ErrorSeverity,
+)
+from rwa_calc.engine.crm.collateral import _record_non_main_index_equity_ineligible
+
+
+def _collateral_frame(
+    collateral_types: list[str],
+    is_main_index: list[bool | None],
+    is_listed: list[bool | None],
+) -> pl.LazyFrame:
+    """Minimal post-haircut collateral frame carrying the gate's signal columns."""
+    n = len(collateral_types)
+    return pl.LazyFrame(
+        {
+            "collateral_reference": [f"COLL{i}" for i in range(n)],
+            "beneficiary_reference": [f"LOAN{i}" for i in range(n)],
+            "collateral_type": collateral_types,
+            "is_main_index": is_main_index,
+            "is_listed": is_listed,
+        },
+        schema={
+            "collateral_reference": pl.String,
+            "beneficiary_reference": pl.String,
+            "collateral_type": pl.String,
+            "is_main_index": pl.Boolean,
+            "is_listed": pl.Boolean,
+        },
+    )
+
+
+class TestCrm018RollsUpToOneWarning:
+    """CRM018 is one count-carrying warning per run, per the RE002 idiom."""
+
+    def test_multiple_gated_rows_emit_single_warning(self) -> None:
+        # Arrange: 3 gated equities, 1 main-index equity, 1 bond (both ungated).
+        lf = _collateral_frame(
+            collateral_types=["equity", "equity", "equity", "equity", "corp_bond"],
+            is_main_index=[None, False, None, True, None],
+            is_listed=[None, None, False, None, None],
+        )
+        errors: list[CalculationError] = []
+
+        # Act
+        _record_non_main_index_equity_ineligible(lf, errors)
+
+        # Assert: exactly one rolled-up CRM018 carrying the gated-row count.
+        assert len(errors) == 1
+        warning = errors[0]
+        assert warning.code == ERROR_NON_MAIN_INDEX_EQUITY_INELIGIBLE
+        assert warning.severity == ErrorSeverity.WARNING
+        assert "3" in warning.message
+        assert warning.regulatory_reference == "CRR/PS1-26 Art. 197(1)(f)/198(1)(a)"
+
+    def test_no_gated_rows_emit_nothing(self) -> None:
+        # Arrange: main-index and listed equities plus a bond — nothing gated.
+        lf = _collateral_frame(
+            collateral_types=["equity", "equity", "corp_bond"],
+            is_main_index=[True, False, None],
+            is_listed=[None, True, None],
+        )
+        errors: list[CalculationError] = []
+
+        # Act
+        _record_non_main_index_equity_ineligible(lf, errors)
+
+        # Assert
+        assert errors == []
+
+    def test_missing_signal_columns_is_a_no_op(self) -> None:
+        # Arrange: legacy frame without is_main_index / is_listed — gate disabled.
+        lf = pl.LazyFrame(
+            {
+                "collateral_reference": ["COLL0"],
+                "beneficiary_reference": ["LOAN0"],
+                "collateral_type": ["equity"],
+            }
+        )
+        errors: list[CalculationError] = []
+
+        # Act
+        _record_non_main_index_equity_ineligible(lf, errors)
+
+        # Assert
+        assert errors == []


### PR DESCRIPTION
## Summary

Fixes the field-reported regression where a calculation that took ~40s now runs 5+ minutes, with the rwa-ui stepper parked on **"Real-estate split"**.

- **Root cause**: the P1.271 listing gate (v0.3.14) emits one CRM018 warning per gated equity collateral row — 13k+ on a 100k book whose `is_main_index`/`is_listed` attestations are unpopulated. The re_split stage adapter dedups splitter errors against the CRM channel with a list-membership scan, O(N×M) in the two error lists — quadratic under the flood (~11s of a ~20s run at 100k scale; grows with the square of the warning count on larger books).
- **Fix 1 — `engine/stages/re_split/stage.py`**: dedup via a set of the prior CRM errors. `CalculationError` is a frozen dataclass with all-hashable fields, so set membership preserves the exact frozen-dataclass-equality semantics at linear cost.
- **Fix 2 — `engine/crm/collateral.py`**: `_record_non_main_index_equity_ineligible` rolls CRM018 up to a **single count-carrying warning per run**, following the splitter's RE002–RE004 per-cause idiom. The gate itself (value zeroing + eligibility clearing) is untouched — RWA outputs are identical.

## Measured (synthetic 100K, CRR)

| | v0.3.13 | v0.3.15 | this PR |
|---|---|---|---|
| re_splitter stage | 259 ms | 11,080 ms | 254 ms |
| total pipeline | 5.0 s | 19.9 s | 8.1 s |
| error-channel entries | — | 13,361 | 4 |

Residual v0.3.13 → HEAD delta is the linear cost of the new CRM features (third-party deposits etc.), out of scope here.

## Tests

- New `tests/unit/crm/test_crm018_rollup.py` (TDD): multiple gated rows → exactly one count-carrying CRM018; zero gated rows → nothing; missing signal columns → no-op.
- P1.271 acceptance suites (CRR + B31) pass unchanged — single-gated-row scenarios still see exactly one CRM018 with the same regulatory reference.
- Gate: arch_check clean, ruff clean, ty clean, full unit (6,291) + acceptance/integration/oracle (2,236) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)