### PR TITLE
fix(reporting): stop C 08.01/02 reporting every guarantee twice

### DIFF
--- a/docs/appendix/changelog.md
+++ b/docs/appendix/changelog.md
@@ -14,6 +14,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (Next release changes will go here)
 
 ### Fixed
+- **C 08.01 / C 08.02 reported every guarantee twice — once in the CRM substitution block
+  and again in the CRM-in-LGD block.** Cols 0150 (guarantees) and 0160 (credit
+  derivatives) bound `Sum("guaranteed_portion")` behind the *same* `protection_type`
+  predicate cols 0040/0050 already use, so a single £400k guarantee was published as a
+  £400k "(-)" substitution outflow at col 0040 **and** a £400k LGD mitigant at col 0150 on
+  the same sheet.
+  - **The two blocks are mutually exclusive by instruction.** Annex II partitions unfunded
+    protection by effect — "Guarantees shall be reported in column 0040 where the
+    adjustment is not made in the LGD. Where the adjustment is made in the LGD, the amount
+    of the guarantee shall be reported in column 0150" — and the cols 0150-0210 heading
+    bars the other side outright: "CRM techniques that have an impact on LGD estimates as a
+    result of the application of the substitution effect of CRM techniques shall not be
+    included in these columns". PS1/26 Annex II partitions the same population by named
+    method: 0040/0050 are the Risk-Weight Substitution and Parameter Substitution Methods,
+    0150/0160 the Article 183 LGD Adjustment Method.
+  - **The engine only ever produces the substitution half.**
+    `engine/irb/guarantee.py::apply_guarantee_substitution` implements SA risk-weight
+    substitution (Art. 235), parameter substitution (Art. 161(3) / CRE22.70-85) and double
+    default (Art. 153(3)) — none of which is the LGD Adjustment Method. Cols 0150/0160
+    therefore now report the recorded constant `0.0`, the convention cols 0170-0173 already
+    followed. The funded half of the block (cols 0180-0210, Art. 197/199 collateral) is
+    untouched and keeps reporting: collateral genuinely is an LGD mitigant.
+  - **The two bindings did not even agree in magnitude.** Cols 0040/0050 read the Annex II
+    block-capped twin (`c08_prot_guaranteed`); cols 0150/0160 read the raw carrier. On a
+    leg where the cap bit, the template published a full-value 0150 against a scaled-down
+    0040 with nothing to flag the divergence.
+  - **No golden file moved.** Cols 0150/0160 are `0.0` in every committed C 08.01/02
+    expected output because no reporting golden portfolio carries a guaranteed IRB leg —
+    which is exactly why the duplication survived. The four new regression tests supply
+    that missing coverage.
+  - **Known residual, tracked separately:** Annex II routes double-default unfunded
+    protection to col 0220 *instead of* col 0040, and a double-default leg is not
+    substituted at all, so it should raise no outflow. Today such a leg reports in
+    0040/0070 and 0220. Correcting it moves the col 0090 waterfall, so it is not bundled
+    here.
 - **The release changelog promoter truncated every multi-line bullet to its first line.**
   `scripts/_deploy_changelog.py` collected only lines beginning `- ` when moving
   `[Unreleased]` into a new version section, so wrapped continuation text and nested

--- a/src/rwa_calc/reporting/corep/c08.py
+++ b/src/rwa_calc/reporting/corep/c08.py
@@ -46,6 +46,16 @@ Cell semantics (recorded decisions, this slice):
   collateral is out. Col 0070 (the outflow) is the already-capped SUBTOTAL of
   that block and so is not capped again. See the helper for the quoted
   instructions behind each of these.
+- THE TWO CRM BLOCKS ARE MUTUALLY EXCLUSIVE, so cols 0150/0160 report a constant
+  0.0 instead of restating cols 0040/0050 (which they did, behind the very same
+  ``protection_type`` predicate, publishing every guarantee twice per sheet).
+  Annex II splits unfunded protection by EFFECT — its cols 0150-0210 heading bars
+  "the substitution effect of CRM techniques" outright — and PS1/26 by NAMED
+  METHOD: 0040/0050 = Risk-Weight / Parameter Substitution, 0150/0160 = the
+  Art. 183 LGD Adjustment Method, which ``engine/irb/guarantee.py`` never
+  applies. The FUNDED half (0180-0210, Art. 197/199 collateral) still reports.
+  Rationale, evidence and the col 0220 double-default residual: see the pin
+  ``test_c08_crm_substitution.py::TestCrmInLgdBlockExcludesSubstitutedProtection``.
 - The CRM SUBSTITUTION BLOCK IS A TWO-STEP WATERFALL — the C 07.00 shape
   (``corep/c07.py::_substitution_outflow`` / ``::_net_after_substitution``) on
   the IRB surface, written to the published identities rather than re-derived:
@@ -672,21 +682,11 @@ def _value_cells(  # noqa: C901, PLR0915 - the full C 08.01/02 column surface
         "0125": CellSpec(Sum(ead_col), predicate=narrowed(("c08_defaulted", True))),
         "0130": CellSpec(Formula(refs=(), fn=_const(None))),
         "0140": _lfse_cell(cols, lambda: Sum(ead_col), terms),
-        "0150": (
-            CellSpec(
-                Sum("guaranteed_portion"), predicate=narrowed(("protection_type", "guarantee"))
-            )
-            if "protection_type" in cols
-            else CellSpec(Sum("guaranteed_portion"), predicate=member)
-        ),
-        "0160": (
-            CellSpec(
-                Sum("guaranteed_portion"),
-                predicate=narrowed(("protection_type", "credit_derivative")),
-            )
-            if "protection_type" in cols
-            else CellSpec(Formula(refs=(), fn=_const(0.0)))
-        ),
+        # 0150/0160: the CRM-in-LGD twins of cols 0040/0050, mutually exclusive
+        # with them and empty on today's calculator (module docstring). The
+        # recorded constant 0.0 is the convention cols 0170-0173 already follow.
+        "0150": CellSpec(Formula(refs=(), fn=_const(0.0))),
+        "0160": CellSpec(Formula(refs=(), fn=_const(0.0))),
         "0170": CellSpec(Formula(refs=(), fn=_const(0.0))),
         "0171": CellSpec(Formula(refs=(), fn=_const(0.0))),
         "0172": CellSpec(Formula(refs=(), fn=_const(0.0))),

--- a/tests/unit/reporting/corep/test_c08_01.py
+++ b/tests/unit/reporting/corep/test_c08_01.py
@@ -693,13 +693,27 @@ class TestDoubleDefaultCOREP:
                 assert total["0220"][0] is None or total["0220"][0] == pytest.approx(0.0)
 
     def test_dd_unfunded_included_in_total_guarantees(self) -> None:
-        """DD unfunded is a subset of total unfunded protection."""
+        """DD unfunded is a subset of total unfunded protection.
+
+        Measured against col 0040 (the SUBSTITUTION guarantees column) rather
+        than col 0150: the CRM-in-LGD twin is structurally empty now that the
+        two blocks no longer restate each other, so comparing against it would
+        assert nothing. Col 0040 carries the "(-)" Annex II sign, hence the abs.
+
+        KNOWN RESIDUAL this test now makes visible: Annex II routes DD unfunded
+        protection to col 0220 INSTEAD of col 0040 ("Regarding exposures subject
+        to the double default treatment, the value of unfunded credit protection
+        shall be reported in column 0220"), so a DD leg should raise no outflow
+        at all. Today it reports in both. Correcting that moves the col 0090
+        waterfall and is tracked separately; the subset relation asserted here
+        holds either way.
+        """
         gen = LedgerShimCorepGenerator()
         bundle = gen.generate_from_lazyframe(_irb_results_with_double_default(), framework="CRR")
         corp = bundle.c08_01["corporate"]
         total = corp.filter(pl.col("row_ref") == "0010")
         dd_amount = total["0220"][0]
-        guar_amount = total["0150"][0] if "0150" in total.columns else None
+        guar_amount = abs(total["0040"][0]) if total["0040"][0] is not None else None
         # DD unfunded should be <= total guarantees (DD is a subset of guarantee treatments)
         if dd_amount is not None and guar_amount is not None:
             assert dd_amount <= guar_amount + 0.01

--- a/tests/unit/reporting/corep/test_c08_crm_substitution.py
+++ b/tests/unit/reporting/corep/test_c08_crm_substitution.py
@@ -672,3 +672,118 @@ class TestC0802OutflowSubtotal:
         expected = row["0020"][0] + row["0070"][0]
         assert row["0090"][0] == pytest.approx(expected)
         assert row["0090"][0] == pytest.approx(2_200.0)
+
+
+class TestCrmInLgdBlockExcludesSubstitutedProtection:
+    """Cols 0150/0160 must NOT restate the protection cols 0040/0050 report.
+
+    The two blocks are mutually exclusive by instruction, and the engine only
+    ever produces the substitution half, so the CRM-in-LGD unfunded columns are
+    structurally empty on today's calculator (the convention cols 0170-0173
+    already follow).
+
+    Annex II (CR IRB, docs/assets/crr-annex-ii-reporting-instructins.pdf p.99):
+      col 0040 "Guarantees shall be reported in column 0040 where the adjustment
+      is NOT made in the LGD. Where the adjustment IS made in the LGD, the amount
+      of the guarantee shall be reported in column 0150."
+      col 0050 "Where the adjustment is made in the LGD, the amount of the credit
+      derivatives shall be reported in column 0160."
+      cols 0150-0210 heading (p.100) "CRM techniques that have an impact on LGD
+      estimates as a result of the application of the substitution effect of CRM
+      techniques shall NOT be included in these columns."
+
+    PS1/26 Annex II (OF 08.01, ps1-26-annex-ii-reporting-instructions.pdf p.102-107)
+    names the methods instead of the effect, and partitions them the same way:
+      col 0040 "Guarantees shall be reported in column 0040 where the Risk Weight
+      Substitution Method or the Parameter Substitution Method ... is applied."
+      col 0150 "Exposures subject to the LGD Adjustment Method (in accordance with
+      Article 183 ...) shall be included."
+      cols 0150-0210 heading "CRM techniques that have an impact on LGD estimates
+      as a result of the application of the Parameter Substitution Method shall
+      not be included in these columns."
+
+    ``engine/irb/guarantee.py::apply_guarantee_substitution`` implements exactly
+    three routes — SA risk-weight substitution (Art. 235), parameter substitution
+    (Art. 161(3) / CRE22.70-85) and double default (Art. 153(3)) — and none of
+    them is the Art. 183 LGD Adjustment Method. Every guarantee the engine
+    recognises therefore belongs in 0040/0050 and none in 0150/0160.
+
+    What this replaced: both columns bound ``Sum("guaranteed_portion")`` behind
+    the SAME ``protection_type`` predicate cols 0040/0050 use, so every guarantee
+    was reported twice on one sheet — once as a "(-)" substitution outflow and
+    once as an LGD mitigant. The two bindings were not even the same magnitude:
+    0040/0050 read the Annex II-capped twin (``c08_prot_guaranteed``) while
+    0150/0160 read the RAW carrier, so on a leg where the block cap bit they
+    disagreed silently. Not caught by the golden estate because no reporting
+    golden portfolio carries a guaranteed IRB leg — cols 0150/0160 are 0.0 in
+    every committed C 08.01/02 expected-output file.
+    """
+
+    def test_guarantee_reported_only_in_the_substitution_block(self) -> None:
+        """A guarantee lands on col 0040 and NOT on col 0150."""
+        # Arrange
+        gen = LedgerShimCorepGenerator()
+
+        # Act
+        bundle = gen.generate_from_lazyframe(_irb_results_different_class_guarantee())
+        total = _get_total_row(bundle.c08_01["corporate"])
+
+        # Assert
+        assert total["0040"][0] == pytest.approx(-800.0)
+        assert total["0150"][0] == pytest.approx(0.0)
+
+    def test_credit_derivative_reported_only_in_the_substitution_block(self) -> None:
+        """A credit derivative lands on col 0050 and NOT on col 0160."""
+        # Arrange
+        gen = LedgerShimCorepGenerator()
+
+        # Act
+        bundle = gen.generate_from_lazyframe(_irb_results_credit_derivative_different_class())
+        total = _get_total_row(bundle.c08_01["corporate"])
+
+        # Assert
+        assert total["0050"][0] == pytest.approx(-600.0)
+        assert total["0160"][0] == pytest.approx(0.0)
+
+    def test_c08_02_shares_the_exclusion(self) -> None:
+        """C 08.02 shares ``_value_cells``, so its grade rows exclude it too.
+
+        ``boe_b0752_12`` / ``boe_b0752_13`` (live, ERROR) tie
+        ``{OF08.01 r0070, c0150}`` and ``{c0160}`` to ``sum({OF08.02})`` on the
+        same columns, so the two templates must agree — 0 == 0 here.
+        """
+        # Arrange
+        gen = LedgerShimCorepGenerator()
+
+        # Act
+        bundle = gen.generate_from_lazyframe(_irb_results_different_class_guarantee())
+        row = bundle.c08_02["corporate"].filter(pl.col("row_ref") == "0.75% - 2.50%")
+        graded = bundle.c08_01["corporate"].filter(pl.col("row_ref") == "0070")
+
+        # Assert
+        assert row["0150"][0] == pytest.approx(0.0)
+        assert row["0160"][0] == pytest.approx(0.0)
+        assert graded["0150"][0] == pytest.approx(0.0)
+        assert graded["0160"][0] == pytest.approx(0.0)
+
+    def test_art_199_collateral_columns_are_untouched(self) -> None:
+        """The FUNDED half of the CRM-in-LGD block still reports.
+
+        Cols 0180-0210 are the Art. 199 / Art. 197 collateral columns — genuine
+        LGD mitigants that never route through substitution — so removing the
+        unfunded duplication must not touch them.
+        """
+        # Arrange
+        gen = LedgerShimCorepGenerator()
+        frame = _irb_results_different_class_guarantee().with_columns(
+            pl.Series("collateral_re_value", [0.0, 500.0, 0.0]),
+            pl.Series("collateral_financial_value", [250.0, 0.0, 0.0]),
+        )
+
+        # Act
+        bundle = gen.generate_from_lazyframe(frame)
+        total = _get_total_row(bundle.c08_01["corporate"])
+
+        # Assert
+        assert total["0180"][0] == pytest.approx(250.0)
+        assert total["0190"][0] == pytest.approx(500.0)

--- a/tests/unit/reporting/corep/test_cross.py
+++ b/tests/unit/reporting/corep/test_cross.py
@@ -958,7 +958,15 @@ class TestCollateralMethodSplit:
         assert total["0173"][0] == pytest.approx(0.0)
 
     def test_c08_guarantees_unfunded(self) -> None:
-        """C 08.01 col 0150 = guaranteed_portion sum."""
+        """C 08.01 reports a guarantee at col 0040, not at col 0150.
+
+        The two CRM blocks are mutually exclusive (Annex II cols 0150-0210
+        heading; PS1/26 splits the same population by named method), and the
+        engine only produces the substitution half, so the CRM-in-LGD unfunded
+        column is structurally empty. This assertion previously read col 0150 —
+        the duplicated half — see ``corep/c08.py`` and
+        ``test_c08_crm_substitution.py::TestCrmInLgdBlockExcludesSubstitutedProtection``.
+        """
         gen = LedgerShimCorepGenerator()
         bundle = gen.generate_from_lazyframe(
             _irb_results_with_collateral_split(), framework="BASEL_3_1"
@@ -966,8 +974,9 @@ class TestCollateralMethodSplit:
         corp = bundle.c08_01["corporate"]
         total = corp.filter(pl.col("row_ref") == "0010")
 
-        # guaranteed_portion = 0 + 500 = 500
-        assert total["0150"][0] == pytest.approx(500.0)
+        # guaranteed_portion = 0 + 500 = 500, reported as a "(-)" outflow
+        assert total["0040"][0] == pytest.approx(-500.0)
+        assert total["0150"][0] == pytest.approx(0.0)
 
     def test_c08_other_funded_for_irb(self) -> None:
         """C 08.01 col 0060 (Art. 232 substitution route) excludes Art. 199
@@ -1070,7 +1079,12 @@ class TestCreditDerivativeTracking:
         assert total["0050"][0] == pytest.approx(-400.0)
 
     def test_c08_unfunded_protection_split(self) -> None:
-        """C 08.01 col 0150=guarantee, col 0160=credit derivative."""
+        """C 08.01 col 0040=guarantee, col 0050=credit derivative.
+
+        The protection_type split lives in the SUBSTITUTION block; its
+        CRM-in-LGD twins (0150/0160) are structurally empty on today's
+        calculator, which produces no Art. 183 LGD Adjustment Method route.
+        """
         gen = LedgerShimCorepGenerator()
         bundle = gen.generate_from_lazyframe(
             _irb_results_with_credit_derivatives(), framework="BASEL_3_1"
@@ -1078,10 +1092,13 @@ class TestCreditDerivativeTracking:
         corp = bundle.c08_01["corporate"]
         total = corp.filter(pl.col("row_ref") == "0010")
 
-        # Col 0150: unfunded guarantees = 800.0
-        assert total["0150"][0] == pytest.approx(800.0)
-        # Col 0160: unfunded credit derivatives = 400.0
-        assert total["0160"][0] == pytest.approx(400.0)
+        # Col 0040: unfunded guarantees = 800.0, as a "(-)" outflow
+        assert total["0040"][0] == pytest.approx(-800.0)
+        # Col 0050: unfunded credit derivatives = 400.0, as a "(-)" outflow
+        assert total["0050"][0] == pytest.approx(-400.0)
+        # Their CRM-in-LGD twins must not restate the same protection
+        assert total["0150"][0] == pytest.approx(0.0)
+        assert total["0160"][0] == pytest.approx(0.0)
 
     def test_c08_pre_credit_derivatives_rwea(self) -> None:
         """C 08.01 col 0310 = total RWEA (pre-credit-derivative baseline)."""


### PR DESCRIPTION
## What

C 08.01 / C 08.02 reported every guarantee **twice** — once in the CRM substitution block and again in the CRM-in-LGD block. Cols 0150 (guarantees) and 0160 (credit derivatives) bound `Sum("guaranteed_portion")` behind the *same* `protection_type` predicate cols 0040/0050 already use.

Reported by a user against v0.3.21. Reproduced end-to-end (A-IRB `retail_other`, £500k loan, 80% UK-government guarantee):

```
                        before                         after
C 08.01 [retail_other]  0020=500,000                   0020=500,000
                        0040=-400,000  0070=-400,000   0040=-400,000  0070=-400,000
                        0150= 400,000  <-- duplicate   0150=       0
```

## Why cols 0150/0160 must be empty

The two blocks are mutually exclusive by instruction, and the split is stated in both rulebooks:

- **Annex II** partitions by *effect* — col 0040: *"Guarantees shall be reported in column 0040 where the adjustment is not made in the LGD. Where the adjustment is made in the LGD, the amount of the guarantee shall be reported in column 0150."* The cols 0150-0210 heading bars the other side outright: *"CRM techniques that have an impact on LGD estimates as a result of the application of the substitution effect of CRM techniques shall not be included in these columns."*
- **PS1/26 Annex II** partitions the same population by *named method* — 0040/0050 = Risk-Weight Substitution and Parameter Substitution Methods; 0150/0160 = the Article 183 LGD Adjustment Method.

`engine/irb/guarantee.py::apply_guarantee_substitution` implements exactly three routes — Art. 235 risk-weight substitution, Art. 161(3) / CRE22.70-85 parameter substitution, Art. 153(3) double default — and **none is the LGD Adjustment Method**. So on today's calculator every recognised guarantee belongs in the substitution block, and the CRM-in-LGD *unfunded* columns are structurally empty. They now report the recorded constant `0.0`, the convention cols 0170-0173 already followed.

The **funded** half of the block (cols 0180-0210, Art. 197/199 collateral) is untouched and keeps reporting — collateral genuinely is an LGD mitigant.

## The bindings did not even agree in magnitude

Cols 0040/0050 read the Annex II block-capped twin (`c08_prot_guaranteed`); cols 0150/0160 read the **raw** carrier. On a leg where the cap bit, the template published a full-value 0150 against a scaled-down 0040 with nothing to flag the divergence.

## Why it survived

No golden file moved. Cols 0150/0160 are `0.0` in **every** committed C 08.01/02 expected output, because no reporting golden portfolio carries a guaranteed IRB leg. The block was entirely uncovered — the same gap that hid the col 0070 defects fixed in #451. The four new tests supply that coverage.

## Published rules

`boe_b0752_12` / `boe_b0752_13` (live, ERROR) tie `{OF08.01 r0070, c0150}` and `{c0160}` to `sum({OF08.02})` on the same columns. C 08.01 and C 08.02 share `_value_cells`, so the identity holds at `0 == 0`. The non-negativity rules over `OF08.01.01.01` are likewise satisfied.

## Tests

New `TestCrmInLgdBlockExcludesSubstitutedProtection` in `test_c08_crm_substitution.py`:
- a guarantee lands on 0040 and not 0150
- a credit derivative lands on 0050 and not 0160
- C 08.02 shares the exclusion (both templates, `boe_b0752_12/13`)
- the Art. 199 collateral columns 0180/0190 are untouched

Three pre-existing tests pinned the duplicated behaviour and were re-pointed at the substitution columns (`test_cross.py::test_c08_guarantees_unfunded`, `::test_c08_unfunded_protection_split`, `test_c08_01.py::test_dd_unfunded_included_in_total_guarantees`).

## Known residual (not bundled)

Annex II routes double-default unfunded protection to col 0220 **instead of** col 0040, and a DD leg is not substituted at all, so it should raise no outflow. Today it reports in 0040/0070 *and* 0220. Correcting that moves the col 0090 waterfall, so it belongs in its own change; recorded in the module docstring and in `test_dd_unfunded_included_in_total_guarantees`.

## Validation gate

- `scripts/arch_check.py` — clean, **no ratchet baseline bump** (`c08.py` back to its pre-change 2208 lines)
- `ruff check` / `ruff format --check` — clean
- `ty check` — 4 diagnostics, all pre-existing (identical count with the change stashed)
- `pytest tests/unit` — 7,250 passed, 1 skipped
- `pytest tests/acceptance tests/integration tests/contracts tests/oracle` — 3,308 passed, 1 skipped

