### PR TITLE
fix(reporting): put CRM-substituted exposure value and RWEA on the guarantor's basis

### DIFF
--- a/docs/appendix/changelog.md
+++ b/docs/appendix/changelog.md
@@ -13,6 +13,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - (Next release changes will go here)
 
+### Fixed
+- **CRM substitution: the covered part's exposure value and RWEA never followed it to the
+  guarantor.** A guaranteed exposure's covered part correctly left the obligor's sheet
+  through the pre-CCF flow columns, but every *exposure-value* and *RWEA* column stayed
+  keyed to the obligor. A £10m slotting loan guaranteed by a CQS1 corporate at 20%
+  reported cols 0100/0110/0150 = £10m on the guarantor's C 07.00 sheet with col 0200 = 0
+  and col 0220 = 0 — the £2m of RWEA appeared nowhere on the template. With a 0%-RW
+  sovereign guarantor col 0220 = 0 is right by coincidence, which is how it survived.
+  - **Annex II is explicit.** Col 0200 is the "exposure value after taking into account
+    value adjustments, **all credit risk mitigants** and conversion factors"; substitution
+    is a credit risk mitigant. Cols 0090/0100 say the covered part is "deducted from the
+    obligor's exposure class and **subsequently assigned to the protection provider's**".
+  - Fixed across **C 07.00, C 08.01, C 08.06, C 09.01, C 09.02, C 02.00, OV1 and CR10**,
+    which had to move together: several are defined by cross-reference to one another, so
+    moving one alone makes two templates state different values for a quantity the
+    regulator defines as identical.
+  - **Geography follows the same split**, as PS1/26 Annex II §3.4 ¶87 prescribes:
+    original exposure pre-CCF by the *immediate* obligor, exposure value and RWEA by the
+    *ultimate* obligor. A GB borrower guaranteed by a German institution now reports its
+    exposure value on the DE sheet.
+- **A declined guarantee no longer migrates anything.** Where the engine declines a
+  guarantee because it would not improve capital (CRR Art. 193(1) — "no exposure ... shall
+  produce a higher risk-weighted exposure amount ... than an otherwise identical exposure
+  ... with no credit risk mitigation"), the exposure kept its own risk weight for capital
+  but still moved class and approach for reporting, booking a substitution outflow and
+  inflow for protection that was never recognised. A 70% slotting weight was published on
+  the SA central-governments sheet, where no such weight exists.
+- **A substituted-away leg no longer distorts the slotting grid.** C 08.06 and CR10 kept a
+  covered part that had left the slotting approach, so a category holding one substituted
+  and one plain leg reported the EAD-weighted blend of their weights — 60.5% inside a
+  fixed Art. 153(5) 90% band, with CR10 printing 90% beside an implied 60.5%.
+- **The covered part no longer appears as the guarantor's specialised lending.** `sl_type`
+  is the obligor's characteristic, so a slotting-origin inflow was populating "of which:
+  specialised lending" on a corporate guarantor's sheet. Annex II admits those rows only
+  for exposures applying the Art. 122B treatment, which a substituted-in part does not.
+- Nineteen published EBA/BoE supervisory validation rules stop breaking, including four
+  Error-severity. Zero new breaks across both regimes and all six portfolios.
+
 ---
 
 ## [0.3.22] - 2026-08-03

--- a/docs/development/citation-matrix.md
+++ b/docs/development/citation-matrix.md
@@ -12,7 +12,7 @@ Regenerate after annotation changes:
 uv run python scripts/generate_citation_matrix.py
 ```
 
-Last generated: 2026-08-03.
+Last generated: 2026-08-04.
 
 ## CRR (Capital Requirements Regulation)
 
@@ -51,14 +51,14 @@ Last generated: 2026-08-03.
 
 ### CRR Art. 112 — Exposure classes
 
-??? quote "`_add_exposure_class_applied` — src/rwa_calc/engine/aggregator/aggregator.py:450"
+??? quote "`_add_exposure_class_applied` — src/rwa_calc/engine/aggregator/aggregator.py:451"
     ```python
-    --8<-- "src/rwa_calc/engine/aggregator/aggregator.py:450:563"
+    --8<-- "src/rwa_calc/engine/aggregator/aggregator.py:451:564"
     ```
 
-??? quote "`_add_reporting_projection` — src/rwa_calc/engine/aggregator/aggregator.py:656"
+??? quote "`_add_reporting_projection` — src/rwa_calc/engine/aggregator/aggregator.py:762"
     ```python
-    --8<-- "src/rwa_calc/engine/aggregator/aggregator.py:655:830"
+    --8<-- "src/rwa_calc/engine/aggregator/aggregator.py:761:936"
     ```
 
 ??? quote "`apply_risk_weights` — src/rwa_calc/engine/sa/risk_weights.py:337"
@@ -79,9 +79,9 @@ Last generated: 2026-08-03.
     --8<-- "src/rwa_calc/engine/sa/factors_output.py:50:61"
     ```
 
-??? quote "`apply_intragroup_zero_rw` — src/rwa_calc/engine/sa/rw_adjustments.py:524"
+??? quote "`apply_intragroup_zero_rw` — src/rwa_calc/engine/sa/rw_adjustments.py:621"
     ```python
-    --8<-- "src/rwa_calc/engine/sa/rw_adjustments.py:524:595"
+    --8<-- "src/rwa_calc/engine/sa/rw_adjustments.py:621:692"
     ```
 
 
@@ -251,9 +251,9 @@ Last generated: 2026-08-03.
 
 ### CRR Art. 122 — Exposures to corporates
 
-??? quote "`_compute_guarantor_rw_sa` — src/rwa_calc/engine/irb/guarantee.py:246"
+??? quote "`_compute_guarantor_rw_sa` — src/rwa_calc/engine/irb/guarantee.py:255"
     ```python
-    --8<-- "src/rwa_calc/engine/irb/guarantee.py:246:352"
+    --8<-- "src/rwa_calc/engine/irb/guarantee.py:255:361"
     ```
 
 ??? quote "`build_entity_rw_expr` — src/rwa_calc/engine/sa/guarantor_rw.py:321"
@@ -269,9 +269,9 @@ Last generated: 2026-08-03.
 
 ### CRR Art. 123 — Retail exposures
 
-??? quote "`_add_exposure_class_applied` — src/rwa_calc/engine/aggregator/aggregator.py:451"
+??? quote "`_add_exposure_class_applied` — src/rwa_calc/engine/aggregator/aggregator.py:452"
     ```python
-    --8<-- "src/rwa_calc/engine/aggregator/aggregator.py:450:563"
+    --8<-- "src/rwa_calc/engine/aggregator/aggregator.py:451:564"
     ```
 
 ??? quote "`build_entity_rw_expr` — src/rwa_calc/engine/sa/guarantor_rw.py:322"
@@ -308,9 +308,9 @@ Last generated: 2026-08-03.
 
 ### CRR Art. 126 — Exposures fully and completely secured by mortgages on commercial immovable property
 
-??? quote "`_add_exposure_class_applied` — src/rwa_calc/engine/aggregator/aggregator.py:452"
+??? quote "`_add_exposure_class_applied` — src/rwa_calc/engine/aggregator/aggregator.py:453"
     ```python
-    --8<-- "src/rwa_calc/engine/aggregator/aggregator.py:450:563"
+    --8<-- "src/rwa_calc/engine/aggregator/aggregator.py:451:564"
     ```
 
 ??? quote "`split` — src/rwa_calc/engine/stages/re_split/splitter.py:172"
@@ -758,9 +758,9 @@ Last generated: 2026-08-03.
     --8<-- "src/rwa_calc/engine/irb/formulas.py:989:1041"
     ```
 
-??? quote "`apply_guarantee_substitution` — src/rwa_calc/engine/irb/guarantee.py:53"
+??? quote "`apply_guarantee_substitution` — src/rwa_calc/engine/irb/guarantee.py:55"
     ```python
-    --8<-- "src/rwa_calc/engine/irb/guarantee.py:53:238"
+    --8<-- "src/rwa_calc/engine/irb/guarantee.py:55:247"
     ```
 
 ??? quote "`apply_firb_lgd` — src/rwa_calc/engine/irb/transforms.py:127"
@@ -862,6 +862,14 @@ Last generated: 2026-08-03.
     ```
 
 
+### CRR Art. 193 — Principles for recognising the effect of credit risk mitigation techniques
+
+??? quote "`apply_guarantee_substitution` — src/rwa_calc/engine/sa/rw_adjustments.py:195"
+    ```python
+    --8<-- "src/rwa_calc/engine/sa/rw_adjustments.py:195:425"
+    ```
+
+
 ### CRR Art. 194 — Principles governing the eligibility of credit risk mitigation techniques
 
 ??? quote "`get_crm_unified_bundle` — src/rwa_calc/engine/crm/processor.py:566"
@@ -935,11 +943,6 @@ Last generated: 2026-08-03.
     --8<-- "src/rwa_calc/engine/crm/guarantees.py:242:285"
     ```
 
-??? quote "`apply_guarantee_substitution` — src/rwa_calc/engine/sa/rw_adjustments.py:191"
-    ```python
-    --8<-- "src/rwa_calc/engine/sa/rw_adjustments.py:191:328"
-    ```
-
 
 ### CRR Art. 217 — Requirements to qualify for the treatment set out in Article 153(3)
 
@@ -985,9 +988,9 @@ Last generated: 2026-08-03.
     --8<-- "src/rwa_calc/engine/crm/simple_method.py:271:373"
     ```
 
-??? quote "`apply_fcsm_rw_substitution` — src/rwa_calc/engine/sa/rw_adjustments.py:69"
+??? quote "`apply_fcsm_rw_substitution` — src/rwa_calc/engine/sa/rw_adjustments.py:73"
     ```python
-    --8<-- "src/rwa_calc/engine/sa/rw_adjustments.py:69:118"
+    --8<-- "src/rwa_calc/engine/sa/rw_adjustments.py:73:122"
     ```
 
 
@@ -1083,14 +1086,14 @@ Last generated: 2026-08-03.
     --8<-- "src/rwa_calc/engine/crm/third_party_deposit.py:82:154"
     ```
 
-??? quote "`apply_life_insurance_rw_mapping` — src/rwa_calc/engine/sa/rw_adjustments.py:121"
+??? quote "`apply_life_insurance_rw_mapping` — src/rwa_calc/engine/sa/rw_adjustments.py:125"
     ```python
-    --8<-- "src/rwa_calc/engine/sa/rw_adjustments.py:121:152"
+    --8<-- "src/rwa_calc/engine/sa/rw_adjustments.py:125:156"
     ```
 
-??? quote "`apply_third_party_deposit_rw_mapping` — src/rwa_calc/engine/sa/rw_adjustments.py:155"
+??? quote "`apply_third_party_deposit_rw_mapping` — src/rwa_calc/engine/sa/rw_adjustments.py:159"
     ```python
-    --8<-- "src/rwa_calc/engine/sa/rw_adjustments.py:155:188"
+    --8<-- "src/rwa_calc/engine/sa/rw_adjustments.py:159:192"
     ```
 
 
@@ -1112,19 +1115,19 @@ Last generated: 2026-08-03.
 
 ### CRR Art. 235 — Calculating risk-weighted exposure amounts under the Standardised Approach
 
-??? quote "`_add_post_crm_reporting_class` — src/rwa_calc/engine/aggregator/aggregator.py:566"
+??? quote "`_add_post_crm_reporting_class` — src/rwa_calc/engine/aggregator/aggregator.py:653"
     ```python
-    --8<-- "src/rwa_calc/engine/aggregator/aggregator.py:566:597"
+    --8<-- "src/rwa_calc/engine/aggregator/aggregator.py:653:695"
     ```
 
-??? quote "`_add_post_crm_reporting_approach` — src/rwa_calc/engine/aggregator/aggregator.py:600"
+??? quote "`_add_post_crm_reporting_approach` — src/rwa_calc/engine/aggregator/aggregator.py:698"
     ```python
-    --8<-- "src/rwa_calc/engine/aggregator/aggregator.py:600:625"
+    --8<-- "src/rwa_calc/engine/aggregator/aggregator.py:698:723"
     ```
 
-??? quote "`_add_reporting_projection` — src/rwa_calc/engine/aggregator/aggregator.py:655"
+??? quote "`_add_reporting_projection` — src/rwa_calc/engine/aggregator/aggregator.py:761"
     ```python
-    --8<-- "src/rwa_calc/engine/aggregator/aggregator.py:655:830"
+    --8<-- "src/rwa_calc/engine/aggregator/aggregator.py:761:936"
     ```
 
 ??? quote "`build_domestic_cgcb_guarantor_expr` — src/rwa_calc/engine/eu_sovereign.py:83"
@@ -1137,14 +1140,19 @@ Last generated: 2026-08-03.
     --8<-- "src/rwa_calc/engine/eu_sovereign.py:169:204"
     ```
 
-??? quote "`_compute_guarantor_rw_sa` — src/rwa_calc/engine/irb/guarantee.py:247"
+??? quote "`_compute_guarantor_rw_sa` — src/rwa_calc/engine/irb/guarantee.py:256"
     ```python
-    --8<-- "src/rwa_calc/engine/irb/guarantee.py:246:352"
+    --8<-- "src/rwa_calc/engine/irb/guarantee.py:255:361"
     ```
 
 ??? quote "`build_guarantor_rw_expr` — src/rwa_calc/engine/sa/guarantor_rw.py:135"
     ```python
     --8<-- "src/rwa_calc/engine/sa/guarantor_rw.py:129:313"
+    ```
+
+??? quote "`apply_guarantee_substitution` — src/rwa_calc/engine/sa/rw_adjustments.py:196"
+    ```python
+    --8<-- "src/rwa_calc/engine/sa/rw_adjustments.py:195:425"
     ```
 
 ??? quote "`apply_guarantee_substitution` — src/rwa_calc/engine/slotting/transforms.py:195"
@@ -1354,17 +1362,17 @@ Last generated: 2026-08-03.
     --8<-- "src/rwa_calc/engine/aggregator/_floor.py:108:356"
     ```
 
-??? quote "`aggregate` — src/rwa_calc/engine/aggregator/aggregator.py:85"
+??? quote "`aggregate` — src/rwa_calc/engine/aggregator/aggregator.py:86"
     ```python
-    --8<-- "src/rwa_calc/engine/aggregator/aggregator.py:85:442"
+    --8<-- "src/rwa_calc/engine/aggregator/aggregator.py:86:443"
     ```
 
 
 ### PS1/26, paragraph 110A — PRA Rulebook: CRR Firms: (CRR) Instrument 2026
 
-??? quote "`apply_due_diligence_override` — src/rwa_calc/engine/sa/rw_adjustments.py:460"
+??? quote "`apply_due_diligence_override` — src/rwa_calc/engine/sa/rw_adjustments.py:557"
     ```python
-    --8<-- "src/rwa_calc/engine/sa/rw_adjustments.py:460:521"
+    --8<-- "src/rwa_calc/engine/sa/rw_adjustments.py:557:618"
     ```
 
 
@@ -1469,17 +1477,17 @@ Last generated: 2026-08-03.
 
 ### PS1/26, paragraph 123B — PRA Rulebook: CRR Firms: (CRR) Instrument 2026
 
-??? quote "`apply_currency_mismatch_multiplier` — src/rwa_calc/engine/sa/rw_adjustments.py:331"
+??? quote "`apply_currency_mismatch_multiplier` — src/rwa_calc/engine/sa/rw_adjustments.py:428"
     ```python
-    --8<-- "src/rwa_calc/engine/sa/rw_adjustments.py:331:457"
+    --8<-- "src/rwa_calc/engine/sa/rw_adjustments.py:428:554"
     ```
 
 
 ### PS1/26, paragraph 123B.3 — PRA Rulebook: CRR Firms: (CRR) Instrument 2026
 
-??? quote "`apply_currency_mismatch_multiplier` — src/rwa_calc/engine/sa/rw_adjustments.py:332"
+??? quote "`apply_currency_mismatch_multiplier` — src/rwa_calc/engine/sa/rw_adjustments.py:429"
     ```python
-    --8<-- "src/rwa_calc/engine/sa/rw_adjustments.py:331:457"
+    --8<-- "src/rwa_calc/engine/sa/rw_adjustments.py:428:554"
     ```
 
 

--- a/docs/specifications/basel31/credit-risk-mitigation.md
+++ b/docs/specifications/basel31/credit-risk-mitigation.md
@@ -668,8 +668,10 @@ collateral.
   [IRB Parameter Substitution (B31-D7)](#irb-parameter-substitution-b31-d7)
   (PSM, Art. 236) or the SA Risk-Weight Substitution Method (Art. 235), per
   the [Method Selection by Approach](#method-selection-by-approach) table.
-- The no-double-counting obligation is anchored in Art. 191A(2)(d) /
-  Art. 193(2); see [Anti-Double-Counting and Consistency Rules](#anti-double-counting-and-consistency-rules)
+- The no-double-counting obligation is anchored in Art. 191A(2)(d) under PS1/26
+  and, for the pre-2027 CRR regime, in Art. 193(2) — two separate framework
+  provisions, not joint anchors; see
+  [Anti-Double-Counting and Consistency Rules](#anti-double-counting-and-consistency-rules)
   immediately below.
 - Maturity-mismatch handling on each leg is governed by
   [Art. 237–239](#maturity-mismatch-art-237-239) — the GA / CVAM
@@ -699,6 +701,26 @@ collateral.
     look-through across two protection layers).
 
 ### Anti-Double-Counting and Consistency Rules
+
+!!! note "CRR vs Basel 3.1 — which framework each article belongs to"
+    The paragraph references below are **PS1/26 Art. 191A**. Their CRR-regime
+    counterpart is the general no-double-counting obligation of **CRR Art. 193(2)**
+    ("Where the risk-weighted exposure amount already takes account of credit
+    protection under Chapter 2 or Chapter 3 … institutions shall not take into
+    account that credit protection in the calculations under this Chapter"). The two
+    are separate provisions in separate frameworks and should not be cited as joint
+    anchors — CRR has no equivalent of the Art. 191A(2)(e) / (f) look-through, which
+    is why the pre-2027 route ran through Art. 193(2) plus per-form CRM application.
+
+    The same framework caution applies to the **Art. 193(1)** no-worse cap relied on
+    by the PSM benefit gate above: it is verified for **CRR only**. The PRA Credit
+    Risk Mitigation (CRR) Part is not held in `docs/assets/`, and a full search of
+    `ps126app1.pdf` returns no equivalent language — the PRA also renumbers, so
+    "Article 193" there is the CRR Art. 161 parameter-substitution rule, not this
+    one. Read the `[Note: This rule corresponds to Article NNN of CRR …]` line, never
+    the number. If PS1/26 carries no equivalent cap, the benefit gate stops being
+    compelled from 1 Jan 2027 and becomes a firm election with a capital
+    consequence.
 
 - **Para 2(d)**: Funded and unfunded CRM must not be recognised simultaneously on the same
   portion of an exposure (no double-counting).

--- a/docs/specifications/basel31/credit-risk-mitigation.md
+++ b/docs/specifications/basel31/credit-risk-mitigation.md
@@ -446,9 +446,29 @@ With:
 - `r_g` = the Step 1–4 result above (`guarantor_rw` post-substitution)
 
 The benefit gate (`is_guarantee_beneficial = guarantor_rw < risk_weight_irb_original`)
-disapplies PSM when it would *worsen* the capital outcome, in line with the implicit
-Art. 213 economic-substance test and the explicit Art. 160(4) "no better than
-direct" floor.
+disapplies PSM when it would *worsen* the capital outcome, in line with the explicit
+CRR Art. 193(1) cap — "No exposure in respect of which an institution obtains credit
+risk mitigation shall produce a higher risk-weighted exposure amount **or expected
+loss amount** than an otherwise identical exposure in respect of which an institution
+has no credit risk mitigation" — and the explicit Art. 160(4) "no better than direct"
+floor.
+
+Art. 193(1) is mandatory and per-exposure, so the gate is compliance with a cap, not
+an election. The matching permissive limb is Art. 193(3) ("institutions **may amend**
+the calculation of risk-weighted exposure amounts under the Standardised Approach and
+the calculation of risk-weighted exposure amounts and expected loss amounts under the
+IRB Approach"), which is the hook that reaches the IRB leg — Art. 113(3) speaks only
+to the SA risk weight. Earlier revisions cited an "implicit Art. 213 economic-substance
+test"; Art. 213 is an eligibility article (conditions on the protection contract) and
+carries no benefit test. It is a *precondition* of the Art. 193(3) election, not the
+election itself, which is how the two came to be conflated.
+
+> **PS1/26 caveat.** The Art. 193(1) cap is verified for CRR only. The PRA Credit Risk
+> Mitigation (CRR) Part is not held locally, and a full search of `ps126app1.pdf`
+> returns no equivalent language. If PS1/26 carries no such cap, then from 1 Jan 2027
+> this gate stops being compelled and becomes a firm election with a capital
+> consequence — see the CRR-vs-B3.1 caveat under
+> [Anti-Double-Counting and Consistency Rules](#anti-double-counting-and-consistency-rules).
 
 ### Expected Loss Under PSM (Art. 236(1A))
 

--- a/scripts/arch_metrics.json
+++ b/scripts/arch_metrics.json
@@ -5,8 +5,8 @@
   "engine_collect_schema_sites": 164,
   "engine_eager_collect_sites": 48,
   "max_engine_module_loc": 1694,
-  "cites_decorators": 328,
-  "max_reporting_module_loc": 2209,
-  "reporting_multi_candidate_picks": 30,
+  "cites_decorators": 329,
+  "max_reporting_module_loc": 2208,
+  "reporting_multi_candidate_picks": 29,
   "max_reporting_test_file_loc": 1475
 }

--- a/src/rwa_calc/contracts/edges.py
+++ b/src/rwa_calc/contracts/edges.py
@@ -1660,6 +1660,29 @@ AGGREGATOR_EXIT_EDGE: EdgeContract = EdgeContract(
         "reporting_approach_origin": EdgeColumn(dtype=pl.String),
         "reporting_class": EdgeColumn(dtype=pl.String, citation="CRR Art. 235"),
         "reporting_class_origin": EdgeColumn(dtype=pl.String, citation="CRR Art. 112"),
+        # The geographical mirror of the class pair (PS1/26 Annex II §3.4
+        # ¶86/¶87): the origin twin is the obligor's own cp_country_code, the
+        # post twin the guarantor's country on a BENEFICIALLY guaranteed leg.
+        # C 09.01 / C 09.02 report the pre-conversion original exposure at the
+        # immediate obligor's country and the exposure value / RWEA at the
+        # ultimate obligor's, so the geographical sheet axis needs both.
+        "reporting_country": EdgeColumn(
+            dtype=pl.String,
+            citation="CRR Art. 235",
+            null_meaning=(
+                "neither the guarantor's nor the obligor's country of "
+                "incorporation is known for this leg (cp_country_code is itself "
+                "null) — the leg reports on no country sheet; must NOT be filled"
+            ),
+        ),
+        "reporting_country_origin": EdgeColumn(
+            dtype=pl.String,
+            null_meaning=(
+                "the obligor's country of incorporation is unknown "
+                "(cp_country_code is null) — the leg reports on no country "
+                "sheet; must NOT be filled"
+            ),
+        ),
         "reporting_ead": EdgeColumn(dtype=pl.Float64),
         "reporting_leg_role": EdgeColumn(dtype=pl.String, citation="CRR Art. 235"),
         "reporting_method": EdgeColumn(dtype=pl.String),
@@ -1850,6 +1873,8 @@ REPORTING_SURFACE: frozenset[str] = frozenset(
         "reporting_approach_origin",
         "reporting_class",
         "reporting_class_origin",
+        "reporting_country",
+        "reporting_country_origin",
         "reporting_ead",
         "reporting_leg_role",
         "reporting_method",

--- a/src/rwa_calc/engine/aggregator/aggregator.py
+++ b/src/rwa_calc/engine/aggregator/aggregator.py
@@ -28,6 +28,7 @@ import logging
 from typing import TYPE_CHECKING
 
 import polars as pl
+import polars.selectors as cs
 from watchfire import cites
 
 from rwa_calc.contracts.bundles import AggregatedResultBundle
@@ -563,6 +564,78 @@ def _add_exposure_class_applied(lf: pl.LazyFrame) -> pl.LazyFrame:
     )
 
 
+# The CRM decline flag (``engine/sa/rw_adjustments.py`` / ``engine/irb/guarantee.py``).
+# CONDITIONAL on the edge (``inject=False``), unlike ``is_guaranteed``, so every
+# read of it is presence-tolerant.
+_BENEFICIAL_COL = "is_guarantee_beneficial"
+
+
+def _beneficial_gate() -> pl.Expr:
+    """True where a guarantee actually substituted; null/False where it did NOT.
+
+    A guarantee the engine DECLINES — ``guarantor_rw >= borrower RW``, so applying
+    it would raise capital (CRR Art. 213) — leaves the RWA on the borrower basis:
+    ``apply_guarantee_substitution`` takes its ``.otherwise()`` branch and
+    ``rwa == rwa_irb_original``. The leg nonetheless keeps a positive
+    ``guaranteed_portion`` and a resolved ``post_crm_exposure_class_guaranteed``,
+    so the post-CRM class/approach twins used to migrate it anyway and publish the
+    BORROWER's risk weight on the GUARANTOR's sheet. Reproduced end to end: a
+    10,000,000 project-finance "strong" slotting loan (RW 0.70) fully guaranteed
+    by an unrated non-GB sovereign (SA RW 1.00, so the guarantee is DECLINED)
+    kept ``risk_weight`` 0.70 and 7,000,000 of RWA, yet reported
+    ``reporting_class=central_govt_central_bank`` /
+    ``reporting_approach=standardised`` — materialising a C 07.00 sovereign sheet
+    for a firm with no SA book at all (breaching the live ``v8643_n``,
+    ``{C 07.00.a} = empty``) and banding 10,000,000 on its 70% row 0210, a weight
+    no SA sovereign row can carry under either framework. Capital was identical
+    with and without the gate, which is exactly why nothing else caught it: this
+    is a pure disclosure defect.
+
+    TWO FURTHER REPRODUCTIONS ON THE SA PATH, at the opposite end of the weight
+    scale, kept SEPARATELY ATTRIBUTED because they land differently and a merged
+    retelling of them was wrong in both directions:
+
+    (a) CROSS-SHEET. A 1,000,000 guarantee from ``SAC-CP-CORP`` (a ``financial``
+        counterparty carrying an external rating, guarantor RW 1.00) over
+        ``SAC-LN-RGLA-UK`` (UK RGLA, SA RW 0.00) in the
+        ``reporting_sa_classes`` portfolio is DECLINED, yet migrates: the
+        ``rgla`` sheet books a -1,000,000 outflow (cols 0050/0090, col 0010
+        6,500,000) while the ``corporate`` sheet books a +1,000,000 inflow at
+        col 0100, its col 0110 rising 9,000,000 -> 10,000,000 — 1,000,000
+        published on the corporate sheet still carrying the BORROWER's 0%
+        weight. Total portfolio RWEA 14,600,000 with and without the declined
+        guarantee. ``sum(0040) == sum(0110) == 34,000,000`` held throughout,
+        which is why conservation checks never flagged it.
+
+    (b) SAME-CLASS. A purpose-built two-counterparty bundle — a 1,000,000 UK
+        RGLA loan fully covered by an unrated corporate guarantor (RW 1.00,
+        DECLINED) — resolves no guarantor class, so the covered part is deducted
+        from the obligor's class and added straight back: the ``rgla`` sheet
+        alone books -1,000,000 at cols 0050/0090 against +1,000,000 at col 0100,
+        banded on the 0% row 0140. Portfolio RWEA 0 either way. Note row 0070
+        (on-balance-sheet) takes the outflow but receives NO inflow, so its cols
+        0110/0150 read 0 while row 0010 reads 1,000,000 — the inflow reaches only
+        the Total and risk-weight-band rows, so the on/off-balance-sheet
+        decomposition stops footing against its own total.
+
+    The three cases bracket the defect: one carries a 70% slotting weight onto a
+    sovereign sheet, one a 0% weight onto a corporate sheet, one churns a 0%
+    weight within a single sheet — and one gate has to stop all three.
+
+    THE THREE-WAY PRESENCE/NULL/VALUE READING IS THE SELECTOR'S, NOT A SCHEMA
+    BRANCH. ``all_horizontal`` over a ``require_all=False`` name selector yields
+    the column where the frame has it, and the vacuous ``True`` where it does not
+    — so an ABSENT flag (the CRM guarantee sub-step never ran, hence nothing to
+    decline, and ``is_guaranteed`` is null on every row anyway) leaves the twins
+    exactly as they were, while a NULL flag makes the predicate null, which
+    ``pl.when`` routes to ``otherwise``. That is the required null-safe reading:
+    an unknown benefit is NOT a substitution, and it must never be filled the
+    other way. Expressing it as an expression rather than a
+    ``collect_schema()``-guarded branch also keeps the twins fully lazy.
+    """
+    return pl.all_horizontal(cs.by_name(_BENEFICIAL_COL, require_all=False))
+
+
 @cites("CRR Art. 235")
 def _add_post_crm_reporting_class(lf: pl.LazyFrame) -> pl.LazyFrame:
     """Add ``exposure_class_post_crm`` — the post-guarantee (post-substitution) class.
@@ -583,11 +656,21 @@ def _add_post_crm_reporting_class(lf: pl.LazyFrame) -> pl.LazyFrame:
     consumed by the reconciliation's by-class allocation so our totals per class
     tie to a post-guarantee legacy extract. A guaranteed leg whose guarantor class
     is unresolved (null / empty) falls back to the applied class.
+
+    THE GATE IS ``is_guaranteed AND BENEFICIAL``, not ``is_guaranteed`` alone.
+    ``is_guaranteed`` means protection EXISTS (``guaranteed_portion > 0``); what
+    MOVES an exposure into the guarantor's class is Art. 235 risk-weight
+    substitution actually being applied. Where the calculators decline it
+    (Art. 213 recognition is permissive and a guarantee must never INCREASE
+    capital) there is no covered part to move, so the leg keeps the obligor's
+    applied class. See :func:`_beneficial_gate` for the reproduction and the
+    null/absence convention.
     """
     guarantor_class = pl.col("post_crm_exposure_class_guaranteed")
     return lf.with_columns(
         pl.when(
             (pl.col("is_guaranteed") == True)  # noqa: E712
+            & _beneficial_gate()
             & guarantor_class.is_not_null()
             & (guarantor_class != "")
         )
@@ -641,10 +724,18 @@ def _post_crm_approach_expr() -> pl.Expr:
     all sealed on every calculator branch exit. A null ``is_guaranteed`` makes the
     predicate null, which ``when`` routes to ``otherwise`` (the obligor's approach),
     so no fill is needed — mirroring ``_add_post_crm_reporting_class``.
+
+    It carries the SAME beneficial gate as its class twin, and must: the two have
+    to partition the same money the same way, so an approach that migrates while
+    the class does not (or the reverse) would key a leg onto a sheet/template pair
+    that never existed. A declined guarantee applies neither Art. 235 nor
+    Art. 161, so the leg keeps the approach its RWA was computed under. See
+    :func:`_beneficial_gate`.
     """
     return (
         pl.when(
             (pl.col("is_guaranteed") == True)  # noqa: E712
+            & _beneficial_gate()
             & (pl.col("guarantor_approach") == "sa")
         )
         .then(pl.lit(ApproachType.SA.value))

--- a/src/rwa_calc/engine/aggregator/aggregator.py
+++ b/src/rwa_calc/engine/aggregator/aggregator.py
@@ -569,6 +569,24 @@ def _add_exposure_class_applied(lf: pl.LazyFrame) -> pl.LazyFrame:
 # read of it is presence-tolerant.
 _BENEFICIAL_COL = "is_guarantee_beneficial"
 
+# The guarantor's country of incorporation, joined by ``guarantor_reference``
+# (``engine/crm/guarantees.py::_join_guarantor_counterparty``). Present only once
+# the CRM guarantee sub-step has run, so it is read through the same
+# absence-tolerant selector as ``_BENEFICIAL_COL``.
+_GUARANTOR_COUNTRY_COL = "guarantor_country_code"
+
+
+def _optional_country(column: str) -> pl.Expr:
+    """``column`` where the frame has it, a typed null String where it does not.
+
+    The value-column counterpart of :func:`_beneficial_gate`'s selector: a
+    ``require_all=False`` name selector expands to nothing on a frame without the
+    column, and the trailing literal keeps ``coalesce`` well-formed in that case.
+    Expressing absence this way instead of a ``collect_schema()``-guarded branch
+    keeps the country twins fully lazy and their input contract narrow.
+    """
+    return pl.coalesce(cs.by_name(column, require_all=False), pl.lit(None, dtype=pl.String))
+
 
 def _beneficial_gate() -> pl.Expr:
     """True where a guarantee actually substituted; null/False where it did NOT.
@@ -778,6 +796,21 @@ def _add_reporting_projection(lf: pl.LazyFrame) -> pl.LazyFrame:
       guaranteed exposure's legs (Art. 112/123) = ``exposure_class_applied``.
     - ``reporting_approach`` / ``reporting_approach_origin`` — the post- and
       pre-substitution approach twins (``approach_post_crm`` / ``approach_applied``).
+    - ``reporting_country`` / ``reporting_country_origin`` — the post- and
+      pre-substitution COUNTRY twins, the geographical mirror of the class pair.
+      PS1/26 Annex II §3.4 ¶86 says outright that "CRM techniques with
+      substitution effects can change the allocation of an exposure to a
+      country", and ¶87 splits the geographical breakdown by column: "original
+      exposure pre-conversion factors" reports at the country of residence of
+      the IMMEDIATE obligor, "exposure value" and "risk-weighted exposure
+      amounts" at the country of residence of the ULTIMATE obligor. So the
+      origin twin is the obligor's own ``cp_country_code`` on every leg, and the
+      post twin is the guarantor's country on a BENEFICIALLY guaranteed leg —
+      gated identically to ``reporting_class`` (see
+      :func:`_add_post_crm_reporting_class`), because a guarantee the engine
+      DECLINES moves neither the class nor the country. Degrades to the
+      obligor's country wherever the guarantor's is unknown, so a run with no
+      CRM guarantee sub-step reports one country on both twins.
     - ``reporting_method`` — the STD/FIRB/AIRB/SLOTTING/EQUITY methodology label
       of the post-substitution approach (``method_label_expr`` materialised).
     - ``reporting_leg_role`` — ``guaranteed`` (the ``__G_`` leg,
@@ -860,6 +893,29 @@ def _add_reporting_projection(lf: pl.LazyFrame) -> pl.LazyFrame:
         rwa_benefit = pl.col("ead_final") * pl.col("guarantee_benefit_rw")
     else:
         rwa_benefit = pl.lit(None, dtype=pl.Float64)
+    # The ¶87 ULTIMATE-obligor country. Read through the same absence-tolerant
+    # selector ``_beneficial_gate`` uses rather than a schema branch: an
+    # unguaranteed run never joined a guarantor counterparty, so
+    # ``guarantor_country_code`` is simply not there and the coalesce yields the
+    # typed null the gate then routes to ``otherwise``. An empty string is
+    # treated as unknown for the same reason the class twin does it — a joined
+    # counterparty row with a blank country is not a country.
+    guarantor_country = _optional_country(_GUARANTOR_COUNTRY_COL)
+    # The obligor's own country is read through the same selector, not as a bare
+    # column: it is a required aggregator-exit column, but the projection is also
+    # exercised directly on minimal frames, and a hard read would make the
+    # function's input contract wider than the two twins actually need.
+    obligor_country = _optional_country("cp_country_code")
+    country_post = (
+        pl.when(
+            (pl.col("is_guaranteed") == True)  # noqa: E712
+            & _beneficial_gate()
+            & guarantor_country.is_not_null()
+            & (guarantor_country != "")
+        )
+        .then(guarantor_country)
+        .otherwise(obligor_country)
+    )
     # Per-side floored gross carriers (CRR Art. 111 SA / Art. 166 IRB). See the
     # docstring: on-side = floored drawn + interest for the on-balance credit
     # types (unknown drawn AND interest -> null); off-side = a contingent's
@@ -913,6 +969,8 @@ def _add_reporting_projection(lf: pl.LazyFrame) -> pl.LazyFrame:
         pl.col("exposure_class_applied").alias("reporting_class_origin"),
         pl.col("approach_post_crm").alias("reporting_approach"),
         pl.col("approach_applied").alias("reporting_approach_origin"),
+        country_post.alias("reporting_country"),
+        obligor_country.alias("reporting_country_origin"),
         method_label_expr("approach_post_crm").alias("reporting_method"),
         leg_role.alias("reporting_leg_role"),
         on_balance_sheet.alias("reporting_on_balance_sheet"),

--- a/src/rwa_calc/engine/aggregator/aggregator.py
+++ b/src/rwa_calc/engine/aggregator/aggregator.py
@@ -574,8 +574,8 @@ def _beneficial_gate() -> pl.Expr:
     """True where a guarantee actually substituted; null/False where it did NOT.
 
     A guarantee the engine DECLINES — ``guarantor_rw >= borrower RW``, so applying
-    it would raise capital (CRR Art. 213) — leaves the RWA on the borrower basis:
-    ``apply_guarantee_substitution`` takes its ``.otherwise()`` branch and
+    it would raise capital, which CRR Art. 193(1) forbids — leaves the RWA on the
+    borrower basis: ``apply_guarantee_substitution`` takes its ``.otherwise()`` and
     ``rwa == rwa_irb_original``. The leg nonetheless keeps a positive
     ``guaranteed_portion`` and a resolved ``post_crm_exposure_class_guaranteed``,
     so the post-CRM class/approach twins used to migrate it anyway and publish the
@@ -622,6 +622,21 @@ def _beneficial_gate() -> pl.Expr:
     sovereign sheet, one a 0% weight onto a corporate sheet, one churns a 0%
     weight within a single sheet — and one gate has to stop all three.
 
+    WHAT THIS GATE IS DOWNSTREAM OF, AND WHY THAT MATTERS HERE. This gate moves
+    no RWA, so the capital-neutrality recorded above is unconditional and holds
+    whatever the calculators do. What it DOES depend on is that the calculators
+    DECLINE rather than apply-and-cap. Art. 193(1) mandates the OUTCOME — no
+    exposure with CRM may produce a higher RWEA or EL than the identical
+    unprotected exposure — not the mechanism, and applying Art. 235(1) then
+    capping the RWEA at the unmitigated amount complies just as well. Under that
+    reading Art. 235 HAS fired and the covered part HAS been assigned to the
+    guarantor's class, so the outflow and inflow WOULD be booked and this gate
+    would be wrong. It is correct BECAUSE we decline. That election, its
+    CRR-conditional capital-neutrality, why the basis is Art. 193 and not
+    Art. 213, the strict-``<`` election and the unverified PS1/26 position are
+    all recorded on
+    ``engine/sa/rw_adjustments.py::apply_guarantee_substitution``.
+
     THE THREE-WAY PRESENCE/NULL/VALUE READING IS THE SELECTOR'S, NOT A SCHEMA
     BRANCH. ``all_horizontal`` over a ``require_all=False`` name selector yields
     the column where the frame has it, and the vacuous ``True`` where it does not
@@ -661,10 +676,11 @@ def _add_post_crm_reporting_class(lf: pl.LazyFrame) -> pl.LazyFrame:
     ``is_guaranteed`` means protection EXISTS (``guaranteed_portion > 0``); what
     MOVES an exposure into the guarantor's class is Art. 235 risk-weight
     substitution actually being applied. Where the calculators decline it
-    (Art. 213 recognition is permissive and a guarantee must never INCREASE
-    capital) there is no covered part to move, so the leg keeps the obligor's
-    applied class. See :func:`_beneficial_gate` for the reproduction and the
-    null/absence convention.
+    (Art. 193(1) bars a guarantee from RAISING the RWEA, and Art. 193(3) makes
+    amending the calculation an election rather than a duty) there is no covered
+    part to move, so the leg keeps the obligor's applied class. See
+    :func:`_beneficial_gate` for the reproduction, the null/absence convention
+    and the decline-vs-apply-and-cap election this gate depends on.
     """
     guarantor_class = pl.col("post_crm_exposure_class_guaranteed")
     return lf.with_columns(

--- a/src/rwa_calc/engine/crm/guarantees.py
+++ b/src/rwa_calc/engine/crm/guarantees.py
@@ -1336,7 +1336,7 @@ def redistribute_non_beneficial(exposures: pl.LazyFrame) -> pl.LazyFrame:
     Single-guarantor and non-guaranteed exposures pass through unchanged.
 
     References:
-        CRR Art. 213: Only beneficial guarantees should be applied
+        CRR Art. 193(1): a guarantee must never raise the RWEA (sa/rw_adjustments.py)
         CRR Art. 215-217: Guarantee substitution with multiple protections
     """
     schema = exposures.collect_schema()

--- a/src/rwa_calc/engine/irb/guarantee.py
+++ b/src/rwa_calc/engine/irb/guarantee.py
@@ -14,6 +14,8 @@ Key responsibilities:
 References:
 - CRR Art. 153(3), 202-203: Double default treatment
 - CRR Art. 161(3): Guarantor PD substitution for expected loss
+- CRR Art. 193(1), (3): CRM recognition principles — the no-worse RWEA/EL cap
+  and the election to amend, i.e. the basis for declining a guarantee
 - CRR Art. 213, 215-217: Guarantee eligibility and substitution
 - CRR Art. 235 / PRA PS1/26 Art. 235: SA risk-weight substitution method (RWSM)
 - CRR Art. 114-122: guarantor SA risk weights (shared builder —
@@ -131,8 +133,15 @@ def apply_guarantee_substitution(
     # --- Blend RWA and adjust expected loss ---
     ead_col = "ead_final" if "ead_final" in cols else "ead"
 
-    # Check if guarantee is beneficial (guarantor RW < borrower IRB RW)
-    # Non-beneficial guarantees should NOT be applied per CRR Art. 213
+    # The Art. 193(1) benefit test on the IRB leg (guarantor RW < borrower IRB
+    # RW). Art. 193(1) binds the EXPECTED LOSS amount as well as the RWEA, and
+    # Art. 193(3)'s "may amend" reaches the IRB approach explicitly — which is
+    # why the basis here is Art. 193 and NOT Art. 113(3) (Chapter 2, SA-only) or
+    # Art. 213 (an eligibility gate on the protection contract, gated upstream).
+    # Declining rather than applying-and-capping, and the strict ``<``, are both
+    # elections the text does not force: the single recorded basis for this flag
+    # and every consumer of it is
+    # ``engine/sa/rw_adjustments.py::apply_guarantee_substitution``.
     lf = lf.with_columns(
         [
             pl.when(

--- a/src/rwa_calc/engine/sa/rw_adjustments.py
+++ b/src/rwa_calc/engine/sa/rw_adjustments.py
@@ -3,7 +3,7 @@ Standardised Approach post-base risk-weight adjustments.
 
 Plain typed functions applied after the base SA risk-weight assignment, in
 regulatory order: Art. 222 FCSM substitution, Art. 232 life-insurance
-mapping, Art. 213-217 guarantee substitution, the Basel 3.1 Art. 123B
+mapping, Art. 235 guarantee substitution, the Basel 3.1 Art. 123B
 currency-mismatch multiplier, and the Basel 3.1 Art. 110A due-diligence
 override. ``SACalculator`` composes them via ``LazyFrame.pipe``.
 
@@ -13,12 +13,16 @@ Pipeline position:
 Key responsibilities:
 - Art. 222 Financial Collateral Simple Method RW substitution
 - Art. 232 life-insurance collateral RW mapping
-- Art. 213-217 unfunded credit protection (guarantee substitution)
+- Art. 235 unfunded credit protection (guarantee substitution)
 - PRA PS1/26 Art. 123B currency-mismatch multiplier (Basel 3.1)
 - PRA PS1/26 Art. 110A due-diligence override (Basel 3.1)
 
 References:
-- CRR Art. 213-217: Unfunded credit protection (guarantee substitution)
+- CRR Art. 193: CRM recognition principles (the no-worse cap and the
+  election to amend the calculation) — the basis for declining a guarantee
+- CRR Art. 235: SA guarantee substitution formula
+- CRR Art. 213-217: Eligibility of the protection (gated upstream in
+  ``engine/crm/guarantees.py``, not here)
 - CRR Art. 222: Financial Collateral Simple Method
 - CRR Art. 232: Life insurance collateral
 - PRA PS1/26 Art. 110A: Basel 3.1 due diligence override
@@ -188,7 +192,8 @@ def apply_third_party_deposit_rw_mapping(lf: pl.LazyFrame) -> pl.LazyFrame:
     )
 
 
-@cites("CRR Art. 213")
+@cites("CRR Art. 193")
+@cites("CRR Art. 235")
 def apply_guarantee_substitution(
     lf: pl.LazyFrame,
     config: CalculationConfig,
@@ -197,11 +202,114 @@ def apply_guarantee_substitution(
 ) -> pl.LazyFrame:
     """Apply guarantee substitution for unfunded credit protection.
 
-    For guaranteed portions, the risk weight is substituted with the
-    guarantor's risk weight. The final RWA is calculated using blended
-    risk weight based on guaranteed vs unguaranteed portions.
+    For guaranteed portions the risk weight is substituted with the guarantor's
+    risk weight, and the row's RWA is the Art. 235(1) blend of the two:
+    ``max(0, E - GA) x r + GA x g``.
 
-    CRR Art. 213-217: Unfunded credit protection.
+    THE DECLINE AND ITS AUTHORITY. This is the canonical account for the whole
+    ``is_guarantee_beneficial`` machinery — its IRB twin
+    (``engine/irb/guarantee.py``) and the three reporting consumers that gate on
+    it (``engine/aggregator/aggregator.py::_beneficial_gate``,
+    ``reporting/corep/crm_substitution.py::_decline_gate``,
+    ``reporting/corep/c07.py::_protection_exprs``) all point here rather than
+    restating it.
+
+    THE BASIS IS ART. 193, NOT ART. 213. Art. 213 ("Requirements common to
+    guarantees and credit derivatives") is an ELIGIBILITY gate on the protection
+    CONTRACT — the protection is direct, its extent clearly defined and
+    incontrovertible, no clause permitting unilateral cancellation / cost
+    escalation on credit deterioration / obstruction of timely payout / reduction
+    of protection maturity, legally effective and enforceable — plus
+    concentration-risk systems (213(2)) and contractual/statutory fulfilment
+    (213(3)). It says nothing about whether a recognised guarantee must be
+    APPLIED, yet this code recorded "recognition is permissive (Art. 213)" in six
+    places. The two provisions that actually carry the decline both sit in
+    Art. 193, "Principles for recognising the effect of credit risk mitigation
+    techniques":
+
+    - Art. 193(1), MANDATORY, about the OUTCOME: "No exposure in respect of which
+      an institution obtains credit risk mitigation shall produce a higher
+      risk-weighted exposure amount or expected loss amount than an otherwise
+      identical exposure in respect of which an institution has no credit risk
+      mitigation." The unit is THE EXPOSURE, not the portfolio, and it binds the
+      EXPECTED LOSS amount as well as the RWEA — which is what makes it the right
+      authority for the IRB leg too.
+    - Art. 193(3), PERMISSIVE, about the MECHANISM: "Where the provisions in
+      Sections 2 and 3 are met, institutions MAY amend the calculation of
+      risk-weighted exposure amounts under the Standardised Approach and the
+      calculation of risk-weighted exposure amounts and expected loss amounts
+      under the IRB Approach in accordance with the provisions of Sections 4, 5
+      and 6." Art. 213 sits IN Section 2 — it is one of the preconditions 193(3)
+      makes the election conditional on, which is exactly why it kept being
+      mistaken for the election itself.
+
+    Art. 113(3) ("Where an exposure is subject to credit protection the risk
+    weight applicable to that item may be amended in accordance with Chapter 4")
+    says the same thing per ITEM, and is the hook Art. 235(1) opens with — "For
+    the purposes of Article 113(3) institutions shall calculate ..." — so that
+    ``shall`` governs HOW you compute if you amend, not WHETHER you amend. But
+    113(3) lives in Chapter 2 and speaks only to the SA risk weight; it does not
+    reach the IRB path. Art. 193(3) covers both, so it is the citation of record.
+
+    THE ARGUMENT THAT NEEDS NO CITATION. The Art. 235(1) formula carries no
+    ``min`` against ``E x r``. Applied mechanically with ``g > r`` it returns a
+    HIGHER RWEA than the identical unprotected exposure — a credit risk
+    mitigation chapter that penalises mitigation. That reading cannot be right,
+    which is precisely why Art. 193(1) exists.
+
+    TWO ELECTIONS THE TEXT DOES NOT FORCE, recorded because nothing else records
+    them:
+
+    (1) DECLINE vs APPLY-AND-CAP — AND ITS CAPITAL-NEUTRALITY IS CRR-CONDITIONAL,
+        WHICH IS THE WHOLE POINT. Art. 193(1) mandates the OUTCOME, not the
+        mechanism, so under CRR there are exactly TWO compliant implementations:
+        decline the guarantee, or apply Art. 235(1) and then cap the RWEA at the
+        unmitigated amount. They give IDENTICAL CAPITAL — but only BECAUSE the
+        Art. 193(1) cap is MANDATORY. That is what collapses the two onto one
+        number and leaves the choice affecting DISCLOSURE alone: under
+        apply-and-cap Art. 235 HAS fired, the covered part HAS been assigned to
+        the guarantor's class, and the C 07.00 / C 08.01 outflow and inflow would
+        both be reported. We decline; that is an implementation election, not a
+        reading of the text. Remove the mandatory cap and a THIRD option appears
+        — apply Art. 235(1) UNCAPPED, returning a HIGHER RWEA — at which point
+        the election stops being capital-neutral and our decline stops being the
+        only permissible behaviour. Whether that coincidence survives into
+        PS1/26 is UNVERIFIED (below); if it does not, this election acquires a
+        capital consequence and needs a recorded policy basis rather than a code
+        comment. Note the scope: this is the ENGINE gate, which moves RWA. The
+        reporting gates that consume its flag
+        (``engine/aggregator/aggregator.py::_beneficial_gate``,
+        ``reporting/corep/crm_substitution.py::_decline_gate``) move no RWA at
+        all, so THEIR capital-neutrality is unconditional and nothing here
+        qualifies it.
+    (2) THE STRICT ``<``. The benefit test below is
+        ``guarantor_rw < pre_crm_risk_weight`` (the IRB twin is identical against
+        ``risk_weight_irb_original``). At EQUALITY Art. 193(1) is SILENT — equal
+        is not "higher" — so an equally-weighted guarantor is declined BY CHOICE:
+        zero capital effect, and a real effect on which sheet the exposure
+        appears on.
+
+    A PS1/26 GAP, STATED RATHER THAN GLOSSED. PS1/26 Art. 113(3) is word for word
+    the CRR text with "the Credit Risk Mitigation (CRR) Part" substituted for
+    "Chapter 4", so the permissive hook carries into 2027. A PS1/26 equivalent of
+    Art. 193(1) has NOT been verified: the PRA renumbers (in ``ps126app1.pdf``
+    "Article 193" is the CRR Art. 161 IRB-parameter-substitution rule — read the
+    ``[Note: This rule corresponds to Article NNN of CRR ...]`` line, never the
+    number), and the PRA Credit Risk Mitigation (CRR) Part is not in
+    ``docs/assets/`` at all. The consequence matters: under CRR the decline is
+    COMPELLED, so doing neither it nor apply-and-cap is a breach; if the PRA CRM
+    Part turns out to lack the equivalent, from 1 Jan 2027 this becomes a pure
+    ELECTION — and an election needs a recorded policy basis in a way that
+    compliance with a mandatory cap does not. No PS1/26 citation is asserted
+    here, because none has been read.
+
+    References:
+        CRR Art. 193(1), (3): CRM recognition principles — the no-worse outcome
+            cap, and the election to amend the calculation at all.
+        CRR Art. 113(3): the SA per-item permissive hook Art. 235(1) hangs off.
+        CRR Art. 235: SA risk-weight substitution formula.
+        CRR Art. 213-217: eligibility of the protection itself, gated upstream in
+            ``engine/crm/guarantees.py``.
     """
     resolved_pack = pack if pack is not None else RulepackV0.from_config(config).pack
     exposures = lf
@@ -261,8 +369,12 @@ def apply_guarantee_substitution(
         ).alias("guarantor_rw"),
     ).drop(short_term_flag_col)
 
-    # Check if guarantee is beneficial (guarantor RW < borrower RW)
-    # Non-beneficial guarantees should NOT be applied per CRR Art. 213
+    # The Art. 193(1) benefit test: no exposure with CRM may produce a HIGHER
+    # RWEA than the identical unprotected exposure, and the Art. 235(1) formula
+    # carries no ``min`` to stop it. DECLINING (rather than applying Art. 235
+    # then capping) and the STRICT ``<`` (equality is declined too) are both
+    # elections the text does not force — see this function's docstring, which is
+    # the single recorded basis for every consumer of this flag.
     exposures = exposures.with_columns(
         [
             pl.when(
@@ -596,7 +708,7 @@ def apply_intragroup_zero_rw(
 
 
 # ---------------------------------------------------------------------------
-# Guarantee-substitution helpers (CRR Art. 213-217)
+# Guarantee-substitution helpers (CRR Art. 235; guarantor eligibility Art. 213-217)
 #
 # The guarantee-substitution stage relies on a few columns that may be missing
 # when the calculator is invoked directly from tests (i.e. bypassing the CRM

--- a/src/rwa_calc/reporting/cellspec.py
+++ b/src/rwa_calc/reporting/cellspec.py
@@ -184,16 +184,28 @@ type ValueBinding = (
 class RowPredicate:
     """A conjunctive row filter over the sealed reporting-ledger columns.
 
-    Post-substitution fields (``classes`` / ``method``) and origin fields
-    (``classes_origin`` / ``approaches_origin``) are both available so each
-    template keys on its RECORDED basis (COREP C 07.00 keys origin; the
+    Post-substitution fields (``classes`` / ``approaches`` / ``method``) and
+    origin fields (``classes_origin`` / ``approaches_origin``) are both
+    available so each template keys on its RECORDED basis (the
     post-substitution retargets are per-template recorded decisions — plan
     F3/F4). Unset fields (empty tuple / None) impose no constraint.
+
+    ``approaches`` is the post-substitution twin of ``approaches_origin``
+    (sealed ``reporting_approach`` = the aggregator's ``approach_post_crm``).
+    A leg whose guarantee the engine applied under Art. 235 is a direct
+    exposure to the protection provider and is treated under the PROVIDER's
+    approach, so a template disclosing "of which: the standardised approach"
+    keys this, while one disclosing the obligor's own book keys the origin
+    twin. Both are needed and neither is the default. Unlike every other
+    field here it compiles in ``_compile``, not ``to_expr``, because it
+    DEGRADES to the origin twin on a frame that seals no post-substitution
+    approach — see the note there.
     """
 
     classes: tuple[str, ...] = ()
     classes_origin: tuple[str, ...] = ()
     method: str | None = None
+    approaches: tuple[str, ...] = ()
     approaches_origin: tuple[str, ...] = ()
     leg_role: Literal["whole", "guaranteed", "retained"] | None = None
     on_balance_sheet: bool | None = None
@@ -274,6 +286,23 @@ class RowPredicate:
         ):
             return pl.lit(False)
         expr = self.to_expr()
+        if self.approaches:
+            # DEGRADES to the origin twin, and compiles HERE rather than in
+            # ``to_expr`` because only here are the frame's columns known. A
+            # frame that seals no post-substitution approach (the synthetic
+            # unit/lineage frames, which carry ``reporting_approach_origin``
+            # alone) then reports exactly what it did before the post-basis
+            # retarget, instead of raising ColumnNotFoundError or — worse, had
+            # this been a tolerant ``equals`` — silently zeroing every
+            # per-approach cell. Matching only where a leg substituted is the
+            # whole point: post == origin wherever nothing did.
+            approach_col = (
+                "reporting_approach"
+                if "reporting_approach" in cols
+                else "reporting_approach_origin"
+            )
+            if approach_col in cols:
+                expr = _conj(expr, pl.col(approach_col).is_in(list(self.approaches)))
         for col, value in self.equals:
             expr = _conj(expr, pl.col(col) == value)
         for col, low, high in self.between:

--- a/src/rwa_calc/reporting/corep/c02.py
+++ b/src/rwa_calc/reporting/corep/c02.py
@@ -32,13 +32,16 @@ Cell semantics (recorded decisions, this slice):
   *and* SA-CCR — so the template foots against rows 0010/0050, which
   are flat ledger sums and always carried the CCR RWEA (recorded fix
   2026-07-12; see the constant for why it is not shared).
-- THREE keys, one per tied template: the approach rows and the SA class
-  rows key the POST-SUBSTITUTION twins (``reporting_approach`` /
-  ``reporting_class``, tying the SA breakdown to C 07.00), while the IRB
-  class rows stay on ``reporting_class_origin`` until C 08.01 follows. See
-  the long note at the binding site for why that PRESERVES the 2026-07-12
-  fix (whose stated purpose was that tie) rather than reversing it, why the
-  IRB half is a sequencing decision, and why Art. 92 is unaffected. Rows
+- THREE keys, one per tied template, and all three now POST-SUBSTITUTION
+  (``reporting_approach`` / ``reporting_class``): the approach rows and the
+  SA class rows tie to C 07.00, the IRB class rows to C 08.01, and both
+  those templates have moved their exposure-value and RWEA columns onto
+  that basis. See the long note at the binding site for why that PRESERVES
+  the 2026-07-12 fix (whose stated purpose was that tie) rather than
+  reversing it, why the IRB half followed one commit later, why Art. 92 is
+  unaffected, and — recorded there rather than fixed here — the
+  ``(foundation_irb, retail_other)`` pair that has no row, which is
+  downstream evidence of a missing CRR Art. 201 eligibility gate. Rows
   0070-0211 route through the many-to-one ACCUMULATING
   ``C02_00_SA_CLASS_MAP``. Rows 0070-0211 are "See CR SA template", so
   the map's groupings ARE the C 07.00 sheet groupings (recorded fix
@@ -78,6 +81,7 @@ References:
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, cast
 
 import polars as pl
@@ -91,6 +95,8 @@ from rwa_calc.reporting.corep.templates import (
     get_c02_00_row_sections,
 )
 from rwa_calc.reporting.kernel import null_row, pick
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from rwa_calc.contracts.bundles import OutputFloorSummary
@@ -119,6 +125,19 @@ type _SubKey = tuple[str, str, bool | None, bool | None, str | None]
 # shared SA-approach constant would also widen the Pillar 3 CR4/CR5 disclosures,
 # which correctly scope CCR out under Basel 3.1 (it has CCR1-CCR8).
 _SA_APPROACHES: tuple[str, ...] = ("standardised", "standardised_ccr")
+
+# The IRB retail classes. CRR Art. 151(4) puts retail exposures under the
+# ADVANCED approach only (own LGD estimates are mandatory), which is why the
+# layout carries retail rows at 0370-0400 under A-IRB and NONE under F-IRB —
+# see ``_placeable_irb_class`` for the pair this makes impossible.
+_RETAIL_CLASSES: tuple[str, ...] = ("retail_mortgage", "retail_qrre", "retail_other")
+
+# The F-IRB / A-IRB detail rows each approach's "of which" breakdown must foot
+# against, for the stranding net (``_warn_if_irb_detail_strands``).
+_IRB_DETAIL_ROWS: dict[str, tuple[str, ...]] = {
+    "0240": ("0250", "0260"),
+    "0300": ("0310", "0330", "0340", "0370"),
+}
 
 # The sealed ``equity_method`` values (domain.enums.EquityApproach, R6) that
 # report under the IRB umbrella — row 0420 "Equity IRB" plus the IRB total
@@ -164,7 +183,7 @@ def generate_c02_00(
     #   approach_col   POST  (``reporting_approach``)      rows 0060 / 0220 / 0240 …
     #   sa_ec_col      POST  (``reporting_class``)         rows 0070-0211, "See CR SA
     #                                                      template" -> C 07.00
-    #   irb_ec_col     ORIGIN(``reporting_class_origin``)  rows 0250-0420 -> C 08.01
+    #   irb_ec_col     POST  (``reporting_class``)         rows 0250-0420 -> C 08.01
     #
     # This PRESERVES the 2026-07-12 fix rather than reversing it. That fix moved
     # the class rows off the origination class onto the applied Art. 112 class for
@@ -178,15 +197,40 @@ def generate_c02_00(
     # substituted leg counted at the obligor's sheet on one template and the
     # guarantor's on the other).
     #
-    # THE IRB CLASS ROWS DELIBERATELY STAY ON THE ORIGIN KEY, and that is a
-    # SEQUENCING decision, not a different answer to the same question. They tie
-    # to C 08.01 col 0260 (``boe_b0616``, ERROR: {OF 02.00 r0271 c0010} =
-    # {OF 08.01 r0010 c0260 z0006}), and C 08.01 still sheets the obligor class.
-    # Moving this key alone broke that rule by exactly one leg — the S1 guarantee,
-    # F-IRB corporate covered by an F-IRB institution: C 02.00 r0271 4,283,321.07
-    # against C 08.01's 2,855,547.38, a difference of 1,427,773.69 = that leg's
-    # rwa_final. Art. 161 substitution does make it an institution exposure, so
-    # BOTH sides should move — together, when C 08.01 does.
+    # THE IRB CLASS ROWS HAVE NOW FOLLOWED, and this was always the PAIRED half of
+    # that sequencing decision rather than a different answer. They tie to C 08.01
+    # col 0260 (``boe_b0616``, ERROR: {OF 02.00 r0271 c0010} = {OF 08.01 r0010
+    # c0260 z0006}), and C 08.01's exposure-value / RWEA columns have moved to the
+    # post-substitution basis. When only ONE side had moved the rule broke by
+    # exactly one leg either way — the S1 guarantee, an F-IRB corporate covered by
+    # an F-IRB institution (1,427,773.69 = that leg's rwa_final): 4,283,321.07 vs
+    # 2,855,547.38 with C 02.00 ahead, and 2,855,547.38 vs 4,283,321.07 with
+    # C 08.01 ahead. Art. 161 substitution makes it an institution exposure on both
+    # templates, so both keys sit on ``reporting_class`` and the rule foots.
+    #
+    # THE IMPOSSIBLE-PAIR TRAP, MEASURED AND ROOT-CAUSED. A post class key against
+    # the obligor's retained approach can produce an (approach, class) pair with no
+    # row — the aggregator moves the class but keeps the obligor's approach for a
+    # non-SA guarantor. Here that is ``(foundation_irb, retail_other)``, which
+    # Art. 151(4) makes impossible (retail is A-IRB only), and its RWEA would fall
+    # out of rows 0250/0260 while row 0240 still counted it — invisible to every
+    # published rule, because the rules only check rows that DO exist. Measured on
+    # the CRM-substitution portfolio: 2,028,365.78 (CRR) / 1,700,935.66 (B31).
+    #
+    # THE CAUSE IS NOT THIS KEY, AND MUST NOT BE PAPERED OVER HERE. The single leg
+    # producing it is an F-IRB corporate loan whose covered part is guaranteed by a
+    # RETAIL counterparty. CRR Art. 201(1) is an exhaustive list of eligible
+    # providers of unfunded credit protection — (a) central governments/banks,
+    # (b) RGLAs, (c) MDBs, (d) 0%-RW international organisations, (e) PSEs,
+    # (f) institutions, (g) other CORPORATE entities, (h) QCCPs — and it has NO
+    # retail limb, while Art. 201(2) additionally requires an IRB guarantor to be
+    # internally rated. So the guarantee is ineligible and should never have
+    # migrated the class at all; the impossible pair is DOWNSTREAM EVIDENCE of a
+    # missing Art. 201 eligibility gate in ``engine/crm/``, not a reporting-layer
+    # keying problem. Re-measured with such a gate applied, stranding is 0.00 in
+    # both regimes. Normalising the pair into an adjacent row here would launder an
+    # ineligible guarantee into a valid-looking disclosure, so it is deliberately
+    # NOT done. Do not "fix" this by remapping the class or the approach.
     #
     # The 2026-07-12 note also said "identical values for IRB rows (raw ==
     # applied for the IRB book)". That is NO LONGER TRUE, and it is the defect
@@ -208,7 +252,14 @@ def generate_c02_00(
     sa_ec_col = pick(
         cols, "reporting_class" if "reporting_class" in cols else "reporting_class_origin"
     )
-    irb_ec_col = pick(cols, "reporting_class_origin")
+    # Written out rather than aliased to ``sa_ec_col``: the two keys are distinct
+    # QUESTIONS that currently have the same answer, and the seam is what let the
+    # SA half move in f94be554/a7ced69e while the IRB half waited for C 08.01.
+    irb_ec_col = pick(
+        cols, "reporting_class" if "reporting_class" in cols else "reporting_class_origin"
+    )
+    # The origin twin, kept for the Art. 151(4) revert in ``_placeable_irb_class``.
+    origin_ec_col = pick(cols, "reporting_class_origin")
     approach_col = pick(
         cols, "reporting_approach" if "reporting_approach" in cols else "approach_applied"
     )
@@ -234,6 +285,7 @@ def generate_c02_00(
             approach_col,
             sa_ec_col,
             irb_ec_col,
+            origin_ec_col or irb_ec_col,
             rwa_col,
             cols,
             is_b31,
@@ -296,6 +348,7 @@ def generate_c02_00(
     # Basel 3.1, Art. 147A). SA-method equity reports at rows 0060/0210.
     row_values["0420"] = {"0010": equity_irb_rwa}
 
+    _warn_if_irb_detail_strands(row_values)
     _floor_indicator_rows(
         row_values,
         output_floor_summary,
@@ -339,6 +392,7 @@ def _aggregate_by_approach(  # noqa: PLR0913 - two class keys, one per tied temp
     approach_col: str,
     sa_ec_col: str,
     irb_ec_col: str,
+    origin_ec_col: str,
     rwa_col: str,
     cols: set[str],
     is_b31: bool,  # noqa: FBT001 - retired positional signature preserved
@@ -355,14 +409,16 @@ def _aggregate_by_approach(  # noqa: PLR0913 - two class keys, one per tied temp
     map, and the equity RWA split into (SA-method, IRB-method) sub-totals.
 
     TWO CLASS KEYS, one per tied template — see the caller's note.
-    ``sa_ec_col`` (post-substitution) keys the SA class rows, which tie to
-    C 07.00; ``irb_ec_col`` (origin) keys the IRB class rows, which tie to
-    C 08.01. They are the same column wherever nothing substitutes.
+    ``sa_ec_col`` keys the SA class rows, which tie to C 07.00; ``irb_ec_col``
+    keys the IRB class rows, which tie to C 08.01. BOTH are now the
+    post-substitution class, because both tied templates have moved; they stay
+    two parameters because they are two questions, and they answered differently
+    for the one commit between C 07.00 moving and C 08.01 following.
     """
     collected = results.select(
         pl.col(approach_col).alias("_approach"),
         pl.col(sa_ec_col).alias("_ec_sa"),
-        pl.col(irb_ec_col).alias("_ec_irb"),
+        _placeable_irb_class(irb_ec_col, origin_ec_col, approach_col).alias("_ec_irb"),
         pl.col(rwa_col).fill_null(0.0).alias("_rwa"),
         _equity_method_expr(cols).alias("_eqm"),
     ).collect()
@@ -420,6 +476,79 @@ def _aggregate_by_approach(  # noqa: PLR0913 - two class keys, one per tied temp
         equity_sa_rwa,
         equity_irb_rwa,
     )
+
+
+def _warn_if_irb_detail_strands(row_values: dict[str, dict[str, object]]) -> None:
+    """WARN when an approach's "of which" class rows do not foot to its total.
+
+    The net for the impossible-pair trap ``_placeable_irb_class`` describes. That
+    revert is deliberately narrow — it fixes only the Art. 151(4) pair we have
+    measured — so any OTHER (approach, class) combination the layout has no row
+    for would strand its RWEA out of the breakdown while the approach total still
+    counted it, and NO published rule would notice: the rules only check rows
+    that exist. This turns that silence into a log line naming the amount.
+
+    Not an error channel: the figures published are still correct at the approach
+    and Art. 92 totals, and a residual is a disclosure-granularity defect
+    upstream of this template, not a miscalculation in it.
+    """
+    for total_ref, detail_refs in _IRB_DETAIL_ROWS.items():
+        total = row_values.get(total_ref, {}).get("0010")
+        if not isinstance(total, (int, float)):
+            continue
+        detail = sum(
+            value
+            for ref in detail_refs
+            if isinstance(value := row_values.get(ref, {}).get("0010"), (int, float))
+        )
+        residual = float(total) - float(detail)
+        if abs(residual) > 0.01:
+            logger.warning(
+                "C 02.00: row %s (%.2f) exceeds its class breakdown %s (%.2f) by %.2f — "
+                "an (approach, class) pair with no row in the layout; the RWEA is counted "
+                "in the approach total but absent from the of-which rows",
+                total_ref,
+                float(total),
+                "+".join(detail_refs),
+                float(detail),
+                residual,
+            )
+
+
+def _placeable_irb_class(post_ec_col: str, origin_ec_col: str, approach_col: str) -> pl.Expr:
+    """The post-substitution IRB class, REVERTED where that class cannot exist
+    under the leg's approach.
+
+    THE IMPOSSIBLE-PAIR TRAP, AND WHY IT IS HANDLED HERE RATHER THAN IGNORED.
+    A post class key against the obligor's RETAINED approach can name a pair the
+    C 02.00 layout has no row for: the aggregator moves the class to the
+    guarantor's but keeps the obligor's approach whenever the guarantor is not
+    SA, so an F-IRB corporate loan covered by a RETAIL guarantor emits
+    ``(foundation_irb, retail_other)``. CRR Art. 151(4) makes that impossible —
+    retail exposures are A-IRB only, so the layout has retail rows under A-IRB
+    (0370-0400) and none under F-IRB (0250/0260 are institutions and corporates).
+    Its RWEA then fell out of rows 0250/0260 while row 0240 still counted it:
+    2,028,365.78 (CRR) / 1,700,935.66 (B31) on the CRM-substitution portfolio,
+    INVISIBLE to every published rule, because the rules only check rows that
+    exist. Reverting the class keeps the "of which" breakdown a true partition of
+    row 0240.
+
+    THIS IS A REPORTING GUARD, NOT THE FIX. The engine should never have
+    recognised the guarantee: CRR Art. 201(1) is an exhaustive list of eligible
+    unfunded-protection providers — central governments/banks, RGLAs, MDBs,
+    0%-RW international organisations, PSEs, institutions, other corporates,
+    QCCPs — and has NO retail limb. Closing that gap is a separate, capital-
+    affecting change with its own regulatory review. Until it lands, C 02.00
+    must not silently drop RWEA it is required to break down, and reverting to
+    the origin class puts the leg exactly where a declined guarantee would have
+    left it. Deliberately narrow: only the Art. 151(4) pair is reverted, so a
+    genuinely new impossible pair strands visibly rather than being absorbed —
+    ``_warn_if_irb_detail_strands`` is the net that catches it.
+    """
+    retail_under_firb = (pl.col(approach_col) == "foundation_irb") & pl.col(post_ec_col).is_in(
+        list(_RETAIL_CLASSES)
+    )
+    return pl.when(retail_under_firb).then(pl.col(origin_ec_col)).otherwise(pl.col(post_ec_col))
 
 
 def _equity_method_expr(cols: set[str]) -> pl.Expr:

--- a/src/rwa_calc/reporting/corep/c02.py
+++ b/src/rwa_calc/reporting/corep/c02.py
@@ -32,9 +32,14 @@ Cell semantics (recorded decisions, this slice):
   *and* SA-CCR — so the template foots against rows 0010/0050, which
   are flat ledger sums and always carried the CCR RWEA (recorded fix
   2026-07-12; see the constant for why it is not shared).
-- Class rows key the APPLIED Art. 112 class (``reporting_class_origin``
-  — recorded fix 2026-07-12, tying the SA breakdown to C 07.00: defaulted
-  SA RWA reports under row 0160) through the many-to-one ACCUMULATING
+- THREE keys, one per tied template: the approach rows and the SA class
+  rows key the POST-SUBSTITUTION twins (``reporting_approach`` /
+  ``reporting_class``, tying the SA breakdown to C 07.00), while the IRB
+  class rows stay on ``reporting_class_origin`` until C 08.01 follows. See
+  the long note at the binding site for why that PRESERVES the 2026-07-12
+  fix (whose stated purpose was that tie) rather than reversing it, why the
+  IRB half is a sequencing decision, and why Art. 92 is unaffected. Rows
+  0070-0211 route through the many-to-one ACCUMULATING
   ``C02_00_SA_CLASS_MAP``. Rows 0070-0211 are "See CR SA template", so
   the map's groupings ARE the C 07.00 sheet groupings (recorded fix
   2026-08-01: the map had been keyed on a vocabulary ``ExposureClass``
@@ -152,12 +157,61 @@ def generate_c02_00(
     column_refs = B31_C02_00_COLUMN_REFS if is_b31 else CRR_C02_00_COLUMN_REFS
     row_sections = get_c02_00_row_sections(framework)
 
-    # Recorded fix (2026-07-12): class rows key the APPLIED Art. 112 class
-    # (the sealed obligor ladder) so the SA breakdown ties to C 07.00 —
-    # defaulted SA RWA reports under row 0160, not the origination class.
-    # Identical values for IRB rows (raw == applied for the IRB book).
-    ec_col = pick(cols, "reporting_class_origin")
-    approach_col = pick(cols, "approach_applied")
+    # THREE keys, because C 02.00's breakdowns tie to THREE different templates
+    # and each must key the basis of the one it ties to (the two-basis discipline
+    # C 07.00 established in f94be554, applied within one template):
+    #
+    #   approach_col   POST  (``reporting_approach``)      rows 0060 / 0220 / 0240 …
+    #   sa_ec_col      POST  (``reporting_class``)         rows 0070-0211, "See CR SA
+    #                                                      template" -> C 07.00
+    #   irb_ec_col     ORIGIN(``reporting_class_origin``)  rows 0250-0420 -> C 08.01
+    #
+    # This PRESERVES the 2026-07-12 fix rather than reversing it. That fix moved
+    # the class rows off the origination class onto the applied Art. 112 class for
+    # a stated reason — "so the SA breakdown ties to C 07.00". C 07.00's
+    # exposure-value and RWEA columns have since moved to the post-substitution
+    # basis, so FOLLOWING C 07.00 is what honours that intent; staying put is what
+    # breaks it. The tie is published as EBA v4239_i / v4240_i ({C 02.00 r0120 /
+    # r0130 c0010} == {C 07.00.a r0010 c0220} per class sheet), both ERROR
+    # severity, and both FAILED on the origin key (institutions 750,000 against
+    # C 07.00's 2,150,000; corporates 6,600,000 against 5,200,000 — the
+    # substituted leg counted at the obligor's sheet on one template and the
+    # guarantor's on the other).
+    #
+    # THE IRB CLASS ROWS DELIBERATELY STAY ON THE ORIGIN KEY, and that is a
+    # SEQUENCING decision, not a different answer to the same question. They tie
+    # to C 08.01 col 0260 (``boe_b0616``, ERROR: {OF 02.00 r0271 c0010} =
+    # {OF 08.01 r0010 c0260 z0006}), and C 08.01 still sheets the obligor class.
+    # Moving this key alone broke that rule by exactly one leg — the S1 guarantee,
+    # F-IRB corporate covered by an F-IRB institution: C 02.00 r0271 4,283,321.07
+    # against C 08.01's 2,855,547.38, a difference of 1,427,773.69 = that leg's
+    # rwa_final. Art. 161 substitution does make it an institution exposure, so
+    # BOTH sides should move — together, when C 08.01 does.
+    #
+    # The 2026-07-12 note also said "identical values for IRB rows (raw ==
+    # applied for the IRB book)". That is NO LONGER TRUE, and it is the defect
+    # this fixes: an IRB-origin leg whose guarantee the engine applied under
+    # Art. 235 carries ``reporting_approach == "standardised"`` against
+    # ``approach_applied == "foundation_irb"``/``"slotting"``, so its RWEA was
+    # disclosed under "Of which: IRB Approach" / "Supervisory slotting" for an
+    # exposure that is a direct SA exposure to the guarantor.
+    #
+    # ART. 92 IS UNTOUCHED: rows 0010/0050 are FLAT ledger sums, and the approach
+    # labels partition the ledger either way (``approach_post_crm`` is
+    # ``approach_applied`` or the SA literal, never a new label), so RWEA moves
+    # BETWEEN rows 0060 and 0220 and their sum still foots to row 0050.
+    #
+    # Each key degrades to its origin twin on a frame that seals no
+    # post-substitution column, so the split is number-neutral wherever nothing
+    # substitutes. Written as conditionals rather than multi-candidate ``pick``
+    # ladders, which the arch_check ratchet counts.
+    sa_ec_col = pick(
+        cols, "reporting_class" if "reporting_class" in cols else "reporting_class_origin"
+    )
+    irb_ec_col = pick(cols, "reporting_class_origin")
+    approach_col = pick(
+        cols, "reporting_approach" if "reporting_approach" in cols else "approach_applied"
+    )
 
     approach_rwa: dict[str, float] = {}
     sa_class_rwa: dict[str, float] = {}
@@ -167,7 +221,7 @@ def generate_c02_00(
     equity_sa_rwa = 0.0
     equity_irb_rwa = 0.0
 
-    if approach_col and ec_col:
+    if approach_col and sa_ec_col and irb_ec_col:
         (
             total_rwa,
             irb_class_rwa,
@@ -176,7 +230,15 @@ def generate_c02_00(
             equity_sa_rwa,
             equity_irb_rwa,
         ) = _aggregate_by_approach(
-            results, approach_col, ec_col, rwa_col, cols, is_b31, approach_rwa, sa_class_rwa
+            results,
+            approach_col,
+            sa_ec_col,
+            irb_ec_col,
+            rwa_col,
+            cols,
+            is_b31,
+            approach_rwa,
+            sa_class_rwa,
         )
     else:
         # Fallback: just compute total RWA (no per-approach breakdowns).
@@ -272,10 +334,11 @@ def generate_c02_00(
 # =============================================================================
 
 
-def _aggregate_by_approach(
+def _aggregate_by_approach(  # noqa: PLR0913 - two class keys, one per tied template
     results: pl.LazyFrame,
     approach_col: str,
-    ec_col: str,
+    sa_ec_col: str,
+    irb_ec_col: str,
     rwa_col: str,
     cols: set[str],
     is_b31: bool,  # noqa: FBT001 - retired positional signature preserved
@@ -290,10 +353,16 @@ def _aggregate_by_approach(
     contract) and RETURNS what used to live on ``self``: the total, the
     IRB (approach, class) map, the slotting SL-type map, the B31 sub-row
     map, and the equity RWA split into (SA-method, IRB-method) sub-totals.
+
+    TWO CLASS KEYS, one per tied template — see the caller's note.
+    ``sa_ec_col`` (post-substitution) keys the SA class rows, which tie to
+    C 07.00; ``irb_ec_col`` (origin) keys the IRB class rows, which tie to
+    C 08.01. They are the same column wherever nothing substitutes.
     """
     collected = results.select(
         pl.col(approach_col).alias("_approach"),
-        pl.col(ec_col).alias("_ec"),
+        pl.col(sa_ec_col).alias("_ec_sa"),
+        pl.col(irb_ec_col).alias("_ec_irb"),
         pl.col(rwa_col).fill_null(0.0).alias("_rwa"),
         _equity_method_expr(cols).alias("_eqm"),
     ).collect()
@@ -325,24 +394,24 @@ def _aggregate_by_approach(
     # being SA, they are not swept into the IRB residual below.
     sa_mask = collected["_approach"].is_in(_SA_APPROACHES)
     sa_rows = collected.filter(sa_mask | equity_sa_mask)
-    by_class = sa_rows.group_by("_ec").agg(pl.col("_rwa").sum().alias("rwa"))
+    by_class = sa_rows.group_by("_ec_sa").agg(pl.col("_rwa").sum().alias("rwa"))
     for row in by_class.iter_rows(named=True):
-        sa_class_rwa[row["_ec"]] = float(row["rwa"])
+        sa_class_rwa[row["_ec_sa"]] = float(row["rwa"])
 
     # IRB per-approach-and-class breakdown (the equity approach is excluded
     # entirely — its RWA reports at row 0420 / the IRB total, never a per-class
     # IRB row, since there is no equity IRB exposure-class row in the layout).
     irb_rows = collected.filter(~sa_mask & ~equity_mask)
-    irb_class_approach = irb_rows.group_by(["_approach", "_ec"]).agg(
+    irb_class_approach = irb_rows.group_by(["_approach", "_ec_irb"]).agg(
         pl.col("_rwa").sum().alias("rwa")
     )
     irb_class_rwa = {
-        (row["_approach"], row["_ec"]): float(row["rwa"])
+        (row["_approach"], row["_ec_irb"]): float(row["rwa"])
         for row in irb_class_approach.iter_rows(named=True)
     }
 
     slotting_type_rwa = _slotting_type_agg(results, approach_col, rwa_col, cols)
-    irb_sub_rwa = _irb_sub_agg(results, approach_col, ec_col, rwa_col, cols) if is_b31 else {}
+    irb_sub_rwa = _irb_sub_agg(results, approach_col, irb_ec_col, rwa_col, cols) if is_b31 else {}
     return (
         total_rwa,
         irb_class_rwa,

--- a/src/rwa_calc/reporting/corep/c07.py
+++ b/src/rwa_calc/reporting/corep/c07.py
@@ -212,6 +212,12 @@ _FCSM_CARRIER: str = "fcsm_collateral_value"
 # The capped unfunded limb (cols 0050 + 0060 per row) that col 0100's inflow is
 # measured on — see ``_protection_exprs``.
 _UNFUNDED_COL: str = "c07_prot_unfunded"
+# The CRM decline flag — CONDITIONAL on the edge, so every read is presence-tolerant.
+# A DECLINED guarantee (it would have raised capital, CRR Art. 213) produces no
+# substitution effect, so it must not appear in the Annex II block headed "CRM
+# TECHNIQUES WITH SUBSTITUTION EFFECTS ON THE EXPOSURE". Gating the unfunded
+# magnitude gates the col 0100 INFLOW too, since that binds the same carrier.
+_BENEFICIAL_COL: str = "is_guarantee_beneficial"
 
 # The guarantor's exposure class (the col 0100 destination key) and the origin
 # approaches whose inflow half ``crm_substitution.irb_origin_inflows`` owns.
@@ -792,6 +798,17 @@ def _protection_exprs(cols: set[str]) -> list[pl.Expr]:
     tighter than col 0010's "exposure value" and it is what makes
     ``0110 = 0040 - 0090 + 0100`` non-negative by construction — the property
     rules ``v10293_s`` / ``boe_b0667`` ({template} >= 0) assert.
+
+    A DECLINED GUARANTEE CONTRIBUTES NOTHING TO COLS 0050/0060. The block heading
+    is "CRM TECHNIQUES **WITH SUBSTITUTION EFFECTS ON THE EXPOSURE**", and a
+    guarantee the calculator declined has none: recognition is permissive
+    (Art. 213), so where the guarantor's weight does not beat the obligor's the
+    engine leaves the RWA on the borrower basis and ``is_guarantee_beneficial`` is
+    false. Reporting it here booked a col 0090 outflow that no exposure ever left
+    and — because the col 0100 inflow binds the same ``_UNFUNDED_COL`` — a
+    matching phantom inflow onto the guarantor's sheet, banded at the BORROWER's
+    own risk weight. Gating the CARRIER, not the two cells, is what keeps outflow
+    and inflow on a single decision, so neither can move without the other.
     """
     guaranteed = (
         pl.col("guaranteed_portion").fill_null(0.0) if "guaranteed_portion" in cols else pl.lit(0.0)
@@ -810,6 +827,15 @@ def _protection_exprs(cols: set[str]) -> list[pl.Expr]:
     else:
         guarantee = guaranteed
         credit_derivative = pl.lit(0.0)
+
+    if _BENEFICIAL_COL in cols:
+        # A DECLINED guarantee has no substitution effect at all, so it belongs in
+        # neither the outflow nor the inflow — see the docstring's closing note.
+        # ``== True`` is the null-safe reading: an unknown benefit is not a
+        # substitution, and it must not be filled the other way.
+        applied = pl.col(_BENEFICIAL_COL) == True  # noqa: E712 - null-safe, see above
+        guarantee = pl.when(applied).then(guarantee).otherwise(pl.lit(0.0))
+        credit_derivative = pl.when(applied).then(credit_derivative).otherwise(pl.lit(0.0))
 
     fcsm = pl.col(_FCSM_CARRIER).fill_null(0.0) if _FCSM_CARRIER in cols else pl.lit(0.0)
     ofcp_parts = [pl.col(col).fill_null(0.0) for col in _OFCP_CARRIERS if col in cols]
@@ -913,6 +939,20 @@ def _add_sa_origin_inflows(
     admits the counterparty-credit-risk rows by ``risk_type`` with NO approach
     filter, so an IRB-origin CCR row can legitimately sit in this frame and would
     otherwise be counted twice.
+
+    DECLINED GUARANTEES ARE EXCLUDED TOO, and without a filter of their own:
+    ``_protection_exprs`` has already zeroed ``_UNFUNDED_COL`` on a leg whose
+    guarantee the calculator declined, so the ``> 0`` filter below drops it. It is
+    Art. 235 substitution ACTUALLY BEING APPLIED that entitles the covered part to
+    the guarantor's sheet; a positive covered carrier only says protection was
+    attached. Recognition is permissive (Art. 213), so the SA calculator declines
+    a guarantee whose guarantor weight does not beat the obligor's
+    (``is_guarantee_beneficial=False``) and leaves the RWA on the borrower basis.
+    Booking that as an inflow moved the covered part onto the guarantor's sheet
+    banded — via ``c07_rw_band`` — at the BORROWER's own risk weight, reproduced
+    as a full 10,000,000 phantom inflow onto ``central_govt_central_bank`` at
+    100%. Sharing the carrier with the col 0090 outflow is what keeps both sides
+    off the SAME decision, so a declined guarantee can neither leave nor arrive.
     """
     cols = set(sa_df.columns)
     if not {_UNFUNDED_COL, _POST_CRM_CLASS_COL} <= cols:

--- a/src/rwa_calc/reporting/corep/c07.py
+++ b/src/rwa_calc/reporting/corep/c07.py
@@ -318,6 +318,32 @@ _PF_PHASE_MAP: dict[str, str] = {
     "0025": "operational",
     "0026": "high_quality_operational",
 }
+# The POST-basis gate on the specialised-lending "of which" rows 0021-0026: does
+# this leg still apply its OWN Art. 122B risk-weight treatment? ``sl_type`` is
+# the OBLIGOR's characteristic and the CRM split never reassigns it, so a covered
+# part substituted onto a protection provider's risk weight carries the obligor's
+# ``sl_type`` onto the GUARANTOR's sheet, where the post-basis cells (0160-0235)
+# would report it as the guarantor's specialised lending.
+#
+# Annex II admits a row 0021-0026 exposure on THREE conjunctive conditions, the
+# third of which is the applied risk weight: row 0023 is "only exposures which
+# are 'project finance exposures' ..., assigned to the exposure class 'Exposures
+# to corporates' ..., [and] apply the risk weight treatment in accordance with
+# Articles 122B(2)(c) or 122B(4)" (PS1/26 Annex II p.89; rows 0024-0026 spell the
+# same limb "(d) subject to the risk weight treatment in accordance with Article
+# 122B(2)(c)"). A substituted-in covered part applies the PROVIDER's Art. 122
+# weight, not Art. 122B — and ¶43 says so directly: "the substitution effect ...
+# shall reflect the risk weighting treatment effectively applicable to the
+# covered part of the exposure". So it fails the third condition and belongs in
+# NEITHER row 0023 nor its phase children.
+#
+# ORIGIN basis deliberately UNCHANGED: cols 0010-0150 are the obligor's own book,
+# where ¶42/¶56A require the covered part to be shown leaving the obligor's class
+# through col 0090. Derived rather than expressed as a bare
+# ``(_BENEFICIAL_COL, False)`` term for the ``c07_qccp`` reason — that compiles to
+# ``== False``, so a NULL flag would drop every unguaranteed SL exposure out of
+# its own row.
+_SL_OWN_RW_COL: str = "c07_sl_own_rw"
 _CIU_ROW_APPROACH: dict[str, str] = {
     "0281": "look_through",
     "0282": "mandate_based",
@@ -719,6 +745,20 @@ def _prepare(data: pl.DataFrame, cols: set[str], framework: str) -> pl.DataFrame
         )
     if "sa_cqs" in cols:
         exprs.append(pl.col("sa_cqs").is_not_null().alias("c07_rated"))
+
+    # Post-basis specialised-lending gate (rows 0021-0026) — see _SL_OWN_RW_COL.
+    # The complement of the ``_protection_exprs`` substitution gate, read the same
+    # null-safe way (an unknown benefit is not a substitution), so the row
+    # exclusion and the col 0090/0100 flow are driven by ONE flag and cannot
+    # drift: exactly the legs whose covered part left for a provider's risk
+    # weight are the legs that stop applying Art. 122B.
+    if _BENEFICIAL_COL in cols:
+        exprs.append(
+            (pl.col(_BENEFICIAL_COL) == True)  # noqa: E712 - null-safe, see _protection_exprs
+            .fill_null(value=False)
+            .not_()
+            .alias(_SL_OWN_RW_COL)
+        )
 
     # CCR discriminators (cols 0210/0211). 0210 = "of which: arising from
     # counterparty credit risk"; 0211 = the same, excluding the Art. 301(1)
@@ -1373,6 +1413,23 @@ def _inflow_key_for(ref: str, terms: _Terms) -> str | None:
     return None
 
 
+def _post_sl_terms(terms: _Terms, cols: set[str]) -> _Terms:
+    """The POST-basis-only narrowing of the specialised-lending "of which" rows.
+
+    A row keying ``sl_type`` (0021-0026) admits a leg on the post basis only
+    while that leg still applies its own Art. 122B risk weight — see
+    ``_SL_OWN_RW_COL`` for the Annex II basis. Recognised by the row's own
+    membership term rather than a hardcoded ref ladder, so the phase children
+    (which key ``sl_type`` AND ``sl_project_phase``) fall out with the parent.
+    Empty when no substitution gate is sealed: the frame then carries no
+    beneficially-substituted leg to exclude, and a term on an underived column
+    would zero the SL rows of every synthetic unit frame.
+    """
+    if _BENEFICIAL_COL not in cols or not any(column == "sl_type" for column, _ in terms):
+        return ()
+    return ((_SL_OWN_RW_COL, True),)
+
+
 def _row_cells(  # noqa: PLR0913 - the full 24-column surface of one row
     terms: _Terms,
     cols: set[str],
@@ -1388,7 +1445,7 @@ def _row_cells(  # noqa: PLR0913 - the full 24-column surface of one row
     # predicate carries its basis flag, INCLUDING the total row's (whose ``terms``
     # are empty) — an unflagged predicate would silently sum both populations.
     origin_terms: _Terms = ((_BASIS_ORIGIN_COL, True), *terms)
-    post_terms: _Terms = ((_BASIS_POST_COL, True), *terms)
+    post_terms: _Terms = ((_BASIS_POST_COL, True), *terms, *_post_sl_terms(terms, cols))
     member = RowPredicate(equals=origin_terms)
     post_member = RowPredicate(equals=post_terms)
 

--- a/src/rwa_calc/reporting/corep/c07.py
+++ b/src/rwa_calc/reporting/corep/c07.py
@@ -9,12 +9,40 @@ Pipeline position:
 Cell semantics (the recorded F4 decision —
 docs/plans/phase7-declarative-reporting.md §6):
 
-- Sheets key the OBLIGOR applied class (the ``exposure_class_applied`` ->
-  ``exposure_class`` ladder — identical to the sealed
-  ``reporting_class_origin`` on ledger frames; the raw ladder is kept so
-  the synthetic COREP unit estate needs no shim). Specialised lending is
-  merged into corporate before keying (Art. 112(1)(g): SL is a corporate
-  sub-type under SA; the SL "of which" rows split it back via sl_type).
+- EVERY SHEET IS TWO POPULATIONS, NOT ONE — the recorded two-basis decision.
+  Annex II makes the front of the template and the back of it answer
+  different questions, so a sheet's cells split by BASIS:
+    * ORIGIN basis (``c07_basis_origin``) — the obligor's own book. Cols
+      0010-0150: the gross exposure, the value adjustments, the CRM
+      substitution block and the pre-conversion waterfall. A guaranteed leg
+      belongs here on the OBLIGOR's sheet, because that is where its covered
+      part is "deducted from the obligor's exposure class" (col 0090).
+    * POST basis (``c07_basis_post``) — after substitution. Cols 0160-0235:
+      the CCF breakdown, the exposure value, and the RWEA. Col 0200 is
+      defined as the "exposure value after taking into account value
+      adjustments, ALL CREDIT RISK MITIGANTS and conversion factors" —
+      substitution is a credit risk mitigant, so the covered part must leave
+      the obligor's sheet and land on the protection provider's, exactly as
+      col 0090/0100 already move it pre-conversion. Cols 0160-0190 follow it
+      because they break down col 0150, which is already post-substitution,
+      and because ``v0308_m`` / ``boe_b0471`` test col 0200 AGAINST them.
+  Binding col 0200/0220 to the ORIGIN population was a recorded build
+  shortfall (F4 never extended substitution-awareness past the waterfall),
+  not a decision: it left a fully-outflowed row reporting its raw EAD at the
+  obligor's sheet and an inflow-only sheet reporting none at all, breaking
+  ``v0308_m`` / ``v8726_m`` / ``boe_b0471`` / ``boe_b0556`` and putting this
+  template on a different basis from Pillar 3 CR4 cols c-f and all of CR5,
+  which cite col 0200 as the DEFINITION of their own post-substitution basis.
+- Sheets key the OBLIGOR applied class on the origin basis (the sealed
+  ``reporting_class_origin``) and the GUARANTOR class on the post basis (the
+  sealed ``reporting_class``); the sheet AXIS is the union of both plus the
+  classes receiving an inflow. Specialised lending is merged into corporate
+  on BOTH keys (Art. 112(1)(g): SL is a corporate sub-type under SA; the SL
+  "of which" rows split it back via sl_type) — an SL guarantor must key a
+  sheet this template has. A frame that seals no ``reporting_class`` /
+  ``reporting_approach`` (synthetic unit frames) degrades the post basis to
+  the origin basis, so a book with no substitution reports identically under
+  both and the split is number-neutral by construction.
 - The population is the standardised book plus BOTH counterparty-credit-risk
   populations (``risk_type in {"CCR_SFT", "CCR_DERIVATIVE"}`` — SA-risk-weighted
   but tagged ``standardised_ccr`` under the output floor, so they are admitted by
@@ -91,8 +119,9 @@ docs/plans/phase7-declarative-reporting.md §6):
   ITEMS BY CONVERSION FACTORS". They therefore sum the PRE-conversion
   off-balance-sheet gross (``reporting_gross_off_bs`` — the same carrier
   col 0010 sums on the off-side, so 0150 decomposes into them by
-  construction), narrowed to the off-balance-sheet side, NOT the
-  post-conversion ``ead_final``. Col 0200 is what survives conversion, and
+  construction, on the POST basis they share with it), narrowed to the
+  off-balance-sheet side, NOT the post-conversion ``ead_final``. Col 0200
+  is what survives conversion, and
   the two are related by the supervisory identity ``boe_b0471``:
   ``{c0200} = {c0150} - 0.9*{c0160} - 0.8*{c0170} - 0.6*{c0171}
   - 0.5*{c0180}``. Summing EAD here would break that rule, ``v6364_m``
@@ -112,7 +141,7 @@ References:
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 import polars as pl
 from watchfire import cites
@@ -135,7 +164,7 @@ from rwa_calc.reporting.corep.templates import (
     get_sa_risk_weight_bands,
     get_sa_row_sections,
 )
-from rwa_calc.reporting.kernel import filter_by_approach, pick
+from rwa_calc.reporting.kernel import pick
 from rwa_calc.reporting.metadata import SUBSTITUTION_INFLOW_RW_PREFIX, ReportingContext
 from rwa_calc.reporting.plans import SheetPlan
 
@@ -150,6 +179,39 @@ logger = logging.getLogger(__name__)
 _NEGATIVE_COLS: frozenset[str] = frozenset(
     {"0030", "0035", "0050", "0060", "0070", "0080", "0090", "0130", "0140", "0216", "0217"}
 )
+
+# The two-basis discriminators (see the module docstring). Four derived columns
+# carry the split; nothing about it reaches ``RowPredicate``, whose ``classes`` /
+# ``classes_origin`` fields are per-CELL keys against the sealed ledger, while a
+# basis here is a per-SHEET question ("is this leg on THIS sheet, on THIS basis?")
+# answered against a class that varies sheet by sheet. Expressing it as derived
+# booleans keeps ONE spec shared across every sheet, keeps the population
+# definition in ``c07_population`` alone, and — decisively — lets the post basis
+# DEGRADE to the origin basis on a frame that seals no post-substitution columns.
+# A strict ``RowPredicate(classes=...)`` term cannot degrade: it would either
+# raise on the missing column or (as a tolerant ``equals``) silently zero the
+# exposure-value and RWEA columns of every synthetic unit frame.
+#
+# Membership of each APPROACH population (both include the CCR limb):
+_POP_ORIGIN_COL: str = "c07_pop_origin"
+_POP_POST_COL: str = "c07_pop_post"
+# The sheet keys, Art. 112 Table A2 merge applied (SL -> corporate):
+_CLASS_ORIGIN_COL: str = "c07_class_origin"
+_CLASS_POST_COL: str = "c07_class_post"
+# Per-SHEET: population membership AND that basis' class == this sheet's class.
+_BASIS_ORIGIN_COL: str = "c07_basis_origin"
+_BASIS_POST_COL: str = "c07_basis_post"
+# The sealed post-substitution twins the post basis reads (``reporting_class`` =
+# the guarantor's class on a beneficially-guaranteed leg, ``reporting_approach`` =
+# the approach that leg is treated under). Both absent -> post degrades to origin.
+_POST_CLASS_SOURCE: str = "reporting_class"
+_POST_APPROACH_SOURCE: str = "reporting_approach"
+_ORIGIN_APPROACH_SOURCE: str = "reporting_approach_origin"
+
+# The ``c07_bs`` labels rows 0070 / 0080 filter on, and the keys the col 0100
+# inflow is split by when it lands on them.
+_ON_BS: str = "on"
+_OFF_BS: str = "off"
 
 # Col 0030 provisions carriers, in preference order: the specific / general
 # provision input pass-throughs (never sealed on the aggregator exit — present
@@ -366,52 +428,100 @@ def c07_plans(
             errors.append("C07: Missing exposure_class column")
         return {}
 
-    sa_df = c07_population(results, cols).collect()
+    sa_df = c07_population(results, cols, both_bases=True).collect()
     # Resolved BEFORE the empty-population guard: an all-IRB book guaranteed by
     # an SA counterparty has NO SA leg of its own, and the early exit would drop
     # the inflow this template is the only home for.
-    inflow_map, inflow_bands = _sa_inflows(results, cols, framework)
-    if len(sa_df) == 0 and not inflow_map:
+    inflows = _sa_inflows(results, cols, framework)
+    if len(sa_df) == 0 and not inflows.total:
         return {}
 
-    # Art. 112 Table A2: SL is a corporate sub-type under SA.
+    # The two sheet keys, Art. 112 Table A2 merge applied to BOTH (SL is a
+    # corporate sub-type under SA). The post key degrades to the origin key on a
+    # frame that seals no ``reporting_class``, which is what makes the two-basis
+    # split number-neutral wherever nothing substitutes.
+    post_class_col = _POST_CLASS_SOURCE if _POST_CLASS_SOURCE in sa_df.columns else ec_col
     sa_df = sa_df.with_columns(
-        pl.when(pl.col(ec_col) == ExposureClass.SPECIALISED_LENDING.value)
-        .then(pl.lit(ExposureClass.CORPORATE.value))
-        .otherwise(pl.col(ec_col))
-        .alias(ec_col)
+        _merge_specialised_lending(ec_col).alias(_CLASS_ORIGIN_COL),
+        _merge_specialised_lending(post_class_col).alias(_CLASS_POST_COL),
     )
     data_cols = set(sa_df.columns)
     sa_df = _prepare(sa_df, data_cols, framework)
     _warn_if_ccf_buckets_unreportable(sa_df, data_cols)
     # The SA-origin half joins the cross-template half only now: it is measured on
     # THIS template's capped carrier, which _prepare has just derived.
-    inflow_map, inflow_bands = _add_sa_origin_inflows(inflow_map, inflow_bands, sa_df)
+    inflows = _add_sa_origin_inflows(inflows, sa_df)
 
     row_terms = _row_terms(framework, data_cols)
     spec = _build_spec(framework, data_cols, ead_col, rwa_col, row_terms)
 
     plans: dict[str, SheetPlan] = {}
-    # Sealed-ledger rule: the class column always exists; a null key
-    # (no source on a synthetic frame) partitions into NO sheet. The axis is the
-    # UNION of the classes present and the classes RECEIVING an inflow — Annex II
-    # requires in- and outflows to and from other templates to be taken into
-    # account, which an inflow with no sheet to land on cannot satisfy. An
-    # inflow-only sheet keeps its constraint-free total row 0010 (every other row
-    # renders all-null through ``_null_empty_rows``) and reports 0110 = 0100.
-    for ec in sorted(set(sa_df[ec_col].drop_nulls().unique().to_list()) | set(inflow_map)):
+    # Sealed-ledger rule: the class columns always exist; a null key (no source
+    # on a synthetic frame) partitions into NO sheet. The axis is the UNION of
+    # the classes present on EITHER basis and the classes RECEIVING an inflow —
+    # Annex II requires in- and outflows to and from other templates to be taken
+    # into account, which an inflow with no sheet to land on cannot satisfy. The
+    # post-basis limb is belt-and-braces: a beneficially-substituted leg's
+    # guarantor class is an inflow key too, so in practice it adds no sheet — but
+    # without it a leg whose inflow the block cap shed to zero would drop its
+    # exposure value and RWEA out of the template silently. An inflow-only sheet
+    # keeps its constraint-free total row 0010 and reports 0110 = 0100.
+    axis = (
+        set(_sheet_keys(sa_df, _POP_ORIGIN_COL, _CLASS_ORIGIN_COL))
+        | set(_sheet_keys(sa_df, _POP_POST_COL, _CLASS_POST_COL))
+        | set(inflows.total)
+    )
+    for ec in sorted(axis):
+        sides = inflows.by_side.get(ec, {})
+        bands = inflows.by_rw_band.get(ec, {})
         plans[ec] = SheetPlan(
             spec=spec,
-            frame=sa_df.filter(pl.col(ec_col) == ec),
+            frame=_sheet_frame(sa_df, ec),
             ctx=ReportingContext(
-                substitution_inflow=inflow_map.get(ec, 0.0),
-                substitution_inflow_by_rw=inflow_bands.get(ec, {}),
+                substitution_inflow=inflows.total.get(ec, 0.0),
+                substitution_inflow_on_bs=sides.get(_ON_BS, 0.0),
+                substitution_inflow_off_bs=sides.get(_OFF_BS, 0.0),
+                substitution_inflow_by_rw=bands,
             ),
             negative_cols=_NEGATIVE_COLS,
             row_terms=row_terms,
-            inflow_rows=_inflow_rows(row_terms, inflow_bands.get(ec, {})),
+            inflow_rows=_inflow_rows(row_terms, sides, bands),
         )
     return plans
+
+
+def _merge_specialised_lending(class_col: str) -> pl.Expr:
+    """Art. 112 Table A2: SL is a corporate sub-type under SA, so it is merged
+    into corporate before keying a sheet (the SL "of which" rows split it back
+    via ``sl_type``). Applied to BOTH sheet keys, so an SL guarantor's covered
+    part keys a sheet this template actually has."""
+    return (
+        pl.when(pl.col(class_col) == ExposureClass.SPECIALISED_LENDING.value)
+        .then(pl.lit(ExposureClass.CORPORATE.value))
+        .otherwise(pl.col(class_col))
+    )
+
+
+def _sheet_keys(data: pl.DataFrame, population_col: str, class_col: str) -> list[str]:
+    """The distinct sheet keys one basis contributes to the sheet axis."""
+    return data.filter(pl.col(population_col))[class_col].drop_nulls().unique().to_list()
+
+
+def _sheet_frame(data: pl.DataFrame, exposure_class: str) -> pl.DataFrame:
+    """One sheet's frame: the legs on it under EITHER basis, each tagged with
+    which. The union is what lets one cell read the obligor's own book (cols
+    0010-0150) while its neighbour reads the post-substitution population (cols
+    0160-0235) — see the module docstring. A leg on neither basis is dropped, so
+    the frame is never wider than the sheet."""
+    tagged = data.with_columns(
+        (pl.col(_POP_ORIGIN_COL) & (pl.col(_CLASS_ORIGIN_COL) == exposure_class))
+        .fill_null(value=False)
+        .alias(_BASIS_ORIGIN_COL),
+        (pl.col(_POP_POST_COL) & (pl.col(_CLASS_POST_COL) == exposure_class))
+        .fill_null(value=False)
+        .alias(_BASIS_POST_COL),
+    )
+    return tagged.filter(pl.col(_BASIS_ORIGIN_COL) | pl.col(_BASIS_POST_COL))
 
 
 @cites("PS1/26, paragraph 1.3")
@@ -431,37 +541,76 @@ def generate_c07(
 
 
 @cites("PS1/26")
-def c07_population(results: pl.LazyFrame, cols: set[str]) -> pl.LazyFrame:
+def c07_population(
+    results: pl.LazyFrame, cols: set[str], *, both_bases: bool = False
+) -> pl.LazyFrame:
     """The C 07.00 population: the standardised book plus the CCR rows.
 
-    The CCR limb admits BOTH counterparty-credit-risk risk types (FCCM SFT
-    synthetic rows and SA-CCR derivative netting sets) by ``risk_type`` —
-    Annex II puts them in rows 0090-0130, and C 07.00 risk-weights under SA the
-    very exposures C 34 analyses by approach. Admission cannot key the approach
-    label: under the output floor ``engine/stages/calc.py`` relabels CCR rows to
-    ``standardised_ccr`` so they route into the floor-eligible approaches, which
-    is load-bearing and must NOT be undone here.
+    ``both_bases`` selects WHICH standardised book. The default is the
+    ORIGIN-approach one — the obligor's own book, and the only thing C 09.01
+    (which shares this population for its geographical breakdown) asks for.
+    C 07.00 itself takes the UNION of the origin-approach book and the
+    POST-substitution one, tagged with ``c07_pop_origin`` / ``c07_pop_post`` so
+    each cell reads its own basis (module docstring). A leg with no substitution
+    is in both, which is why the split is number-neutral on a book that never
+    substitutes. The post limb is what carries an IRB-origin leg guaranteed by an
+    SA protection provider onto this template: its exposure value and RWEA belong
+    on the guarantor's SA sheet under Art. 235, which is where col 0100 already
+    routes its inflow. Widening C 09.01 the same way is a separate question with
+    its own goldens, so the default deliberately does not.
 
-    Under CRR the derivative rows already arrive on the ``"standardised"`` limb;
-    the ``unique`` dedupe means admitting them again costs nothing (the CRR
-    totals do not move). Under Basel 3.1 this limb is the only one that admits
-    them at all.
+    The CCR limb admits ALL THREE counterparty-credit-risk risk types by
+    ``risk_type`` — Annex II puts them in rows 0090-0130, and C 07.00
+    risk-weights under SA the very exposures C 34 analyses by approach.
+    Admission cannot key the approach label: under the output floor
+    ``engine/stages/calc.py`` relabels CCR rows to ``standardised_ccr`` so they
+    route into the floor-eligible approaches, which is load-bearing and must NOT
+    be undone here. CCR legs join BOTH bases: substitution does not move them.
+
+    The dedupe keys the exposure reference, which the sealed ledger always
+    carries. The ``subset=None`` fallback (synthetic unit frames only, where no
+    reference column exists) dedupes on ALL columns — two genuinely distinct
+    exposures identical in every column would collapse into one. Harmless where
+    it can fire; do not promote this fallback to the ledger path.
     """
-    sa = filter_by_approach(
-        results, "standardised", cols, candidates=("reporting_approach_origin",)
+    tagged = results.with_columns(_population_exprs(cols))
+    admitted = (
+        tagged.filter(pl.col(_POP_ORIGIN_COL) | pl.col(_POP_POST_COL))
+        if both_bases
+        else tagged.filter(pl.col(_POP_ORIGIN_COL)).drop(_POP_ORIGIN_COL, _POP_POST_COL)
     )
-    if "risk_type" not in cols:
-        return sa
-    ccr = results.filter(pl.col("risk_type").is_in(_CCR_RISK_TYPES))
-    # The dedupe keys the exposure reference, which the sealed ledger always
-    # carries. The `subset=None` fallback (synthetic unit frames only, where no
-    # reference column exists) dedupes on ALL columns — two genuinely distinct
-    # exposures identical in every column would collapse into one. Harmless
-    # where it can fire; do not promote this fallback to the ledger path.
-    return pl.concat([sa, ccr], how="diagonal_relaxed").unique(
+    return admitted.unique(
         subset=["exposure_reference"] if "exposure_reference" in cols else None,
         keep="first",
     )
+
+
+def _population_exprs(cols: set[str]) -> list[pl.Expr]:
+    """The two population-membership flags (see :func:`c07_population`).
+
+    ``_is_standardised`` mirrors ``filter_by_approach``'s missing-column rule —
+    no approach discriminator means an EMPTY population, never a silent
+    pass-through. The post limb falls back to the ORIGIN approach when no
+    post-substitution approach is sealed, so a synthetic frame reports the same
+    figures under both bases instead of zeroing its exposure-value columns.
+    """
+    ccr = (
+        pl.col("risk_type").is_in(_CCR_RISK_TYPES).fill_null(value=False)
+        if "risk_type" in cols
+        else pl.lit(value=False)
+    )
+    origin = _is_standardised(cols, _ORIGIN_APPROACH_SOURCE)
+    post = (
+        _is_standardised(cols, _POST_APPROACH_SOURCE) if _POST_APPROACH_SOURCE in cols else origin
+    )
+    return [(origin | ccr).alias(_POP_ORIGIN_COL), (post | ccr).alias(_POP_POST_COL)]
+
+
+def _is_standardised(cols: set[str], approach_col: str) -> pl.Expr:
+    """Is this leg standardised under ``approach_col``? (Absent column = no.)"""
+    if approach_col not in cols:
+        return pl.lit(value=False)
+    return (pl.col(approach_col) == "standardised").fill_null(value=False)
 
 
 def _has_bs_side(cols: set[str]) -> bool:
@@ -880,9 +1029,50 @@ def _block_cap_scale(cols: set[str], block_total: pl.Expr) -> pl.Expr:
     return pl.when(block_total > basis).then(basis / block_total).otherwise(1.0)
 
 
-def _sa_inflows(
-    results: pl.LazyFrame, cols: set[str], framework: str
-) -> tuple[dict[str, float], dict[str, dict[str, float]]]:
+class _Inflows(NamedTuple):
+    """The col 0100 inflow per destination class, on the three row axes C 07.00
+    decomposes it over.
+
+    ``total`` lands on the Total row 0010; ``by_side`` on the balance-sheet rows
+    0070 / 0080 (keyed by the ``c07_bs`` label those rows filter on); ``by_rw_band``
+    on the section-2 risk-weight rows. Each axis re-counts the SAME money — a
+    native exposure appears once in each decomposition, so a substituted-in amount
+    must too.
+
+    THE BALANCE-SHEET AXIS BECAME LOAD-BEARING WITH THE TWO-BASIS SPLIT. It was
+    once correctly absent: the recorded reasoning was that C 07.00's own row sum
+    ``boe_b0717`` is scoped to cols 0200/0220, "neither of which the inflow
+    touches", so rows 0070/0080 imposed no constraint on col 0100. Col 0200 is
+    now on the POST basis, so it DOES report the arriving legs — and it reports
+    them on row 0070/0080 as well as on row 0010, because the arriving leg's own
+    balance-sheet side is in the frame. Leaving those two rows' col 0150 without
+    the inflow left them declaring an exposure value larger than the fully
+    adjusted exposure it came from, breaching ``boe_b0556`` / ``v8726_m``
+    ({c0200} <= {c0150}) on precisely the sheets the substitution reached.
+
+    IT IS NOT ``boe_b0717`` THAT FORCES THIS, AND THE DIFFERENCE IS INSTRUCTIVE —
+    two reviewers predicted that rule as the casualty, and it was MEASURED not to
+    be (it passes with the split, without it, and before the two-basis change:
+    6 evaluated, 5 passing; its EBA twin ``v0310_m`` likewise). Its row
+    decomposition is scoped to cols 0200/0220 ONLY, and those columns read the
+    arriving LEGS THEMSELVES off the post-basis frame — each carries its own
+    ``c07_bs``, so rows 0070/0080 pick it up with no out-of-frame scalar at all
+    and the sum foots by construction. ``boe_b0556`` breaks because it STRADDLES
+    the two mechanisms: col 0200 gets the arriving legs from the frame while col
+    0150 gets the arriving amount only from the ``SideContext`` scalar, which
+    landed on row 0010 and the band rows but not on 0070/0080. A rule confined to
+    either mechanism alone is safe; the ones to check are the ones spanning both.
+    (The CCR rows in ``boe_b0717``'s list — 0090/0110/0130 — take no inflow at
+    all: they key ``risk_type``, which ``_inflow_key_for`` does not recognise, and
+    0130 is inert. Verified, not assumed.)
+    """
+
+    total: dict[str, float]
+    by_side: dict[str, dict[str, float]]
+    by_rw_band: dict[str, dict[str, float]]
+
+
+def _sa_inflows(results: pl.LazyFrame, cols: set[str], framework: str) -> _Inflows:
     """The SA-destined substitution inflows, keyed the way C 07.00 keys sheets.
 
     TWO HALVES, because the inflow must be measured with the cap of the template
@@ -906,27 +1096,27 @@ def _sa_inflows(
     guarantor would key a sheet C 07.00 does not have.
     """
     merged: dict[str, float] = {}
+    sides: dict[str, dict[str, float]] = {}
     bands: dict[str, dict[str, float]] = {}
-    # The on/off-BS and graded/slotting splits are NOT read here: C 07.00's own
-    # row sum ``boe_b0717`` is scoped to cols 0200/0220, neither of which the
-    # inflow touches, so its rows 0070/0080 impose no constraint on col 0100. The
-    # RISK-WEIGHT split is read, because ``v0312_m`` / ``boe_b0719`` decompose row
-    # 0010 over the band rows on col 0150, which the inflow does reach (through
-    # 0110). ``risk_weight`` is absent on a frame too thin to band; the router then
-    # returns no split and the band rows keep their ordinary empty policy.
+    # The graded/slotting split is NOT read: C 07.00 has no IRB-treatment row
+    # axis. The other two are — ``v0312_m`` / ``boe_b0719`` decompose row 0010
+    # over the band rows and ``boe_b0717`` over rows 0070/0080, on columns the
+    # inflow now reaches (col 0150 through 0110, and col 0200 through the post
+    # basis). ``risk_weight`` is absent on a frame too thin to band; the router
+    # then returns no split and the band rows keep their ordinary empty policy.
     band_expr = _rw_band_expr(framework) if "risk_weight" in cols else None
     for exposure_class, inflow in irb_origin_inflows(
         results, cols, destination="standardised", band_expr=band_expr
     ).items():
         _accumulate(merged, exposure_class, inflow.total)
+        _accumulate_split(sides, exposure_class, _ON_BS, inflow.on_bs)
+        _accumulate_split(sides, exposure_class, _OFF_BS, inflow.off_bs)
         for band, amount in inflow.by_rw_band.items():
-            _accumulate_band(bands, exposure_class, band, amount)
-    return merged, bands
+            _accumulate_split(bands, exposure_class, band, amount)
+    return _Inflows(merged, sides, bands)
 
 
-def _add_sa_origin_inflows(
-    inflows: dict[str, float], bands: dict[str, dict[str, float]], sa_df: pl.DataFrame
-) -> tuple[dict[str, float], dict[str, dict[str, float]]]:
+def _add_sa_origin_inflows(inflows: _Inflows, sa_df: pl.DataFrame) -> _Inflows:
     """Add the SA-origin half of col 0100, off this template's own capped frame.
 
     ``sa_df`` is post-``_prepare``, so it carries ``_UNFUNDED_COL`` — the same
@@ -956,69 +1146,103 @@ def _add_sa_origin_inflows(
     """
     cols = set(sa_df.columns)
     if not {_UNFUNDED_COL, _POST_CRM_CLASS_COL} <= cols:
-        return inflows, bands
-    frame = sa_df.filter((pl.col(_UNFUNDED_COL) > 0) & pl.col(_POST_CRM_CLASS_COL).is_not_null())
-    if "reporting_approach_origin" in cols:
-        frame = frame.filter(~pl.col("reporting_approach_origin").is_in(list(_IRB_ORIGINS)))
+        return inflows
+    # The ORIGIN population only: this half speaks for legs whose OUTFLOW this
+    # template reported, and only an origin-basis leg has one here. Post-basis-
+    # only legs are IRB-origin by construction (they are in the post population
+    # and not the origin one), so they arrive from ``irb_origin_inflows`` already
+    # measured on the IRB cap — counting them again would create money.
+    frame = sa_df.filter(
+        pl.col(_POP_ORIGIN_COL)
+        & (pl.col(_UNFUNDED_COL) > 0)
+        & pl.col(_POST_CRM_CLASS_COL).is_not_null()
+    )
+    if _ORIGIN_APPROACH_SOURCE in cols:
+        frame = frame.filter(~pl.col(_ORIGIN_APPROACH_SOURCE).is_in(list(_IRB_ORIGINS)))
     grouped = frame.group_by(_POST_CRM_CLASS_COL).agg(pl.col(_UNFUNDED_COL).sum().alias("inflow"))
-    merged = dict(inflows)
+    merged = dict(inflows.total)
     for row in grouped.iter_rows(named=True):
         _accumulate(merged, row[_POST_CRM_CLASS_COL], float(row["inflow"]))
-    merged_bands = {key: dict(value) for key, value in bands.items()}
-    if "c07_rw_band" in cols:
-        banded = frame.group_by(_POST_CRM_CLASS_COL, "c07_rw_band").agg(
-            pl.col(_UNFUNDED_COL).sum().alias("inflow")
-        )
-        for row in banded.iter_rows(named=True):
-            _accumulate_band(
-                merged_bands,
-                row[_POST_CRM_CLASS_COL],
-                row["c07_rw_band"],
-                float(row["inflow"]),
-            )
-    return merged, merged_bands
-
-
-def _accumulate_band(
-    bands: dict[str, dict[str, float]], exposure_class: str, band: str, amount: float
-) -> None:
-    """Add one destination-class/band amount under this template's sheet key."""
-    key = (
-        ExposureClass.CORPORATE.value
-        if exposure_class == ExposureClass.SPECIALISED_LENDING.value
-        else exposure_class
+    # The two split axes, each a group_by on the SAME frame. A leg the frame
+    # cannot place on a balance-sheet side (null ``c07_bs``) joins the ON side,
+    # matching ``crm_substitution._off_bs``'s convention — that is what keeps
+    # on + off == total, and therefore keeps ``boe_b0717`` footing.
+    merged_sides = _add_split(inflows.by_side, frame, _side_label(cols))
+    merged_bands = _add_split(
+        inflows.by_rw_band, frame, pl.col("c07_rw_band") if "c07_rw_band" in cols else None
     )
-    per_class = bands.setdefault(key, {})
-    per_class[band] = per_class.get(band, 0.0) + amount
+    return _Inflows(merged, merged_sides, merged_bands)
+
+
+def _side_label(cols: set[str]) -> pl.Expr:
+    """The ``c07_bs`` label rows 0070/0080 filter on, defaulting to the ON side."""
+    if "c07_bs" not in cols:
+        return pl.lit(_ON_BS)
+    return pl.when(pl.col("c07_bs") == _OFF_BS).then(pl.lit(_OFF_BS)).otherwise(pl.lit(_ON_BS))
+
+
+def _add_split(
+    existing: dict[str, dict[str, float]], frame: pl.DataFrame, label: pl.Expr | None
+) -> dict[str, dict[str, float]]:
+    """Accumulate one inflow split axis over the SA-origin frame into a copy of
+    ``existing`` (the cross-template half). ``None`` label = axis unavailable on
+    this frame; its rows then keep their ordinary empty policy."""
+    merged = {key: dict(value) for key, value in existing.items()}
+    if label is None:
+        return merged
+    grouped = (
+        frame.with_columns(label.alias("_axis"))
+        .group_by(_POST_CRM_CLASS_COL, "_axis")
+        .agg(pl.col(_UNFUNDED_COL).sum().alias("inflow"))
+    )
+    for row in grouped.iter_rows(named=True):
+        _accumulate_split(merged, row[_POST_CRM_CLASS_COL], row["_axis"], float(row["inflow"]))
+    return merged
+
+
+def _accumulate_split(
+    split: dict[str, dict[str, float]], exposure_class: str, axis: str, amount: float
+) -> None:
+    """Add one destination-class/axis amount under this template's sheet key."""
+    per_class = split.setdefault(_sheet_key(exposure_class), {})
+    per_class[axis] = per_class.get(axis, 0.0) + amount
 
 
 def _accumulate(merged: dict[str, float], exposure_class: str, amount: float) -> None:
     """Add one destination-class amount under this template's sheet key."""
-    key = (
-        ExposureClass.CORPORATE.value
-        if exposure_class == ExposureClass.SPECIALISED_LENDING.value
-        else exposure_class
-    )
+    key = _sheet_key(exposure_class)
     merged[key] = merged.get(key, 0.0) + amount
 
 
-def _inflow_rows(row_terms: dict[str, _Terms | None], bands: dict[str, float]) -> frozenset[str]:
-    """Band rows carrying a NON-ZERO inflow on this sheet.
+def _sheet_key(exposure_class: str) -> str:
+    """A raw guarantor class as this template's sheet key — the Art. 112 Table A2
+    merge the sheet axis applies (SL is a corporate sub-type under SA), so an
+    inflow into an SL guarantor cannot key a sheet C 07.00 does not have."""
+    if exposure_class == ExposureClass.SPECIALISED_LENDING.value:
+        return ExposureClass.CORPORATE.value
+    return exposure_class
+
+
+def _inflow_rows(
+    row_terms: dict[str, _Terms | None], sides: dict[str, float], bands: dict[str, float]
+) -> frozenset[str]:
+    """Split rows carrying a NON-ZERO inflow on this sheet.
 
     ``_null_empty_rows`` renders a row all-null when its own subset is empty,
-    which would delete the banded inflow on exactly the sheets that need it most —
+    which would delete the split inflow on exactly the sheets that need it most —
     an inflow-only destination class has no native rows at all. Exempting them is
-    what makes the row-0010 decomposition foot there."""
-    if not bands:
-        return frozenset()
-    return frozenset(
-        ref
-        for ref, terms in row_terms.items()
-        if terms is not None
-        and len(terms) == 1
-        and terms[0][0] == "c07_rw_band"
-        and bands.get(str(terms[0][1]))
-    )
+    what makes the row-0010 decompositions foot there. A row qualifies by its own
+    single membership term, the same way ``_inflow_key_for`` recognises it, so the
+    regime-specific band axis needs no hardcoded ref ladder."""
+    keep: set[str] = set()
+    for ref, terms in row_terms.items():
+        if terms is None or len(terms) != 1:
+            continue
+        column, value = terms[0]
+        split = bands if column == "c07_rw_band" else sides if column == "c07_bs" else None
+        if split is not None and split.get(str(value)):
+            keep.add(ref)
+    return frozenset(keep)
 
 
 def _row_terms(framework: str, cols: set[str]) -> dict[str, _Terms | None]:
@@ -1181,17 +1405,23 @@ def _build_spec(
 def _inflow_key_for(ref: str, terms: _Terms) -> str | None:
     """Which ``ReportingContext`` inflow component this row's col 0100 takes.
 
-    The Total row takes the whole inflow; a RISK-WEIGHT BAND row takes the share
-    of it reported at that band. Band rows are recognised by their own membership
-    terms — a lone ``c07_rw_band`` equals-term — rather than by a hardcoded ref
-    ladder, so the regime-specific axis (Basel 3.1 adds thirteen sub-bands) and
-    the two-term memo rows 0300/0320 (defaulted AND banded, which are "of which"
-    memos and NOT part of the row-0010 decomposition) both fall out correctly.
+    The Total row takes the whole inflow; a BALANCE-SHEET row (0070/0080) and a
+    RISK-WEIGHT BAND row each take the share of it reported on their side / at
+    their band. Both are recognised by their own single membership term rather
+    than by a hardcoded ref ladder, so the regime-specific band axis (Basel 3.1
+    adds thirteen sub-bands) and the two-term memo rows 0300/0320 (defaulted AND
+    banded, which are "of which" memos and NOT part of the row-0010
+    decomposition) both fall out correctly.
     """
     if ref == "0010":
         return "substitution_inflow"
-    if len(terms) == 1 and terms[0][0] == "c07_rw_band":
-        return f"{SUBSTITUTION_INFLOW_RW_PREFIX}{terms[0][1]}"
+    if len(terms) != 1:
+        return None
+    column, value = terms[0]
+    if column == "c07_rw_band":
+        return f"{SUBSTITUTION_INFLOW_RW_PREFIX}{value}"
+    if column == "c07_bs":
+        return "substitution_inflow_off_bs" if value == _OFF_BS else "substitution_inflow_on_bs"
     return None
 
 
@@ -1205,10 +1435,19 @@ def _row_cells(  # noqa: PLR0913 - the full 24-column surface of one row
     is_b31: bool,
     inflow_key: str | None,
 ) -> dict[str, CellSpec]:
-    member = RowPredicate(equals=terms)
+    # The two-basis split (module docstring): cols 0010-0150 read the obligor's
+    # own book, cols 0160-0235 read the post-substitution population. Every
+    # predicate carries its basis flag, INCLUDING the total row's (whose ``terms``
+    # are empty) — an unflagged predicate would silently sum both populations.
+    origin_terms: _Terms = ((_BASIS_ORIGIN_COL, True), *terms)
+    post_terms: _Terms = ((_BASIS_POST_COL, True), *terms)
+    member = RowPredicate(equals=origin_terms)
+    post_member = RowPredicate(equals=post_terms)
 
     def narrowed(*extra: tuple[str, str | bool]) -> RowPredicate:
-        return RowPredicate(equals=(*terms, *extra))
+        """A further-narrowed POST-basis predicate — every caller (cols
+        0210/0211/0230/0235) is an exposure-value or RWEA breakdown."""
+        return RowPredicate(equals=(*post_terms, *extra))
 
     cells: dict[str, CellSpec] = {
         "0010": CellSpec(
@@ -1250,7 +1489,13 @@ def _row_cells(  # noqa: PLR0913 - the full 24-column surface of one row
             else CellSpec(Formula(refs=(), fn=_const(None)))
         ),
         "0150": CellSpec(Formula(refs=("0110", "0130"), fn=_fully_adjusted)),
-        "0200": CellSpec(Sum(ead_col), predicate=member),
+        # Col 0200 onwards are POST-basis. Annex II defines col 0200 as the
+        # "exposure value after taking into account value adjustments, ALL CREDIT
+        # RISK MITIGANTS and conversion factors that is to be assigned to risk
+        # weights in accordance with Article 113" — Art. 235 substitution is a
+        # credit risk mitigant, so the covered part's exposure value and RWEA
+        # follow its col 0090/0100 flow onto the protection provider's sheet.
+        "0200": CellSpec(Sum(ead_col), predicate=post_member),
         # Annex II col 0200: "Exposure values for CCR business shall be the same
         # as reported in column 0210" — so 0210 is the row's exposure value
         # narrowed to its CCR rows, and 0211 narrows further by excluding the
@@ -1265,7 +1510,7 @@ def _row_cells(  # noqa: PLR0913 - the full 24-column surface of one row
             if {"risk_type", "cp_entity_type"} <= cols
             else CellSpec(Formula(refs=(), fn=_const(None)))
         ),
-        "0220": CellSpec(Sum(rwa_col), predicate=member),
+        "0220": CellSpec(Sum(rwa_col), predicate=post_member),
         "0240": CellSpec(Formula(refs=(), fn=_const(None))),
     }
     # Col 0100 lands on the Total row AND on the risk-weight band row matching the
@@ -1281,13 +1526,16 @@ def _row_cells(  # noqa: PLR0913 - the full 24-column surface of one row
         cells["0040"] = CellSpec(Formula(refs=("0010", "0030", "0035"), fn=_net_of_adjustments))
     else:
         cells["0040"] = CellSpec(Formula(refs=("0010", "0030"), fn=_net_of_adjustments))
-        # CRR supporting-factor columns (Art. 501/501a).
+        # CRR supporting-factor columns (Art. 501/501a) — POST basis with col
+        # 0220, which they have to foot against (0215 + 0216 + 0217 = 0220).
         cells["0215"] = CellSpec(
-            Sum("rwa_pre_factor" if "rwa_pre_factor" in cols else rwa_col), predicate=member
+            Sum("rwa_pre_factor" if "rwa_pre_factor" in cols else rwa_col), predicate=post_member
         )
-        cells["0216"] = _sf_adjustment_cell(terms, cols, "sme_supporting_factor_applied", "is_sme")
+        cells["0216"] = _sf_adjustment_cell(
+            post_terms, cols, "sme_supporting_factor_applied", "is_sme"
+        )
         cells["0217"] = _sf_adjustment_cell(
-            terms, cols, "infrastructure_factor_applied", "is_infrastructure"
+            post_terms, cols, "infrastructure_factor_applied", "is_infrastructure"
         )
 
     # CCF buckets (0160-0190): the PRE-conversion off-balance-sheet gross per
@@ -1304,10 +1552,16 @@ def _row_cells(  # noqa: PLR0913 - the full 24-column surface of one row
     # empty_cell="null": a row with no off-balance-sheet item in the bucket
     # reports blank, not 0.0 — the template's recorded empty-subset contract
     # (the retired _null_row semantics these cells replaced).
+    #
+    # POST basis, with col 0200 rather than with the gross col 0010 they read the
+    # carrier of: they break down col 0150, which is ALREADY post-substitution
+    # (it nets the col 0090 outflow and adds the col 0100 inflow), and
+    # ``v0308_m`` / ``boe_b0471`` test col 0200 AGAINST them. Leaving them on the
+    # origin basis while col 0200 moved would break that identity the other way.
     ccf_refs = [ref for ref in _CCF_REFS if ref in column_refs]
     for ref in ccf_refs:
         if pick(cols, *_CCF_CARRIERS) is not None and _OFF_BS_GROSS_COL in cols:
-            bucket_terms: _Terms = (*terms, ("c07_ccf_bucket", ref))
+            bucket_terms: _Terms = (*post_terms, ("c07_ccf_bucket", ref))
             if _has_bs_side(cols):
                 bucket_terms = (*bucket_terms, ("c07_bs", "off"))
             cells[ref] = CellSpec(
@@ -1362,7 +1616,17 @@ def _null_empty_rows(
 ) -> pl.DataFrame:
     """Render inert rows and rows with EMPTY subsets all-null — the retired
     ``_null_row`` contract (the COREP zero policy applies only to populated
-    rows' unbound cells)."""
+    rows' unbound cells).
+
+    THE COUNT IS OVER THE UNION OF BOTH BASES, deliberately: ``class_df`` is the
+    sheet frame and each row's terms are the BASIS-FREE ones, so a row is nulled
+    only when it is empty on the origin basis AND on the post basis. Keying it on
+    the origin basis alone would null out the very cells the two-basis split
+    exists to publish — an inflow-only sheet's band row has no origin-basis leg
+    at all, yet must report the exposure value and RWEA that arrived on it. The
+    converse costs a fully-outflowed row a null it used to get: it now reports
+    real zeros in cols 0200/0220 against its real gross in col 0010, which is
+    what ``v8726_m`` / ``boe_b0556`` ({c0200} <= {c0150}) ask of it."""
     constrained = {
         ref: RowPredicate(equals=terms)
         for ref, terms in row_terms.items()

--- a/src/rwa_calc/reporting/corep/c07.py
+++ b/src/rwa_calc/reporting/corep/c07.py
@@ -275,10 +275,12 @@ _FCSM_CARRIER: str = "fcsm_collateral_value"
 # measured on — see ``_protection_exprs``.
 _UNFUNDED_COL: str = "c07_prot_unfunded"
 # The CRM decline flag — CONDITIONAL on the edge, so every read is presence-tolerant.
-# A DECLINED guarantee (it would have raised capital, CRR Art. 213) produces no
-# substitution effect, so it must not appear in the Annex II block headed "CRM
-# TECHNIQUES WITH SUBSTITUTION EFFECTS ON THE EXPOSURE". Gating the unfunded
-# magnitude gates the col 0100 INFLOW too, since that binds the same carrier.
+# A DECLINED guarantee (it would have raised capital, which CRR Art. 193(1)
+# forbids) produces no substitution effect, so it must not appear in the Annex II
+# block headed "CRM TECHNIQUES WITH SUBSTITUTION EFFECTS ON THE EXPOSURE". Gating
+# the unfunded magnitude gates the col 0100 INFLOW too, since that binds the same
+# carrier. Basis and the recorded elections (decline vs apply-and-cap; the strict
+# ``<``): ``engine/sa/rw_adjustments.py::apply_guarantee_substitution``.
 _BENEFICIAL_COL: str = "is_guarantee_beneficial"
 
 # The guarantor's exposure class (the col 0100 destination key) and the origin
@@ -950,9 +952,10 @@ def _protection_exprs(cols: set[str]) -> list[pl.Expr]:
 
     A DECLINED GUARANTEE CONTRIBUTES NOTHING TO COLS 0050/0060. The block heading
     is "CRM TECHNIQUES **WITH SUBSTITUTION EFFECTS ON THE EXPOSURE**", and a
-    guarantee the calculator declined has none: recognition is permissive
-    (Art. 213), so where the guarantor's weight does not beat the obligor's the
-    engine leaves the RWA on the borrower basis and ``is_guarantee_beneficial`` is
+    guarantee the calculator declined has none: Art. 193(1) bars a guarantee from
+    raising the RWEA and Art. 193(3) leaves amending the calculation an election,
+    so where the guarantor's weight does not beat the obligor's the engine leaves
+    the RWA on the borrower basis and ``is_guarantee_beneficial`` is
     false. Reporting it here booked a col 0090 outflow that no exposure ever left
     and — because the col 0100 inflow binds the same ``_UNFUNDED_COL`` — a
     matching phantom inflow onto the guarantor's sheet, banded at the BORROWER's
@@ -1135,8 +1138,9 @@ def _add_sa_origin_inflows(inflows: _Inflows, sa_df: pl.DataFrame) -> _Inflows:
     guarantee the calculator declined, so the ``> 0`` filter below drops it. It is
     Art. 235 substitution ACTUALLY BEING APPLIED that entitles the covered part to
     the guarantor's sheet; a positive covered carrier only says protection was
-    attached. Recognition is permissive (Art. 213), so the SA calculator declines
-    a guarantee whose guarantor weight does not beat the obligor's
+    attached. Art. 193(1) bars a guarantee from raising the RWEA and Art. 193(3)
+    makes amending the calculation an election, so the SA calculator DECLINES a
+    guarantee whose guarantor weight does not beat the obligor's
     (``is_guarantee_beneficial=False``) and leaves the RWA on the borrower basis.
     Booking that as an inflow moved the covered part onto the guarantor's sheet
     banded — via ``c07_rw_band`` — at the BORROWER's own risk weight, reproduced

--- a/src/rwa_calc/reporting/corep/c07.py
+++ b/src/rwa_calc/reporting/corep/c07.py
@@ -156,15 +156,23 @@ from rwa_calc.reporting.cellspec import (
     Sum,
     TemplateSpec,
     execute,
-    matched_counts,
 )
 from rwa_calc.reporting.corep.crm_substitution import irb_origin_inflows
+from rwa_calc.reporting.corep.postpass import negate_deduction_cols, null_empty_rows
 from rwa_calc.reporting.corep.templates import (
     get_c07_columns,
     get_sa_risk_weight_bands,
     get_sa_row_sections,
 )
-from rwa_calc.reporting.kernel import pick
+from rwa_calc.reporting.kernel import (
+    TwoBasis,
+    class_keys,
+    pick,
+    population_flags,
+    sheet_axis,
+    sheet_frame,
+)
+from rwa_calc.reporting.kernel.bases import ORIGIN_APPROACH_SOURCE
 from rwa_calc.reporting.metadata import SUBSTITUTION_INFLOW_RW_PREFIX, ReportingContext
 from rwa_calc.reporting.plans import SheetPlan
 
@@ -180,33 +188,14 @@ _NEGATIVE_COLS: frozenset[str] = frozenset(
     {"0030", "0035", "0050", "0060", "0070", "0080", "0090", "0130", "0140", "0216", "0217"}
 )
 
-# The two-basis discriminators (see the module docstring). Four derived columns
-# carry the split; nothing about it reaches ``RowPredicate``, whose ``classes`` /
-# ``classes_origin`` fields are per-CELL keys against the sealed ledger, while a
-# basis here is a per-SHEET question ("is this leg on THIS sheet, on THIS basis?")
-# answered against a class that varies sheet by sheet. Expressing it as derived
-# booleans keeps ONE spec shared across every sheet, keeps the population
-# definition in ``c07_population`` alone, and — decisively — lets the post basis
-# DEGRADE to the origin basis on a frame that seals no post-substitution columns.
-# A strict ``RowPredicate(classes=...)`` term cannot degrade: it would either
-# raise on the missing column or (as a tolerant ``equals``) silently zero the
-# exposure-value and RWEA columns of every synthetic unit frame.
-#
-# Membership of each APPROACH population (both include the CCR limb):
-_POP_ORIGIN_COL: str = "c07_pop_origin"
-_POP_POST_COL: str = "c07_pop_post"
-# The sheet keys, Art. 112 Table A2 merge applied (SL -> corporate):
-_CLASS_ORIGIN_COL: str = "c07_class_origin"
-_CLASS_POST_COL: str = "c07_class_post"
-# Per-SHEET: population membership AND that basis' class == this sheet's class.
-_BASIS_ORIGIN_COL: str = "c07_basis_origin"
-_BASIS_POST_COL: str = "c07_basis_post"
-# The sealed post-substitution twins the post basis reads (``reporting_class`` =
-# the guarantor's class on a beneficially-guaranteed leg, ``reporting_approach`` =
-# the approach that leg is treated under). Both absent -> post degrades to origin.
-_POST_CLASS_SOURCE: str = "reporting_class"
-_POST_APPROACH_SOURCE: str = "reporting_approach"
-_ORIGIN_APPROACH_SOURCE: str = "reporting_approach_origin"
+# The two-basis discriminators (see the module docstring). The mechanism —
+# derived boolean columns rather than ``RowPredicate`` fields, and why that is
+# the only shape the post basis can DEGRADE in — lives in
+# ``reporting/kernel/bases.py``, shared with C 08.01.
+_BASIS: TwoBasis = TwoBasis("c07")
+_BASIS_ORIGIN_COL: str = _BASIS.basis_origin
+_BASIS_POST_COL: str = _BASIS.basis_post
+_ORIGIN_APPROACH_SOURCE: str = ORIGIN_APPROACH_SOURCE
 
 # The ``c07_bs`` labels rows 0070 / 0080 filter on, and the keys the col 0100
 # inflow is split by when it lands on them.
@@ -442,10 +431,8 @@ def c07_plans(
     # corporate sub-type under SA). The post key degrades to the origin key on a
     # frame that seals no ``reporting_class``, which is what makes the two-basis
     # split number-neutral wherever nothing substitutes.
-    post_class_col = _POST_CLASS_SOURCE if _POST_CLASS_SOURCE in sa_df.columns else ec_col
     sa_df = sa_df.with_columns(
-        _merge_specialised_lending(ec_col).alias(_CLASS_ORIGIN_COL),
-        _merge_specialised_lending(post_class_col).alias(_CLASS_POST_COL),
+        class_keys(_BASIS, set(sa_df.columns), ec_col, key=_merge_specialised_lending)
     )
     data_cols = set(sa_df.columns)
     sa_df = _prepare(sa_df, data_cols, framework)
@@ -468,17 +455,13 @@ def c07_plans(
     # without it a leg whose inflow the block cap shed to zero would drop its
     # exposure value and RWEA out of the template silently. An inflow-only sheet
     # keeps its constraint-free total row 0010 and reports 0110 = 0100.
-    axis = (
-        set(_sheet_keys(sa_df, _POP_ORIGIN_COL, _CLASS_ORIGIN_COL))
-        | set(_sheet_keys(sa_df, _POP_POST_COL, _CLASS_POST_COL))
-        | set(inflows.total)
-    )
+    axis = sheet_axis(_BASIS, sa_df) | set(inflows.total)
     for ec in sorted(axis):
         sides = inflows.by_side.get(ec, {})
         bands = inflows.by_rw_band.get(ec, {})
         plans[ec] = SheetPlan(
             spec=spec,
-            frame=_sheet_frame(sa_df, ec),
+            frame=sheet_frame(_BASIS, sa_df, ec),
             ctx=ReportingContext(
                 substitution_inflow=inflows.total.get(ec, 0.0),
                 substitution_inflow_on_bs=sides.get(_ON_BS, 0.0),
@@ -504,28 +487,6 @@ def _merge_specialised_lending(class_col: str) -> pl.Expr:
     )
 
 
-def _sheet_keys(data: pl.DataFrame, population_col: str, class_col: str) -> list[str]:
-    """The distinct sheet keys one basis contributes to the sheet axis."""
-    return data.filter(pl.col(population_col))[class_col].drop_nulls().unique().to_list()
-
-
-def _sheet_frame(data: pl.DataFrame, exposure_class: str) -> pl.DataFrame:
-    """One sheet's frame: the legs on it under EITHER basis, each tagged with
-    which. The union is what lets one cell read the obligor's own book (cols
-    0010-0150) while its neighbour reads the post-substitution population (cols
-    0160-0235) — see the module docstring. A leg on neither basis is dropped, so
-    the frame is never wider than the sheet."""
-    tagged = data.with_columns(
-        (pl.col(_POP_ORIGIN_COL) & (pl.col(_CLASS_ORIGIN_COL) == exposure_class))
-        .fill_null(value=False)
-        .alias(_BASIS_ORIGIN_COL),
-        (pl.col(_POP_POST_COL) & (pl.col(_CLASS_POST_COL) == exposure_class))
-        .fill_null(value=False)
-        .alias(_BASIS_POST_COL),
-    )
-    return tagged.filter(pl.col(_BASIS_ORIGIN_COL) | pl.col(_BASIS_POST_COL))
-
-
 @cites("PS1/26, paragraph 1.3")
 def generate_c07(
     results: pl.LazyFrame,
@@ -537,8 +498,14 @@ def generate_c07(
     result: dict[str, pl.DataFrame] = {}
     for ec, plan in c07_plans(results, cols, framework, errors).items():
         frame = execute(plan.spec, plan.frame, plan.ctx)
-        frame = _null_empty_rows(frame, plan.frame, plan.row_terms, plan.inflow_rows)
-        result[ec] = _negate_deduction_cols(frame)
+        # ``row_terms`` -> predicates: ``None`` is an inert row, ``()`` the
+        # constraint-free Total row (never nulled), anything else constrained.
+        preds = {
+            ref: None if terms is None else RowPredicate(equals=terms)
+            for ref, terms in plan.row_terms.items()
+        }
+        frame = null_empty_rows(frame, plan.frame, preds, plan.inflow_rows)
+        result[ec] = negate_deduction_cols(frame, _NEGATIVE_COLS)
     return result
 
 
@@ -575,44 +542,21 @@ def c07_population(
     exposures identical in every column would collapse into one. Harmless where
     it can fire; do not promote this fallback to the ledger path.
     """
-    tagged = results.with_columns(_population_exprs(cols))
+    ccr = (
+        pl.col("risk_type").is_in(_CCR_RISK_TYPES).fill_null(value=False)
+        if "risk_type" in cols
+        else None
+    )
+    tagged = results.with_columns(population_flags(_BASIS, cols, ("standardised",), admit=ccr))
     admitted = (
-        tagged.filter(pl.col(_POP_ORIGIN_COL) | pl.col(_POP_POST_COL))
+        tagged.filter(pl.col(_BASIS.pop_origin) | pl.col(_BASIS.pop_post))
         if both_bases
-        else tagged.filter(pl.col(_POP_ORIGIN_COL)).drop(_POP_ORIGIN_COL, _POP_POST_COL)
+        else tagged.filter(pl.col(_BASIS.pop_origin)).drop(_BASIS.pop_origin, _BASIS.pop_post)
     )
     return admitted.unique(
         subset=["exposure_reference"] if "exposure_reference" in cols else None,
         keep="first",
     )
-
-
-def _population_exprs(cols: set[str]) -> list[pl.Expr]:
-    """The two population-membership flags (see :func:`c07_population`).
-
-    ``_is_standardised`` mirrors ``filter_by_approach``'s missing-column rule —
-    no approach discriminator means an EMPTY population, never a silent
-    pass-through. The post limb falls back to the ORIGIN approach when no
-    post-substitution approach is sealed, so a synthetic frame reports the same
-    figures under both bases instead of zeroing its exposure-value columns.
-    """
-    ccr = (
-        pl.col("risk_type").is_in(_CCR_RISK_TYPES).fill_null(value=False)
-        if "risk_type" in cols
-        else pl.lit(value=False)
-    )
-    origin = _is_standardised(cols, _ORIGIN_APPROACH_SOURCE)
-    post = (
-        _is_standardised(cols, _POST_APPROACH_SOURCE) if _POST_APPROACH_SOURCE in cols else origin
-    )
-    return [(origin | ccr).alias(_POP_ORIGIN_COL), (post | ccr).alias(_POP_POST_COL)]
-
-
-def _is_standardised(cols: set[str], approach_col: str) -> pl.Expr:
-    """Is this leg standardised under ``approach_col``? (Absent column = no.)"""
-    if approach_col not in cols:
-        return pl.lit(value=False)
-    return (pl.col(approach_col) == "standardised").fill_null(value=False)
 
 
 def _has_bs_side(cols: set[str]) -> bool:
@@ -1157,7 +1101,7 @@ def _add_sa_origin_inflows(inflows: _Inflows, sa_df: pl.DataFrame) -> _Inflows:
     # and not the origin one), so they arrive from ``irb_origin_inflows`` already
     # measured on the IRB cap — counting them again would create money.
     frame = sa_df.filter(
-        pl.col(_POP_ORIGIN_COL)
+        pl.col(_BASIS.pop_origin)
         & (pl.col(_UNFUNDED_COL) > 0)
         & pl.col(_POST_CRM_CLASS_COL).is_not_null()
     )
@@ -1610,65 +1554,3 @@ def _sf_adjustment_cell(terms: _Terms, cols: set[str], dedicated: str, flag_col:
             ),
         )
     return CellSpec(Formula(refs=(), fn=_const(None)))
-
-
-def _null_empty_rows(
-    frame: pl.DataFrame,
-    class_df: pl.DataFrame,
-    row_terms: dict[str, _Terms | None],
-    keep: frozenset[str] = frozenset(),
-) -> pl.DataFrame:
-    """Render inert rows and rows with EMPTY subsets all-null — the retired
-    ``_null_row`` contract (the COREP zero policy applies only to populated
-    rows' unbound cells).
-
-    THE COUNT IS OVER THE UNION OF BOTH BASES, deliberately: ``class_df`` is the
-    sheet frame and each row's terms are the BASIS-FREE ones, so a row is nulled
-    only when it is empty on the origin basis AND on the post basis. Keying it on
-    the origin basis alone would null out the very cells the two-basis split
-    exists to publish — an inflow-only sheet's band row has no origin-basis leg
-    at all, yet must report the exposure value and RWEA that arrived on it. The
-    converse costs a fully-outflowed row a null it used to get: it now reports
-    real zeros in cols 0200/0220 against its real gross in col 0010, which is
-    what ``v8726_m`` / ``boe_b0556`` ({c0200} <= {c0150}) ask of it."""
-    constrained = {
-        ref: RowPredicate(equals=terms)
-        for ref, terms in row_terms.items()
-        if terms is not None and len(terms) > 0
-    }
-    counts = matched_counts(class_df, constrained)
-    null_refs = [
-        ref
-        for ref, terms in row_terms.items()
-        if ref not in keep and (terms is None or (len(terms) > 0 and counts[ref] == 0))
-    ]
-    if not null_refs:
-        return frame
-    value_cols = [col for col in frame.columns if col not in ("row_ref", "row_name")]
-    return frame.with_columns(
-        pl.when(pl.col("row_ref").is_in(null_refs))
-        .then(pl.lit(None, dtype=pl.Float64))
-        .otherwise(pl.col(col))
-        .alias(col)
-        for col in value_cols
-    )
-
-
-def _negate_deduction_cols(frame: pl.DataFrame) -> pl.DataFrame:
-    """COREP Annex II §1.3: emit "(-)"-labelled deduction columns as negative
-    figures (after the waterfalls consumed positive magnitudes); a zero
-    deduction is normalised to ``+0.0`` and null stays null."""
-    targets = [col for col in frame.columns if col in _NEGATIVE_COLS]
-    if not targets:
-        return frame
-    return frame.with_columns(_negate_expr(col) for col in targets)
-
-
-def _negate_expr(col: str) -> pl.Expr:
-    """Negate a "(-)"-labelled deduction column, normalising a zero to ``+0.0``.
-
-    Plain ``-pl.col(col)`` flips the IEEE sign bit, so a ``0.0`` cell would
-    serialise as ``-0.0`` (``+ 0.0`` does NOT clear it in Polars); the explicit
-    zero branch keeps a zero deduction as ``+0.0``. Null stays null. Identical
-    expression to C 08.01/02's ``_negate`` pass."""
-    return pl.when(pl.col(col) == 0.0).then(pl.lit(0.0)).otherwise(-pl.col(col)).alias(col)

--- a/src/rwa_calc/reporting/corep/c08.py
+++ b/src/rwa_calc/reporting/corep/c08.py
@@ -17,6 +17,85 @@ Cell semantics (recorded decisions, this slice):
   ``reporting_approach_origin`` (F-IRB / A-IRB / slotting); C 08.02/03/04/05
   exclude slotting per template. C 08.07 alone keeps the RAW class key
   (Art. 147 origination taxonomy over the FULL population).
+- C 08.01 ALONE IS TWO POPULATIONS PER SHEET — the recorded two-basis decision,
+  C 07.00's (``corep/c07.py``) on the IRB surface. A sheet's cells split by
+  BASIS, the flags derived by ``kernel/bases.py``:
+    * ORIGIN basis (``c08_basis_origin``) — the obligor's own book. Cols
+      0010-0104: the gross exposure, the LFSE memo, the on-balance-sheet
+      netting, the CRM substitution block and the pre-conversion waterfall. A
+      guaranteed leg belongs here on the OBLIGOR's sheet, because that is where
+      its covered part is "deducted from the obligor's exposure class" (col
+      0070). Also the CRM-in-LGD block (0150-0220) and the parameter, EL,
+      provisions and obligor-count columns — see below.
+    * POST basis (``c08_basis_post``) — after substitution. Cols 0110-0140
+      (exposure value and its of-which breakdowns) and 0251-0276 (RWEA, its
+      adjustments and the output floor's SA-equivalent twins). PS1/26 Annex II
+      col 0110: "The exposure values determined in accordance with Article 166A
+      to 166D ... **CRM techniques affecting the exposure value shall be taken
+      into account**." Art. 235/236 substitution is such a technique, so the
+      covered part's exposure value and RWEA must leave the obligor's sheet and
+      land on the protection provider's, exactly as cols 0070/0080 already move
+      it pre-conversion.
+  Binding cols 0110/0260 to the ORIGIN population was a build shortfall, not a
+  decision: a 10,000,000 slotting loan fully guaranteed by a CQS1 corporate
+  reported ``0090 = 0`` (the whole exposure had left) while simultaneously
+  reporting ``0110 = 10,000,000`` and ``0260 = 2,000,000`` as still there — and
+  since the C 07.00 fix put the same money on the guarantor's SA sheet, the
+  estate DOUBLE-COUNTED it across two templates.
+  UNDER CRR THE COL 0110 CLAUSE IS ABSENT (PS1/26 added it), and the basis rests
+  instead on two things Annex II states positively: col 0110 is the post-CCF
+  continuation of col 0090 — itself "after taking into account outflows and
+  inflows due to CRM techniques with substitution effects" — through
+  Art. 166(8)-(10); and cols 0300/0310 carve THEMSELVES out of the redistribution
+  ("**without taking into account the effect of CRM techniques (in particular
+  redistribution effects)**"; "presented in the exposure classes relevant for the
+  exposures to the **original obligor**"), which only means something if the
+  surrounding exposure-value and RWEA columns do take it into account.
+  THE PARAMETER AVERAGES STAY ON THE ORIGIN BASIS AND THAT IS DELIBERATE (cols
+  0010 PD, 0230/0240 LGD, 0250 maturity, plus the EL memos 0280-0282 and
+  provisions 0290). Annex II weights those averages BY col 0110, which is an
+  argument to move them; against it, the sealed ledger carries the OBLIGOR's
+  ``pd_floored`` / ``lgd_floored`` / ``irb_maturity_m`` on every leg and NEVER
+  the guarantor's (``engine/irb/guarantee.py`` swaps and restores inside a local
+  window; under CRR the guarantor is SA-risk-weight-substituted and has no IRB
+  parameters at all), so a post-basis average would publish the obligor's PD and
+  LGD on the guarantor's sheet — the exact misattribution R12's surviving
+  reasoning forbids for the grade axis. Sealing the guarantor's parameters per leg
+  is the enhancement that would allow the move. Cost, on the record: a
+  fully-outflowed sheet reports a real LGD and maturity against ``0110 = 0``.
+- C 08.02 MOVES WITH C 08.01, MEASURED, and the seam is only C 08.03-06. The
+  premise this was first built to — that ``{OF08.01 r0070} = sum({OF08.02})`` is
+  stated over cols 0080/0090 alone (``boe_b0752_8`` / ``_9``, ``boe_b0814_07`` /
+  ``_08``) — is FALSE: those are two members of a family stated once per SHARED
+  COLUMN, all live ERROR, and it reaches every column this split moves
+  (``boe_b0752_10`` c0110, ``_11`` c0140, ``_25`` c0251, ``_26``-``_28``
+  c0252-0254, ``_29`` c0260, ``_30`` c0265, ``_31`` c0270, plus the
+  ``boe_b0814_09`` / ``_18`` twins). Leaving C 08.02 behind broke five of them on
+  the CRM-substitution portfolio the moment C 08.01 moved — measured, not
+  predicted: 6,000,000 vs 4,000,000 on c0110 and 4,283,321 vs 2,855,547 on
+  c0251/c0260, across three sheets.
+  WHERE AN ARRIVED LEG LANDS ON C 08.02 IS R12'S DECISION, EXTENDED FROM THE
+  SCALAR TO THE FRAME: the "Unassigned" residual row, via the derived
+  ``c08_02_key_post`` (``_c08_02_keyed``). R12's reasoning is untouched — the
+  ledger carries the OBLIGOR's grade, never the guarantor's — so an arrived leg's
+  exposure value and RWEA may not assert a grade in this sheet's scale either,
+  and the row already meaning "an exposure whose grade we do not carry" is where
+  the col 0080 scalar and the legs that make it up both belong.
+- C 08.03-06 STAY SINGLE-BASIS. The seam is the ``both_bases`` default on
+  ``_irb_population`` / the ``basis`` default on ``_value_cells``, so widening
+  C 08.01/02 did not silently widen the four templates sharing the population.
+- SURFACED BY THIS CHANGE AND NOT FIXED HERE (measured on the CRM-substitution
+  portfolio, both regimes): the dependents that tie to the moved columns and are
+  still keyed on the origin class — C 09.02's geographical cols 0105/0110
+  (``boe_b0277`` / ``_0283`` / ``_0292``, EBA ``v0421_m`` / ``v0423_m`` /
+  ``v0426_m`` / ``v0428_m`` / ``v0441_m`` / ``v0443_m`` / ``v0466_m`` /
+  ``v0468_m``) and OF 02.00's per-class IRB RWEA row 0271 (``boe_b0616``). The
+  C 09.02 rebinding is NOT mechanical: it sheets on the obligor's
+  ``cp_country_code`` and the ledger seals no guarantor country, so keying the
+  class post-substitution while the country stays the obligor's would close all
+  eleven rules — every one on the all-geographies TOTAL — while silently
+  mis-allocating the per-country breakdown. Same open question as C 09.01's
+  (recorded on the C 07.00 change), and it needs the same answer.
 - SLOTTING IS OUT OF SCOPE OF C 08.02 (recorded, evidenced): PS1/26 Annex II
   §3.3.4 paragraph 77A — "Institutions shall complete this template in respect
   of exposures subject to the AIRB approach and the FIRB approach, but not in
@@ -120,16 +199,16 @@ Cell semantics (recorded decisions, this slice):
   substitution inflow, so the Total-row col 0080 (``SideContext``) drills to its
   real value (the C 07.00 pattern); C 08.02's per-grade 0080 is a constant 0.0
   (R12) and its String label col 0005 is skipped by the tie-out value-column sweep.
-  Ratchet note (R23/R24): each extraction bumped ``max_reporting_module_loc``
-  (2016 -> post-R23 -> 2320 post-R24, zero slack) — the mechanical additive
-  cost of exposing each template's cells/plans builders with their mandated
-  docstrings, no behaviour change. Unlike the c07/cr4/cr8/cr7a extractions this
-  module alone needs a bump per wave: it hosts SEVEN templates in one file.
-  R24 added the ``c08_03_plans`` / ``c08_05_plans`` / ``c08_06_plans`` builders
-  (and split ``_c08_03_cells`` / ``_c08_05_cells`` and the c08_06 row helpers
-  out of their generators). Splitting c08.py per-template is the honest
+  Ratchet note: R23/R24's lineage extractions each bumped
+  ``max_reporting_module_loc`` (2016 -> 2320) with zero slack left, because this
+  module alone hosts SEVEN templates. The two-basis change repaid that instead
+  of bumping again, by lifting the POST-EXECUTE PASSES this file shared with
+  C 07.00 / C 09.0x into ``corep/postpass.py`` (``null_empty_rows``,
+  ``negate_deduction_cols``, ``provisions_postfix``, ``c08_off_bs_pre_ccf``,
+  ``c08_after_all_crm``) and the two-basis discriminators into
+  ``kernel/bases.py``. Splitting c08.py per-TEMPLATE is still the honest
   long-term answer — recorded as a deferred follow-up (shared value surface,
-  its own risky item).
+  its own risky item); the pass extraction is one coherent slice of it.
 - The EL memo columns 0280 (pre post-model adjustment) and its B31 twin 0282
   (after post-model adjustments) coalesce PER LEG (R10a): they read the
   formula-IRB ``el_pre_adjustment`` / ``el_after_adjustment`` where non-null
@@ -263,7 +342,6 @@ from rwa_calc.reporting.cellspec import (
     TemplateSpec,
     WeightedAvg,
     execute,
-    matched_counts,
     subset_rows,
 )
 from rwa_calc.reporting.corep.crm_substitution import (
@@ -277,6 +355,13 @@ from rwa_calc.reporting.corep.crm_substitution import (
     waterfall_refs,
 )
 from rwa_calc.reporting.corep.pd_scale import banded_rows
+from rwa_calc.reporting.corep.postpass import (
+    c08_after_all_crm,
+    c08_off_bs_pre_ccf,
+    negate_deduction_cols,
+    null_empty_rows,
+    provisions_postfix,
+)
 from rwa_calc.reporting.corep.templates import (
     C08_04_ROWS,
     C08_06_CATEGORY_MAP,
@@ -292,9 +377,13 @@ from rwa_calc.reporting.corep.templates import (
     get_irb_row_sections,
 )
 from rwa_calc.reporting.kernel import (
+    TwoBasis,
     available_columns,
+    class_keys,
     pick,
-    safe_sum,
+    population_flags,
+    sheet_axis,
+    sheet_frame,
 )
 from rwa_calc.reporting.metadata import ReportingContext
 from rwa_calc.reporting.plans import SheetPlan
@@ -317,6 +406,13 @@ _NEGATIVE_COLS: frozenset[str] = frozenset(
 )
 
 _IRB_APPROACHES: tuple[str, ...] = ("foundation_irb", "advanced_irb", "slotting")
+
+# The C 08.01 two-basis discriminators (see the module docstring). The mechanism
+# — derived boolean columns rather than ``RowPredicate`` fields, and why that is
+# the only shape the post basis can DEGRADE in — lives in
+# ``reporting/kernel/bases.py``, shared with C 07.00. C 08.02-06 stay
+# single-basis: they read ``_irb_population``'s origin-only default.
+_BASIS: TwoBasis = TwoBasis("c08")
 
 # Which ``ReportingContext`` inflow component each C 08.01 row's col 0080 takes.
 # The Total row 0010 takes the whole inflow; rows 0020/0030 take its balance-sheet
@@ -423,12 +519,30 @@ def _c08_04_other_flow(cells: Mapping[str, float | None], prior_available: bool)
 # =============================================================================
 
 
-def _irb_population(results: pl.LazyFrame, cols: set[str]) -> pl.LazyFrame:
-    """The IRB book (retired _filter_by_irb_approach): F-IRB/A-IRB/slotting."""
-    approach_col = pick(cols, "reporting_approach_origin")
-    if approach_col is None:
-        return results.filter(pl.lit(value=False))
-    return results.filter(pl.col(approach_col).is_in(list(_IRB_APPROACHES)))
+def _irb_population(
+    results: pl.LazyFrame, cols: set[str], *, both_bases: bool = False
+) -> pl.LazyFrame:
+    """The IRB book (retired _filter_by_irb_approach): F-IRB/A-IRB/slotting.
+
+    ``both_bases`` selects WHICH IRB book. The default is the ORIGIN-approach one
+    — the obligor's own book, which is what C 08.02/03/04/05/06 read. C 08.01
+    takes the UNION of it and the POST-substitution book, tagged with
+    ``c08_pop_origin`` / ``c08_pop_post`` so each cell reads its own basis (see
+    the module docstring). A leg with no substitution is in both, which is why
+    the split is number-neutral on a book that never substitutes.
+
+    The post book is a SUBSET of the origin one here, unlike C 07.00's:
+    ``aggregator._post_crm_approach_expr`` maps an SA guarantor to the SA literal
+    and everything else to the obligor's own approach, so an IRB-origin leg can
+    only LEAVE the IRB population post-substitution (to an SA guarantor) and an
+    SA-origin leg can never enter it. No dedupe is needed, and the row-0070/0080
+    approach-partition terms — which key ``reporting_approach_origin`` — stay a
+    valid partition of the post population.
+    """
+    tagged = results.with_columns(population_flags(_BASIS, cols, _IRB_APPROACHES))
+    if both_bases:
+        return tagged.filter(pl.col(_BASIS.pop_origin) | pl.col(_BASIS.pop_post))
+    return tagged.filter(pl.col(_BASIS.pop_origin)).drop(_BASIS.pop_origin, _BASIS.pop_post)
 
 
 def _prepare(data: pl.DataFrame, cols: set[str]) -> pl.DataFrame:
@@ -601,12 +715,32 @@ def _value_cells(  # noqa: C901, PLR0915 - the full C 08.01/02 column surface
     *,
     inflow_key: str | None,
     netting_in_waterfall: bool,
+    basis: TwoBasis | None = None,
+    post_terms: _Terms | None = None,
 ) -> dict[str, CellSpec]:
-    member = RowPredicate(equals=terms)
+    # The two-basis split (module docstring). ``basis=None`` is the single-basis
+    # surface C 08.03-06 keep: both term tuples collapse to the caller's own, so
+    # every predicate is byte-identical to the pre-split one. Every basis-split
+    # predicate carries a flag, INCLUDING the Total row's (whose ``terms`` are
+    # empty) — an unflagged predicate would silently sum both populations.
+    # ``post_terms`` lets the post basis key a DIFFERENT row axis from the origin
+    # one: C 08.01 keys the same rows on both, C 08.02 routes an arrived leg to
+    # its "Unassigned" residual row rather than to a grade it does not carry.
+    base_post: _Terms = terms if post_terms is None else post_terms
+    origin: _Terms = terms if basis is None else ((basis.basis_origin, True), *terms)
+    post: _Terms = base_post if basis is None else ((basis.basis_post, True), *base_post)
+    member = RowPredicate(equals=origin)
+    post_member = RowPredicate(equals=post)
     refs_0090 = waterfall_refs(column_refs, netting=netting_in_waterfall)
 
     def narrowed(*extra: tuple[str, str | bool]) -> RowPredicate:
-        return RowPredicate(equals=(*terms, *extra))
+        """A further-narrowed ORIGIN-basis predicate (the substitution block)."""
+        return RowPredicate(equals=(*origin, *extra))
+
+    def narrowed_post(*extra: tuple[str, str | bool]) -> RowPredicate:
+        """A further-narrowed POST-basis predicate — every caller (cols
+        0120/0125/0265) is an exposure-value or RWEA breakdown."""
+        return RowPredicate(equals=(*post, *extra))
 
     lgd_col = pick(cols, "lgd_floored", "lgd_input")
     # The substitution block (0040/0050/0060) reads the Annex II-capped twins
@@ -623,7 +757,7 @@ def _value_cells(  # noqa: C901, PLR0915 - the full C 08.01/02 column surface
             SafeSum(("reporting_gross_on_bs", "reporting_gross_off_bs")), predicate=member
         ),
         "0030": _lfse_cell(
-            cols, lambda: SafeSum(("reporting_gross_on_bs", "reporting_gross_off_bs")), terms
+            cols, lambda: SafeSum(("reporting_gross_on_bs", "reporting_gross_off_bs")), origin
         ),
         "0035": CellSpec(Sum("on_bs_netting_amount"), predicate=member),
         "0040": (
@@ -674,14 +808,20 @@ def _value_cells(  # noqa: C901, PLR0915 - the full C 08.01/02 column surface
         # Formula cells and the executor forbids a formula referencing a formula.
         # The placeholder null is what an inert row keeps (the 0100 convention).
         "0104": CellSpec(Formula(refs=(), fn=_const(None))),
-        "0110": CellSpec(Sum(ead_col), predicate=member),
+        # Col 0110 onwards are POST-basis. PS1/26 Annex II defines col 0110 as
+        # "the exposure values determined in accordance with Article 166A to
+        # 166D ... CRM techniques affecting the exposure value shall be taken
+        # into account" — Art. 235/236 substitution is a CRM technique affecting
+        # the exposure value, so the covered part's exposure value and RWEA
+        # follow its col 0070/0080 flow onto the protection provider's sheet.
+        "0110": CellSpec(Sum(ead_col), predicate=post_member),
         # 0120 ("of which: off balance sheet") sits in the EXPOSURE VALUE
         # (post-CCF) group, so it is Sum(ead_final) over the off-BS legs —
         # exactly the basis the old 0100 carried before R11 moved it here.
-        "0120": CellSpec(Sum(ead_col), predicate=narrowed(("c08_bs", "off"))),
-        "0125": CellSpec(Sum(ead_col), predicate=narrowed(("c08_defaulted", True))),
+        "0120": CellSpec(Sum(ead_col), predicate=narrowed_post(("c08_bs", "off"))),
+        "0125": CellSpec(Sum(ead_col), predicate=narrowed_post(("c08_defaulted", True))),
         "0130": CellSpec(Formula(refs=(), fn=_const(None))),
-        "0140": _lfse_cell(cols, lambda: Sum(ead_col), terms),
+        "0140": _lfse_cell(cols, lambda: Sum(ead_col), post),
         # 0150/0160: the CRM-in-LGD twins of cols 0040/0050, mutually exclusive
         # with them and empty on today's calculator (module docstring). The
         # recorded constant 0.0 is the convention cols 0170-0173 already follow.
@@ -702,7 +842,7 @@ def _value_cells(  # noqa: C901, PLR0915 - the full C 08.01/02 column surface
             else CellSpec(Formula(refs=(), fn=_const(None)))
         ),
         "0240": (
-            _lfse_cell(cols, lambda: WeightedAvg(lgd_col, weight=ead_col), terms)
+            _lfse_cell(cols, lambda: WeightedAvg(lgd_col, weight=ead_col), origin)
             if lgd_col is not None
             else CellSpec(Formula(refs=(), fn=_const(None)))
         ),
@@ -711,26 +851,33 @@ def _value_cells(  # noqa: C901, PLR0915 - the full C 08.01/02 column surface
             predicate=member,
             empty_cell="null",
         ),
+        # The RWEA block is POST-basis with the exposure value it weights:
+        # Art. 153/154 applied to col 0110's population, so 0251-0254 foot into
+        # 0260 and (under CRR) 0255 + 0256 + 0257 = 0260, on one population.
         "0251": CellSpec(
             Sum("c08_rwa_pre_adj" if "rwa_pre_adjustments" in cols else "rwa_pre_adjustments"),
-            predicate=member,
+            predicate=post_member,
         ),
-        "0252": CellSpec(Sum("post_model_adjustment_rwa"), predicate=member),
-        "0253": CellSpec(Sum("mortgage_rw_floor_adjustment"), predicate=member),
-        "0254": CellSpec(Sum("unrecognised_exposure_adjustment"), predicate=member),
+        "0252": CellSpec(Sum("post_model_adjustment_rwa"), predicate=post_member),
+        "0253": CellSpec(Sum("mortgage_rw_floor_adjustment"), predicate=post_member),
+        "0254": CellSpec(Sum("unrecognised_exposure_adjustment"), predicate=post_member),
         "0255": CellSpec(
-            Sum("rwa_pre_factor" if "rwa_pre_factor" in cols else rwa_col), predicate=member
+            Sum("rwa_pre_factor" if "rwa_pre_factor" in cols else rwa_col), predicate=post_member
         ),
-        "0256": _sf_adjustment_cell(terms, cols, "sme_supporting_factor_applied", "is_sme"),
+        "0256": _sf_adjustment_cell(post, cols, "sme_supporting_factor_applied", "is_sme"),
         "0257": _sf_adjustment_cell(
-            terms, cols, "infrastructure_factor_applied", "is_infrastructure"
+            post, cols, "infrastructure_factor_applied", "is_infrastructure"
         ),
-        "0260": CellSpec(Sum(rwa_col), predicate=member),
-        "0265": CellSpec(Sum(rwa_col), predicate=narrowed(("c08_defaulted", True))),
-        "0270": _lfse_cell(cols, lambda: Sum(rwa_col), terms),
-        "0275": CellSpec(Sum(ead_col), predicate=member),
+        "0260": CellSpec(Sum(rwa_col), predicate=post_member),
+        "0265": CellSpec(Sum(rwa_col), predicate=narrowed_post(("c08_defaulted", True))),
+        "0270": _lfse_cell(cols, lambda: Sum(rwa_col), post),
+        # 0275/0276 are the output floor's SA-equivalent twins of 0110/0260, and
+        # Annex II gives 0275 col 0110's own clause verbatim ("Exposure value
+        # shall be provided after taking into account value adjustments, ALL
+        # CREDIT RISK MITIGANTS and conversion factors").
+        "0275": CellSpec(Sum(ead_col), predicate=post_member),
         "0276": (
-            CellSpec(Sum("sa_rwa"), predicate=member)
+            CellSpec(Sum("sa_rwa"), predicate=post_member)
             if "sa_rwa" in cols
             else CellSpec(Formula(refs=(), fn=_const(None)))
         ),
@@ -836,6 +983,7 @@ def _c08_01_spec(framework: str, cols: set[str], ead_col: str, rwa_col: str) -> 
                 column_refs,
                 inflow_key=_C08_01_INFLOW_KEYS.get("0070"),
                 netting_in_waterfall=True,
+                basis=_BASIS,
             ).items():
                 merged = (
                     CellSpec(cell.binding, predicate=pred, empty_cell=cell.empty_cell)
@@ -858,6 +1006,7 @@ def _c08_01_spec(framework: str, cols: set[str], ead_col: str, rwa_col: str) -> 
             column_refs,
             inflow_key=_C08_01_INFLOW_KEYS.get(row.ref),
             netting_in_waterfall=netting,
+            basis=_BASIS,
         ).items():
             cells[(row.ref, col_ref)] = cell
     return TemplateSpec(
@@ -904,13 +1053,17 @@ def c08_01_plans(
     population, not over the IRB book: an inflow whose substituted leg is treated
     under the standardised approach belongs on C 07.00, and reading it off this
     template's own approach-filtered frame dropped it entirely. The sheet axis is
-    correspondingly the UNION of the classes present in the IRB book and the
-    classes RECEIVING an inflow — Annex II's "Exposures stemming from possible in-
-    and outflows from and to other templates shall be taken into account" is not
-    satisfied by an inflow with nowhere to land, so a guarantor class with no
-    native IRB exposure gets an inflow-only sheet (its Total row 0010 is
-    constraint-free, so it survives ``_null_empty_rows`` and reports
-    ``0090 = 0080``)."""
+    correspondingly the UNION of the classes present in the IRB book ON EITHER
+    BASIS and the classes RECEIVING an inflow — Annex II's "Exposures stemming
+    from possible in- and outflows from and to other templates shall be taken
+    into account" is not satisfied by an inflow with nowhere to land, so a
+    guarantor class with no native IRB exposure gets an inflow-only sheet (its
+    Total row 0010 is constraint-free, so it survives ``null_empty_rows`` and
+    reports ``0090 = 0080``). The post-basis limb is belt-and-braces: a
+    beneficially-substituted leg's guarantor class is an inflow key too, so in
+    practice it adds no sheet — but without it a leg whose inflow the Annex II
+    block cap shed to zero would drop its exposure value and RWEA out of the
+    template silently."""
     ec_col = pick(cols, "reporting_class_origin")
     ead_col = pick(cols, "ead_final")
     rwa_col = pick(cols, "rwa_final", "rwa_post_factor", "rwa")
@@ -920,24 +1073,28 @@ def c08_01_plans(
         if ec_col is None:
             errors.append("C08.01: Missing exposure_class column")
         return {}
-    irb_df = _irb_population(results, cols).collect()
+    irb_df = _irb_population(results, cols, both_bases=True).collect()
     # Resolved BEFORE the empty-population guard: a book whose IRB-destined
     # inflow comes entirely from legs outside this template would lose it to the
     # early exit, which is the same dropped-inflow defect one level up.
     inflow_map = irb_origin_inflows(results, cols, destination="irb")
     if len(irb_df) == 0 and not inflow_map:
         return {}
+    # The two sheet keys. C 08 applies NO key transform (no specialised-lending
+    # merge, unlike C 07.00), and the post key degrades to the origin key on a
+    # frame that seals no ``reporting_class``.
+    irb_df = irb_df.with_columns(class_keys(_BASIS, set(irb_df.columns), ec_col))
     data_cols = set(irb_df.columns)
     irb_df = _prepare(irb_df, data_cols)
     spec = _c08_01_spec(framework, data_cols, ead_col, rwa_col)
     row_terms = _c08_01_row_terms(framework, data_cols)
     plans: dict[str, SheetPlan] = {}
-    sheet_keys = set(irb_df[ec_col].drop_nulls().unique().to_list()) | set(inflow_map)
+    sheet_keys = sheet_axis(_BASIS, irb_df) | set(inflow_map)
     for ec in sorted(sheet_keys):
         inflow = inflow_map.get(ec)
         plans[ec] = SheetPlan(
             spec=spec,
-            frame=irb_df.filter(pl.col(ec_col) == ec),
+            frame=sheet_frame(_BASIS, irb_df, ec),
             ctx=ReportingContext(
                 substitution_inflow=inflow.total if inflow else 0.0,
                 substitution_inflow_on_bs=inflow.on_bs if inflow else 0.0,
@@ -994,14 +1151,34 @@ def generate_c08_01(
     result: dict[str, pl.DataFrame] = {}
     for ec, plan in c08_01_plans(results, cols, framework, errors).items():
         row_preds = _c08_01_row_preds(plan.row_terms)
+        origin_preds = _origin_preds(row_preds)
         data_cols = set(plan.frame.columns)
         frame = execute(plan.spec, plan.frame, plan.ctx)
-        frame = _c08_off_bs_pre_ccf(frame, plan.frame, row_preds)
-        frame = _c08_after_all_crm(frame)
-        frame = _null_empty_rows(frame, plan.frame, row_preds, plan.inflow_rows)
-        frame = _provisions_postfix(frame, plan.frame, row_preds, data_cols, ref="0290")
-        result[ec] = _negate(frame)
+        frame = c08_off_bs_pre_ccf(frame, plan.frame, origin_preds)
+        frame = c08_after_all_crm(frame)
+        frame = null_empty_rows(frame, plan.frame, row_preds, plan.inflow_rows)
+        frame = provisions_postfix(frame, plan.frame, origin_preds, data_cols, ref="0290")
+        result[ec] = negate_deduction_cols(frame, _NEGATIVE_COLS)
     return result
+
+
+def _origin_preds(
+    preds: Mapping[str, RowPredicate | None],
+) -> dict[str, RowPredicate | None]:
+    """The same per-row predicates narrowed to the ORIGIN basis.
+
+    Cols 0100 and 0290 are origin-basis (the off-BS slice of the col 0090
+    waterfall, and value adjustments booked against the obligor's own exposure),
+    so their post-passes must not see a leg that ARRIVED on this sheet — it would
+    add an off-balance-sheet gross and a provision the obligor's book never had.
+    ``null_empty_rows`` deliberately keeps the BASIS-FREE predicates instead, so
+    its emptiness count is over the union of both bases (see that function).
+    """
+    flag: tuple[str, str | bool] = (_BASIS.basis_origin, True)
+    return {
+        ref: None if pred is None else RowPredicate(equals=(flag, *pred.equals), any_of=pred.any_of)
+        for ref, pred in preds.items()
+    }
 
 
 # =============================================================================
@@ -1024,7 +1201,10 @@ def _c08_02_spec(
     the PRE-``_prepare`` base-column set (see ``_c08_01_spec``).
 
     The substitution INFLOW lands on the "Unassigned" residual row and nowhere
-    else — see ``_C08_02_INFLOW_ROW`` for why that row and not a grade."""
+    else — see ``_C08_02_INFLOW_ROW`` for why that row and not a grade. The POST
+    basis keys ``c08_02_key_post``, which routes an ARRIVED leg to that same row
+    (``_c08_02_keyed``), so the pre-conversion scalar and the post-conversion legs
+    that make it up report on one row."""
     rows = tuple(_Row(label, label) for label in labels)
     cells: dict[tuple[str, str], CellSpec] = {}
     for label in labels:
@@ -1037,6 +1217,8 @@ def _c08_02_spec(
             value_refs,
             inflow_key=("substitution_inflow_graded" if label == _C08_02_INFLOW_ROW else None),
             netting_in_waterfall=True,
+            basis=_BASIS,
+            post_terms=(("c08_02_key_post", label),),
         ).items():
             cells[(label, col_ref)] = cell
     return TemplateSpec(
@@ -1073,25 +1255,31 @@ def c08_02_plans(
     if pd_col is None:
         errors.append("C08.02: No PD column available — skipping PD grade breakdown")
         return {}
-    irb_df = _non_slotting(results, cols).collect()
+    irb_df = _non_slotting(results, cols, both_bases=True).collect()
     # The GRADED component only: C 08.02 excludes slotting, and the tie-out it must
     # satisfy is against C 08.01 row 0070, which is the F-IRB/A-IRB union.
     inflow_map = irb_origin_inflows(results, cols, destination="irb")
     graded = {ec: flow.graded for ec, flow in inflow_map.items() if flow.graded}
     if len(irb_df) == 0 and not graded:
         return {}
+    irb_df = irb_df.with_columns(class_keys(_BASIS, set(irb_df.columns), ec_col))
     data_cols = set(irb_df.columns)
     irb_df = _prepare(irb_df, data_cols)
     value_refs = tuple(col.ref for col in get_c08_02_columns(framework) if col.ref != "0005")
     plans: dict[str, SheetPlan] = {}
-    sheet_keys = set(irb_df[ec_col].drop_nulls().unique().to_list()) | set(graded)
+    sheet_keys = sheet_axis(_BASIS, irb_df) | set(graded)
     for ec in sorted(sheet_keys):
-        class_df = irb_df.filter(pl.col(ec_col) == ec)
+        class_df = sheet_frame(_BASIS, irb_df, ec)
         labels, keyed = _c08_02_keyed(class_df, pd_col, grade_col)
-        if graded.get(ec) and _C08_02_INFLOW_ROW not in labels:
+        arrived = bool(
+            len(keyed.filter(pl.col(_BASIS.basis_post) & pl.col(_BASIS.basis_origin).not_()))
+        )
+        if (graded.get(ec) or arrived) and _C08_02_INFLOW_ROW not in labels:
             # A destination class whose own book has no unassigned-grade legs (or no
             # legs at all) still needs the row the inflow lands on, or the C 08.01
-            # r0070 tie-out has nothing to sum against.
+            # r0070 tie-out has nothing to sum against. ``arrived`` is the
+            # belt-and-braces limb: a leg whose inflow the Annex II block cap shed
+            # to zero still brings its exposure value and RWEA onto this sheet.
             labels = [*labels, _C08_02_INFLOW_ROW]
         plans[ec] = SheetPlan(
             spec=_c08_02_spec(labels, data_cols, ead_col, rwa_col, value_refs),
@@ -1124,15 +1312,15 @@ def generate_c08_02(
         if not plan.spec.rows:
             result[ec] = _empty_frame(column_refs, string_refs=("0005",))
             continue
-        row_preds: dict[str, RowPredicate | None] = {
-            row.ref: RowPredicate(equals=(("c08_02_key", row.ref),)) for row in plan.spec.rows
-        }
+        row_preds: dict[str, RowPredicate | None] = _origin_preds(
+            {row.ref: RowPredicate(equals=(("c08_02_key", row.ref),)) for row in plan.spec.rows}
+        )
         data_cols = set(plan.frame.columns)
         frame = execute(plan.spec, plan.frame, plan.ctx)
-        frame = _c08_off_bs_pre_ccf(frame, plan.frame, row_preds)
-        frame = _c08_after_all_crm(frame)
-        frame = _provisions_postfix(frame, plan.frame, row_preds, data_cols, ref="0290")
-        frame = _negate(frame)
+        frame = c08_off_bs_pre_ccf(frame, plan.frame, row_preds)
+        frame = c08_after_all_crm(frame)
+        frame = provisions_postfix(frame, plan.frame, row_preds, data_cols, ref="0290")
+        frame = negate_deduction_cols(frame, _NEGATIVE_COLS)
         frame = frame.with_columns(pl.col("row_name").alias("0005"))
         result[ec] = frame.select(["row_ref", "row_name", *column_refs])
     return result
@@ -1141,20 +1329,45 @@ def generate_c08_02(
 def _c08_02_keyed(
     class_df: pl.DataFrame, pd_col: str, grade_col: str | None
 ) -> tuple[list[str], pl.DataFrame]:
-    """Derive the C 08.02 row key column: distinct firm grades when the
-    grade column has values (null grades -> "Unassigned"), else the
-    populated fixed PD bands (out-of-band/null PD -> "Unassigned")."""
+    """Derive the C 08.02 row key columns and the sheet's row labels.
+
+    ``c08_02_key`` (the ORIGIN axis) is the retired rule: distinct firm grades
+    when the grade column has values (null grades -> "Unassigned"), else the
+    populated fixed PD bands (out-of-band/null PD -> "Unassigned").
+
+    ``c08_02_key_post`` (the POST axis) is the same key EXCEPT on a leg that
+    ARRIVED on this sheet by substitution (post-basis here, origin-basis
+    elsewhere), which keys the "Unassigned" residual row. That is R12's landing
+    decision applied to the frame-based columns rather than only to the col 0080
+    scalar: the ledger carries the OBLIGOR's ``cp_internal_rating_grade``, never
+    the guarantor's, so an arrived leg's grade is a label in a FOREIGN class's
+    rating scale and asserting it here would misattribute the exposure value and
+    RWEA to a grade this sheet's scale does not mean. "Unassigned" already means
+    "an exposure whose grade we do not carry", which is exactly what an arrived
+    leg is — and it puts the post-conversion legs on the same row as the
+    pre-conversion scalar they make up.
+
+    BOTH THE LABEL SET AND THE GRADE-VS-BAND CHOICE ARE MADE ON THE ORIGIN LEGS
+    ALONE — they answer "what rating scale does THIS sheet publish?", which an
+    arrived leg cannot speak to. Without that an arrived leg would open a
+    spurious grade row on the guarantor's sheet, empty on every origin column.
+    """
+    native = (
+        class_df.filter(pl.col(_BASIS.basis_origin))
+        if _BASIS.basis_origin in class_df.columns
+        else class_df
+    )
     if grade_col is not None and grade_col in class_df.columns:
-        non_null = class_df.filter(pl.col(grade_col).is_not_null())
+        non_null = native.filter(pl.col(grade_col).is_not_null())
         if len(non_null) > 0:
             keyed = class_df.with_columns(
-                pl.col(grade_col).fill_null("Unassigned").alias("c08_02_key")
+                pl.col(grade_col).fill_null(_C08_02_INFLOW_ROW).alias("c08_02_key")
             )
             labels = non_null[grade_col].unique().sort().to_list()
-            if len(non_null) < len(class_df):
-                labels.append("Unassigned")
-            return labels, keyed
-    band_expr: pl.Expr = pl.lit("Unassigned")
+            if len(non_null) < len(native):
+                labels.append(_C08_02_INFLOW_ROW)
+            return labels, _c08_02_post_key(keyed)
+    band_expr: pl.Expr = pl.lit(_C08_02_INFLOW_ROW)
     for lower, upper, label in reversed(PD_BANDS):
         band_expr = (
             pl.when((pl.col(pd_col) >= lower) & (pl.col(pd_col) < upper))
@@ -1162,11 +1375,28 @@ def _c08_02_keyed(
             .otherwise(band_expr)
         )
     keyed = class_df.with_columns(band_expr.alias("c08_02_key"))
-    present = set(keyed["c08_02_key"].to_list())
+    present = set(
+        keyed.filter(pl.col(_BASIS.basis_origin))["c08_02_key"].to_list()
+        if _BASIS.basis_origin in keyed.columns
+        else keyed["c08_02_key"].to_list()
+    )
     labels = [label for _lo, _hi, label in PD_BANDS if label in present]
-    if "Unassigned" in present:
-        labels.append("Unassigned")
-    return labels, keyed
+    if _C08_02_INFLOW_ROW in present:
+        labels.append(_C08_02_INFLOW_ROW)
+    return labels, _c08_02_post_key(keyed)
+
+
+def _c08_02_post_key(keyed: pl.DataFrame) -> pl.DataFrame:
+    """Add ``c08_02_key_post`` — the origin key, except "Unassigned" on a leg
+    that arrived here by substitution (see :func:`_c08_02_keyed`)."""
+    if _BASIS.basis_origin not in keyed.columns:
+        return keyed.with_columns(pl.col("c08_02_key").alias("c08_02_key_post"))
+    return keyed.with_columns(
+        pl.when(pl.col(_BASIS.basis_post) & pl.col(_BASIS.basis_origin).not_())
+        .then(pl.lit(_C08_02_INFLOW_ROW))
+        .otherwise(pl.col("c08_02_key"))
+        .alias("c08_02_key_post")
+    )
 
 
 # =============================================================================
@@ -1316,7 +1546,7 @@ def generate_c08_03(
             ref: RowPredicate(equals=terms) for ref, terms in plan.row_terms.items() if terms
         }
         frame = execute(plan.spec, banded)
-        frame = _provisions_postfix(frame, banded, row_preds, data_cols, ref="0110")
+        frame = provisions_postfix(frame, banded, row_preds, data_cols, ref="0110")
         result[ec] = frame
     return result
 
@@ -1906,7 +2136,7 @@ def _c08_06_sheet(
         if fixes:
             overrides[row_ref] = fixes
     frame = _c08_06_apply_overrides(frame, overrides)
-    return _provisions_postfix(frame, type_df, row_preds, cols, ref="0100")
+    return provisions_postfix(frame, type_df, row_preds, cols, ref="0100")
 
 
 def _c08_06_zero_row(column_refs: tuple[str, ...], rw_display: str) -> dict[str, float | None]:
@@ -1958,244 +2188,14 @@ def _copy_of_0010(cells: Mapping[str, float | None], _prior: bool) -> float | No
 # =============================================================================
 
 
-def _non_slotting(results: pl.LazyFrame, cols: set[str]) -> pl.LazyFrame:
-    irb = _irb_population(results, cols)
+def _non_slotting(
+    results: pl.LazyFrame, cols: set[str], *, both_bases: bool = False
+) -> pl.LazyFrame:
+    irb = _irb_population(results, cols, both_bases=both_bases)
     approach_col = pick(cols, "reporting_approach_origin", "approach")
     if approach_col is not None:
         return irb.filter(pl.col(approach_col) != "slotting")
     return irb
-
-
-def _null_empty_rows(
-    frame: pl.DataFrame,
-    class_df: pl.DataFrame,
-    row_preds: dict[str, RowPredicate | None],
-    keep: frozenset[str] = frozenset(),
-) -> pl.DataFrame:
-    """Render inert rows and rows with EMPTY subsets all-null.
-
-    ``keep`` exempts rows whose content is a cross-sheet inflow: their own subset
-    is legitimately empty (the money lives in other sheets), so nulling them would
-    delete the component the published row sums need — visibly so on an
-    inflow-only sheet, where EVERY constrained subset is empty."""
-    constrained = {
-        ref: pred
-        for ref, pred in row_preds.items()
-        if pred is not None and (pred.equals or pred.any_of)
-    }
-    counts = matched_counts(class_df, constrained)
-    null_refs = [
-        ref
-        for ref, pred in row_preds.items()
-        if ref not in keep and (pred is None or ((pred.equals or pred.any_of) and counts[ref] == 0))
-    ]
-    if not null_refs:
-        return frame
-    value_cols = [col for col in frame.columns if col not in ("row_ref", "row_name")]
-    return frame.with_columns(
-        pl.when(pl.col("row_ref").is_in(null_refs))
-        .then(pl.lit(None, dtype=pl.Float64))
-        .otherwise(pl.col(col))
-        .alias(col)
-        for col in value_cols
-    )
-
-
-def _provisions_postfix(
-    frame: pl.DataFrame,
-    class_df: pl.DataFrame,
-    row_preds: Mapping[str, RowPredicate | None],
-    cols: set[str],
-    *,
-    ref: str,
-) -> pl.DataFrame:
-    """The provisions ladder: when the SCRA/GCRA base sum nets to ~0, swap the
-    whole cell to the best available provisions carrier for the row subset (a
-    value-dependent, PER-CELL branch — the recorded C 08 granularity, distinct
-    from C 07.00's per-row ladder).
-
-    The fallback carrier is ``provision_held`` when the frame carries it (the
-    synthetic COREP unit frames supply it), else the sealed ``provision_allocated``
-    (R10b). The retired ``provision_held``-only fallback was DEAD on every real
-    submission: ``provision_held`` is an input pass-through the aggregator seal
-    strips, so ``"provision_held" not in cols`` returned early and the provisions
-    cells (C 08.01/02 col 0290, C 08.03 col 0110, C 08.06 col 0100) rendered a
-    hard 0.0. ``provision_allocated`` is the sealed provisions carrier that IS
-    meaningful on the IRB book: unlike C 07.00's ``provision_deducted`` (R9), the
-    Art. 111(2) drawn-first deduction is SA-only (engine/crm/provisions.py —
-    IRB/Slotting: provision_on_drawn = 0, provision_on_nominal = 0, so
-    provision_deducted is STRUCTURALLY 0.0 on every IRB/slotting leg), whereas
-    provision_allocated is tracked for all approaches (it feeds the IRB EL
-    shortfall/excess). scra/gcra stay the preferred base; a book that supplies
-    them non-degenerately keeps that granular figure."""
-    fallback_col = (
-        "provision_held"
-        if "provision_held" in cols
-        else "provision_allocated"
-        if "provision_allocated" in cols
-        else None
-    )
-    if ref not in frame.columns or fallback_col is None:
-        return frame
-    needed: dict[str, RowPredicate | None] = {}
-    for row_ref, pred in row_preds.items():
-        if pred is None:
-            continue
-        current = frame.filter(pl.col("row_ref") == row_ref)
-        if current.height == 0 or current[ref][0] is None:
-            continue
-        if abs(current[ref][0]) >= 1e-9:
-            continue
-        needed[row_ref] = pred
-    fixes: dict[str, float] = {}
-    for row_ref, subset in subset_rows(class_df, needed).items():
-        if subset.height == 0:
-            continue
-        fixes[row_ref] = float(subset[fallback_col].fill_null(0.0).sum())
-    if not fixes:
-        return frame
-    expr: pl.Expr = pl.col(ref)
-    for row_ref, value in fixes.items():
-        expr = pl.when(pl.col("row_ref") == row_ref).then(pl.lit(value)).otherwise(expr)
-    return frame.with_columns(expr.alias(ref))
-
-
-def _c08_off_bs_pre_ccf(
-    frame: pl.DataFrame,
-    class_df: pl.DataFrame,
-    row_preds: Mapping[str, RowPredicate | None],
-) -> pl.DataFrame:
-    """Fill C 08.01/02 col 0100 with the off-BS slice of the 0090 waterfall.
-
-    Col 0100 ("of which: off balance sheet") sits in the POST-CRM PRE-CCF
-    column group (the 0090 "Exposure after CRM substitution pre CCFs"
-    waterfall), so it reports the off-BS share of that PRE-conversion-factor
-    quantity — NOT the post-CCF exposure value (that is col 0120). The
-    executor has no intra-row sub-waterfall verb, so 0100 is derived here per
-    row over the row's ``c08_bs == "off"`` legs, mirroring ``_value_cells`` +
-    ``crm_substitution.crm_waterfall`` term-for-term:
-
-        0100 = off-BS gross (0020: the sealed reporting_gross_off_bs carrier)
-             - off-BS substitution outflow (0070: the ``c08_prot_block``
-               subtotal cols 0040/0050/0060 break down)
-
-    It carries the waterfall's OWN correction: reading the breakdown columns AND
-    the outflow subtotal — as this did before — deducts the same covered part
-    twice, exactly as ``crm_waterfall`` did. Binding the same per-leg subtotal
-    col 0070 binds keeps the memo a true slice of 0090 by construction rather
-    than by two derivations agreeing.
-
-    THE B31 COL 0035 TERM IS DELIBERATELY ABSENT, and that is load-bearing rather
-    than an oversight: col 0035 is the Art. 166(3) on-balance-sheet netting of
-    loans and deposits, so it has no off-balance-sheet share to slice. The BoE
-    scoping says the same thing structurally — ``boe_b0746_1`` drops the 0035 term
-    from the col 0090 waterfall on exactly the off-balance-sheet row family
-    (``crm_substitution.C08_01_NETTING_EXEMPT_ROWS``), so an off-BS memo that
-    subtracted it would contradict the published rule for row 0030 while claiming
-    to be its slice. Do not "restore" it for symmetry with the on-BS rows.
-
-    It is computed on POSITIVE magnitudes read from the raw ``class_df`` (so
-    the result is independent of the later ``_negate`` sign pass). The 0080
-    substitution INFLOW is EXCLUDED: it is a total-row cross-sheet scalar
-    (``ReportingContext.substitution_inflow``, a per-destination-class
-    aggregate with no leg-level on/off-BS attribution), so an off-BS memo
-    cannot claim a share of it — recorded decision, matching 0090's own
-    convention that the inflow only lands on the (constraint-free) total row.
-
-    Every leg is either on- or off-BS (``c08_bs``) and the outflow carrier is a
-    leg-level amount pro-rated across the two-leg guarantee split, so summing it
-    over the off-BS legs is the EXACT slice. Inert (None-predicate) rows are left
-    as the null placeholder for ``_null_empty_rows``; C 08.02 has none.
-    """
-    if "0100" not in frame.columns:
-        return frame
-    cols = set(class_df.columns)
-    if "c08_bs" not in cols:
-        return frame
-    active = {ref: pred for ref, pred in row_preds.items() if pred is not None}
-    if not active:
-        return frame
-    fixes: dict[str, float] = {}
-    for row_ref, subset in subset_rows(class_df, active).items():
-        off = subset.filter(pl.col("c08_bs") == "off")
-        off_cols = set(off.columns)
-        gross = safe_sum(off, off_cols, "reporting_gross_off_bs")
-        fixes[row_ref] = gross - safe_sum(off, off_cols, IRB_BLOCK_COL)
-    expr: pl.Expr = pl.col("0100")
-    for row_ref, value in fixes.items():
-        expr = (
-            pl.when(pl.col("row_ref") == row_ref)
-            .then(pl.lit(value, dtype=pl.Float64))
-            .otherwise(expr)
-        )
-    return frame.with_columns(expr.alias("0100"))
-
-
-def _c08_after_all_crm(frame: pl.DataFrame) -> pl.DataFrame:
-    """Fill C 08.01/02 col 0104 — exposure after ALL CRM, pre-conversion factors.
-
-    PS1/26 Annex II (OF 08.01 col 0104): "Institutions shall report the value
-    reported in column 0090 after adjusting for the reduction in exposure due to
-    the Financial Collateral Comprehensive Method reported in columns 0101-0103."
-    The published identity (boe_b1040) states it additively over the REPORTED
-    (signed) cells::
-
-        0104 = 0090 + 0101 + 0102
-
-    — col 0103 is an "of which" sub-item of 0102 and is excluded, and 0102 is a
-    "(-)"-labelled deduction, so on the POSITIVE magnitudes this pass sees (it
-    runs before ``_negate``) the arithmetic is ``0090 + 0101 - 0102``.
-
-    Cols 0101-0103 apply to slotting exposures only ("An institution shall only
-    report values for exposures subject to the slotting approach") and are
-    structural nulls today — no FCCM-under-slotting carrier is sealed — so 0104
-    currently reproduces 0090 on every row. The subtraction is written out
-    anyway so the cell stays truthful the day a carrier is wired.
-
-    This is a post-execute pass and not a ``Formula`` cell because 0090, 0101 and
-    0102 are themselves ``Formula`` cells and the executor refuses a formula that
-    references another formula. A null 0090 (an inert row) keeps 0104 null for
-    ``_null_empty_rows``; a frame without col 0104 (CRR, which has no FCCM
-    column block) is left untouched.
-    """
-    if "0104" not in frame.columns or "0090" not in frame.columns:
-        return frame
-    total = pl.col("0090").fill_null(0.0)
-    if "0101" in frame.columns:
-        total = total + pl.col("0101").fill_null(0.0)
-    if "0102" in frame.columns:
-        total = total - pl.col("0102").fill_null(0.0)
-    return frame.with_columns(
-        pl.when(pl.col("0090").is_null())
-        .then(pl.lit(None, dtype=pl.Float64))
-        .otherwise(total)
-        .alias("0104")
-    )
-
-
-def _negate_expr(col: str) -> pl.Expr:
-    """Negate a "(-)"-labelled deduction column, normalising a zero to ``+0.0``.
-
-    Plain ``-pl.col(col)`` flips the IEEE sign bit, so a ``0.0`` cell would
-    serialise as ``-0.0`` (``+ 0.0`` does NOT clear it in Polars); the explicit
-    zero branch keeps a zero deduction as ``+0.0``. Null stays null (``== 0.0``
-    is null on a null row, so the ``otherwise`` branch returns ``-null``). This
-    is the identical expression used by C 07.00's ``_negate_deduction_cols``."""
-    return pl.when(pl.col(col) == 0.0).then(pl.lit(0.0)).otherwise(-pl.col(col)).alias(col)
-
-
-def _negate(frame: pl.DataFrame) -> pl.DataFrame:
-    """Annex II §1.3: emit the "(-)"-labelled deduction columns negative on the
-    C 08.01/02 surface (``_NEGATIVE_COLS``), AFTER the CRM waterfall (0090) has
-    consumed their positive magnitudes. Intersecting with the frame's columns
-    makes the framework-specific members (B31's 0035/0102/0103, CRR's 0256/0257)
-    no-ops in the regime where the column is absent. A zero cell is emitted as
-    ``+0.0`` (not ``-0.0`` — plain float negation flips the sign bit and Polars
-    keeps it) and null stays null; identical expression to C 07.00's pass."""
-    targets = [col for col in frame.columns if col in _NEGATIVE_COLS]
-    if not targets:
-        return frame
-    return frame.with_columns(_negate_expr(col) for col in targets)
 
 
 def _empty_frame(column_refs: tuple[str, ...], string_refs: tuple[str, ...] = ()) -> pl.DataFrame:

--- a/src/rwa_calc/reporting/corep/c08.py
+++ b/src/rwa_calc/reporting/corep/c08.py
@@ -356,6 +356,8 @@ from rwa_calc.reporting.corep.crm_substitution import (
 )
 from rwa_calc.reporting.corep.pd_scale import banded_rows
 from rwa_calc.reporting.corep.postpass import (
+    c08_06_apply_overrides,
+    c08_06_zero_row,
     c08_after_all_crm,
     c08_off_bs_pre_ccf,
     negate_deduction_cols,
@@ -1876,6 +1878,30 @@ def _c08_06_row_preds(
     }
 
 
+def _c08_06_post(pred: RowPredicate) -> RowPredicate:
+    """The row predicate narrowed to the POST-substitution slotting book.
+
+    Annex II defines C 08.06 cols 0020/0040/0080 BY CROSS-REFERENCE to C 08.01
+    cols 0090/0110/0260 ("See CR-IRB 1 instructions for column 0090", etc.),
+    and those three moved to the post-substitution basis with C 08.01. A leg
+    whose guarantee substituted onto an SA guarantor is no longer risk-weighted
+    under Art. 153(5) at all, so it must leave the category grid for those
+    columns — otherwise the two IRB templates state different values for
+    quantities the regulator defines as identical.
+
+    Cols 0010/0030 (original exposure pre-CCF) stay on the ORIGIN basis: the
+    grid is the obligor's slotting book by origination, and that is the column
+    the covered part is deducted FROM.
+
+    Uses ``RowPredicate.approaches``, NOT a tolerant ``equals`` term: that field
+    DEGRADES to ``reporting_approach_origin`` on a frame sealing no
+    post-substitution approach, whereas an absent ``equals`` column compiles to
+    match-nothing and would silently zero every one of these columns on the
+    synthetic unit and lineage frames.
+    """
+    return RowPredicate(equals=pred.equals, any_of=pred.any_of, approaches=("slotting",))
+
+
 def _c08_06_empty_refs(
     type_df: pl.DataFrame,
     row_defs: list[tuple[str, str, bool | None, str]],
@@ -1890,7 +1916,7 @@ def _c08_06_empty_refs(
     zero-fill pass), so lineage reports it as the template's empty policy rather
     than a WeightedAvg with no legs whose value would contradict the screen. Uses
     the SAME emptiness test as ``_c08_06_sheet`` (subset height 0, label != Total)."""
-    subsets = subset_rows(type_df, dict(row_preds))
+    subsets = subset_rows(type_df, {ref: _c08_06_post(p) for ref, p in row_preds.items()})
     return frozenset(
         row_def[0]
         for row_def in row_defs
@@ -2055,7 +2081,6 @@ def _c08_06_spec(
     row_defs = _c08_06_row_defs(framework)
     rows = tuple(_Row(row_def[0], row_def[1]) for row_def in row_defs)
     row_preds = _c08_06_row_preds(row_defs, cols)
-    crm_col = pick(cols, "ead_pre_ccf", "exposure_post_crm")
     if framework != "BASEL_3_1" and "rwa_post_factor" in cols:
         rwea_col = "rwa_post_factor"  # CRR prefers the post-supporting-factor RWEA
     else:
@@ -2065,20 +2090,31 @@ def _c08_06_spec(
         ref = row_def[0]
         pred = row_preds[ref]
         off_pred = RowPredicate(equals=(*pred.equals, ("c0806_off_bs", True)))
+        post_pred = _c08_06_post(pred)
+        off_post = _c08_06_post(off_pred)
         cells[(ref, "0010")] = CellSpec(
             SafeSum(("reporting_gross_on_bs", "reporting_gross_off_bs")),
             predicate=pred,
         )
-        cells[(ref, "0020")] = (
-            CellSpec(Sum(crm_col), predicate=pred)
-            if crm_col is not None
-            else CellSpec(Formula(refs=("0010",), fn=_copy_of_0010))
+        # Col 0020 "EXPOSURE AFTER CRM SUBSTITUTION EFFECTS PRE CONVERSION
+        # FACTORS" — Annex II: "See CR-IRB 1 instructions for column 0090", the
+        # substitution waterfall. It binds col 0010's OWN pre-CCF gross carriers
+        # over the POST population, which IS that quantity: the covered part has
+        # left, so what remains is the exposure after substitution effects, still
+        # pre-conversion. The retired binding was wrong twice — ``ead_pre_ccf`` /
+        # ``exposure_post_crm`` are FUNDED-CRM carriers, not the substitution
+        # waterfall, and their absent-carrier fallback was a Formula copying col
+        # 0010, which no predicate can narrow, so the column could not follow the
+        # basis at all.
+        cells[(ref, "0020")] = CellSpec(
+            SafeSum(("reporting_gross_on_bs", "reporting_gross_off_bs")),
+            predicate=post_pred,
         )
         cells[(ref, "0030")] = CellSpec(Sum("reporting_gross_off_bs"), predicate=pred)
         if "0031" in column_refs:
             cells[(ref, "0031")] = CellSpec(Formula(refs=(), fn=_const(None)))
-        cells[(ref, "0040")] = CellSpec(Sum(ead_col), predicate=pred)
-        cells[(ref, "0050")] = CellSpec(Sum(ead_col), predicate=off_pred, empty_cell="null")
+        cells[(ref, "0040")] = CellSpec(Sum(ead_col), predicate=post_pred)
+        cells[(ref, "0050")] = CellSpec(Sum(ead_col), predicate=off_post, empty_cell="null")
         cells[(ref, "0060")] = CellSpec(Formula(refs=(), fn=_const(None)))
         # Col 0070 on an EMPTY non-Total row is a fixed display risk weight from
         # the zero-fill post-pass (not a measured weighted average), so it is left
@@ -2086,9 +2122,9 @@ def _c08_06_spec(
         # reports the template's empty policy, never a WeightedAvg with no legs.
         if ref not in empty_refs:
             cells[(ref, "0070")] = CellSpec(
-                WeightedAvg("risk_weight", weight=ead_col), predicate=pred, empty_cell="null"
+                WeightedAvg("risk_weight", weight=ead_col), predicate=post_pred, empty_cell="null"
             )
-        cells[(ref, "0080")] = CellSpec(Sum(rwea_col), predicate=pred)
+        cells[(ref, "0080")] = CellSpec(Sum(rwea_col), predicate=post_pred)
         cells[(ref, "0090")] = (
             CellSpec(Sum("expected_loss"), predicate=pred)
             if "expected_loss" in cols
@@ -2120,11 +2156,18 @@ def _c08_06_sheet(
     naturally and the retired whole-subset nominal fallback is gone."""
     frame = execute(spec, type_df)
     overrides: dict[str, dict[str, float | None]] = {}
-    row_subsets = subset_rows(type_df, dict(row_preds))
+    # THE SECOND EMPTINESS TEST, and it must key the SAME basis as the first.
+    # ``_c08_06_empty_refs`` decides whether the spec BINDS col 0070; this loop
+    # decides whether the FIXED display weight is INJECTED. Move one without the
+    # other and a fully-substituted category publishes a gross with no risk
+    # weight at all — measured NULL with only the spec moved, 0.0 with only this
+    # one. Their docstrings say they use the same test, which is exactly what
+    # makes moving one silently dangerous.
+    row_subsets = subset_rows(type_df, {ref: _c08_06_post(p) for ref, p in row_preds.items()})
     for row_ref, label, _is_short, rw_display in row_defs:
         subset = row_subsets[row_ref]
         if subset.height == 0 and label != "Total":
-            overrides[row_ref] = _c08_06_zero_row(spec.column_refs, rw_display)
+            overrides[row_ref] = c08_06_zero_row(spec.column_refs, rw_display)
             continue
         fixes: dict[str, float | None] = {}
         ead_sum = float(subset[ead_col].fill_null(0.0).sum())
@@ -2135,52 +2178,8 @@ def _c08_06_sheet(
             fixes["0070"] = float(rw_vals[0]) if len(rw_vals) > 0 else None
         if fixes:
             overrides[row_ref] = fixes
-    frame = _c08_06_apply_overrides(frame, overrides)
+    frame = c08_06_apply_overrides(frame, overrides)
     return provisions_postfix(frame, type_df, row_preds, cols, ref="0100")
-
-
-def _c08_06_zero_row(column_refs: tuple[str, ...], rw_display: str) -> dict[str, float | None]:
-    """The retired zero-fill for an empty non-Total row: every cell 0.0
-    except 0070 = the row definition's display risk weight ("50%" -> 0.5;
-    unparseable/blank -> None)."""
-    values: dict[str, float | None] = dict.fromkeys(column_refs, 0.0)
-    if rw_display:
-        try:
-            values["0070"] = float(rw_display.replace("%", "").strip()) / 100.0
-        except ValueError:
-            values["0070"] = None
-    else:
-        values["0070"] = None
-    return values
-
-
-def _c08_06_apply_overrides(
-    frame: pl.DataFrame, overrides: dict[str, dict[str, float | None]]
-) -> pl.DataFrame:
-    if not overrides:
-        return frame
-    exprs: list[pl.Expr] = []
-    value_cols = [col for col in frame.columns if col not in ("row_ref", "row_name")]
-    for col in value_cols:
-        expr = pl.col(col)
-        touched = False
-        for row_ref, values in overrides.items():
-            if col in values:
-                expr = (
-                    pl.when(pl.col("row_ref") == row_ref)
-                    .then(pl.lit(values[col], dtype=pl.Float64))
-                    .otherwise(expr)
-                )
-                touched = True
-        if touched:
-            exprs.append(expr.alias(col))
-    return frame.with_columns(exprs) if exprs else frame
-
-
-def _copy_of_0010(cells: Mapping[str, float | None], _prior: bool) -> float | None:
-    """C 08.06 col 0020 falls back to col 0010 when no post-CRM carrier
-    (``ead_pre_ccf`` / ``exposure_post_crm``) exists."""
-    return cells["0010"]
 
 
 # =============================================================================

--- a/src/rwa_calc/reporting/corep/c09.py
+++ b/src/rwa_calc/reporting/corep/c09.py
@@ -145,10 +145,10 @@ from rwa_calc.reporting.cellspec import (
     TemplateSpec,
     WeightedAvg,
     execute,
-    matched_counts,
     subset_rows,
 )
 from rwa_calc.reporting.corep.c07 import c07_population
+from rwa_calc.reporting.corep.postpass import negate_deduction_cols, null_empty_rows
 from rwa_calc.reporting.corep.templates import (
     C09_01_SA_CLASS_MAP,
     get_c09_01_columns,
@@ -156,7 +156,7 @@ from rwa_calc.reporting.corep.templates import (
     get_c09_02_columns,
     get_c09_02_rows,
 )
-from rwa_calc.reporting.kernel import pick
+from rwa_calc.reporting.kernel import TwoBasis, pick, population_flags
 from rwa_calc.reporting.metadata import ReportingContext
 from rwa_calc.reporting.plans import SheetPlan
 
@@ -169,6 +169,17 @@ if TYPE_CHECKING:
     from rwa_calc.reporting.corep.templates import COREPRow
 
 _IRB_APPROACHES: tuple[str, ...] = ("foundation_irb", "advanced_irb", "slotting")
+
+# C 09.02's own two-basis namespace (C 09.01 keys C 07.00's, via c07_population).
+# Annex II §3.4 ¶87 splits this template BY COLUMN: "original exposure
+# pre-conversion factors" reports at the IMMEDIATE obligor, while "exposure
+# value" and "risk-weighted exposure amounts" report at the ULTIMATE obligor —
+# which is the origin/post pair under the regulator's own vocabulary, and ¶86
+# says so outright ("CRM techniques with substitution effects can change the
+# allocation of an exposure to a country").
+_C09_BASIS: TwoBasis = TwoBasis("c09")
+# The sealed post-substitution class twin (the ULTIMATE obligor of ¶87).
+_POST_CLASS_COL: str = "reporting_class"
 
 # C 09.02 row keys that map directly to a single exposure_class value.
 _C09_02_DIRECT_EC: frozenset[str] = frozenset(
@@ -649,10 +660,21 @@ def generate_c09_02(
 
 
 def _irb_population(results: pl.LazyFrame, cols: set[str]) -> pl.LazyFrame:
-    """The retired _filter_by_irb_approach: keyed to approach_applied only."""
-    if "reporting_approach_origin" not in cols:
-        return results.filter(pl.lit(value=False))
-    return results.filter(pl.col("reporting_approach_origin").is_in(list(_IRB_APPROACHES)))
+    """The IRB book on BOTH bases, tagged (mirrors ``c08.py::_irb_population``).
+
+    Returns the UNION of the origin-approach IRB book and the post-substitution
+    one, with ``c09_pop_origin`` / ``c09_pop_post`` recording which each leg is
+    in. A leg with no substitution is in both, which is why the split is
+    number-neutral on a book that never substitutes.
+
+    The post book is a SUBSET of the origin one here, exactly as on C 08.01:
+    ``aggregator._post_crm_approach_expr`` maps an SA guarantor to the SA literal
+    and everything else to the obligor's own approach, so an IRB-origin leg can
+    only LEAVE the IRB population post-substitution and an SA-origin leg can
+    never enter it. So the union IS the origin book, and the flags do the work.
+    """
+    tagged = results.with_columns(population_flags(_C09_BASIS, cols, _IRB_APPROACHES))
+    return tagged.filter(pl.col(_C09_BASIS.pop_origin) | pl.col(_C09_BASIS.pop_post))
 
 
 def _c09_02_prepare(
@@ -686,49 +708,53 @@ def _c09_02_prepare(
 
 
 def _c09_02_row_pred(  # noqa: PLR0911 - the retired branch cascade, one return per row family
-    row_def: COREPRow, cols: set[str], approach_col: str | None
+    row_def: COREPRow, cols: set[str], approach_col: str | None, basis_col: str
 ) -> RowPredicate | None:
-    """The retired _filter_c09_02_row branch cascade as predicates."""
+    """The retired _filter_c09_02_row branch cascade as predicates.
+
+    ``basis_col`` is the class column the row keys on — the ORIGIN twin for the
+    original-exposure and provisions columns, the POST twin for exposure value
+    and RWEA (Annex II §3.4 ¶87). Every class term routes through it, so the two
+    bases cannot drift apart in one branch of the cascade.
+    """
     if row_def.ref == "0150":
         return RowPredicate()
     key = row_def.exposure_class_value
     if key is None or key in _C09_02_EMPTY_KEYS:
         return None
     if key in _C09_02_DIRECT_EC:
-        return RowPredicate(equals=(("reporting_class_origin", key),))
+        return RowPredicate(equals=((basis_col, key),))
     if key == "corporate":
-        return _class_union(*_CORPORATE_FAMILY, "specialised_lending")
+        return _class_union(*_CORPORATE_FAMILY, "specialised_lending", col=basis_col)
     if key == "sl_excl_slotting":
-        terms: tuple[tuple[str, str | bool], ...] = (
-            ("reporting_class_origin", "specialised_lending"),
-        )
+        terms: tuple[tuple[str, str | bool], ...] = ((basis_col, "specialised_lending"),)
         if approach_col is not None:
             terms = (*terms, ("c09_slotting", False))
         return RowPredicate(equals=terms)
     if key == "sl_slotting":
         if approach_col is None:
             return None
-        return RowPredicate(
-            equals=(("reporting_class_origin", "specialised_lending"), ("c09_slotting", True))
-        )
+        return RowPredicate(equals=((basis_col, "specialised_lending"), ("c09_slotting", True)))
     if key == "corporate_sme":
-        return _conjoin(_class_union(*_CORPORATE_FAMILY), ("c09_sme", True))
+        return _conjoin(_class_union(*_CORPORATE_FAMILY, col=basis_col), ("c09_sme", True))
     if key == "corporate_fse_large":
-        return _conjoin(_class_union(*_CORPORATE_FAMILY), ("cp_apply_fi_scalar", True))
+        return _conjoin(
+            _class_union(*_CORPORATE_FAMILY, col=basis_col), ("cp_apply_fi_scalar", True)
+        )
     if key == "corporate_non_sme":
-        return _conjoin(_class_union(*_CORPORATE_FAMILY), ("c09_corp_non_sme", True))
+        return _conjoin(_class_union(*_CORPORATE_FAMILY, col=basis_col), ("c09_corp_non_sme", True))
     if key == "retail":
-        return _class_union("retail_mortgage", "retail_qrre", "retail_other")
+        return _class_union("retail_mortgage", "retail_qrre", "retail_other", col=basis_col)
     if key in ("retail_mortgage_sme", "retail_mortgage_non_sme"):
         flag = "c09_sme" if key == "retail_mortgage_sme" else "c09_non_sme"
-        return RowPredicate(equals=(("reporting_class_origin", "retail_mortgage"), (flag, True)))
+        return RowPredicate(equals=((basis_col, "retail_mortgage"), (flag, True)))
     if key in ("retail_other_sme", "retail_other_non_sme"):
         flag = "c09_sme" if key == "retail_other_sme" else "c09_non_sme"
-        return RowPredicate(equals=(("reporting_class_origin", "retail_other"), (flag, True)))
+        return RowPredicate(equals=((basis_col, "retail_other"), (flag, True)))
     if key in _C09_02_RE_ROWS:
         ptypes, is_sme = _C09_02_RE_ROWS[key]
         terms = (
-            ("reporting_class_origin", "retail_mortgage"),
+            (basis_col, "retail_mortgage"),
             ("c09_sme" if is_sme else "c09_non_sme", True),
         )
         # The retired code skips the property filter when the column is
@@ -760,12 +786,30 @@ def _c09_02_spec(
     row_preds: dict[str, RowPredicate | None] = {}
     cells: dict[tuple[str, str], CellSpec] = {}
     for row_def in row_defs:
-        pred = _c09_02_row_pred(row_def, cols, approach_col)
-        row_preds[row_def.ref] = pred
-        if pred is None:
+        # Annex II §3.4 ¶87 splits this template by COLUMN, so each row carries
+        # TWO predicates. ``pred`` is the IMMEDIATE obligor (origin class, origin
+        # population) for the original-exposure and provisions columns;
+        # ``post_pred`` is the ULTIMATE obligor (post class, post population) for
+        # exposure value and RWEA. Each is narrowed to its own population, or a
+        # leg that left the IRB book post-substitution would leak into the
+        # origin-keyed columns — the C 09.01 prototype measured that leak at a
+        # 61% inflation of the original-exposure column.
+        pred = _narrow_opt(
+            _c09_02_row_pred(row_def, cols, approach_col, "reporting_class_origin"),
+            (_C09_BASIS.pop_origin, True),
+        )
+        post_pred = _narrow_opt(
+            _c09_02_row_pred(row_def, cols, approach_col, _POST_CLASS_COL),
+            (_C09_BASIS.pop_post, True),
+        )
+        # The all-null post-pass must count the UNION: keying it on the origin
+        # basis alone nulls the very rows the post columns exist to populate.
+        row_preds[row_def.ref] = _either_pred(pred, post_pred)
+        if pred is None or post_pred is None:
             continue
         ref = row_def.ref
         def_pred = _conjoin(pred, ("c09_defaulted", True))
+        post_def_pred = _conjoin(post_pred, ("c09_defaulted", True))
         cells[(ref, "0010")] = _bind_or_null(gross_pre_ccf, pred)
         if gross_pre_ccf is not None:
             # 0030 "Of which defaulted" is the ORIGINAL exposure value of the
@@ -778,21 +822,26 @@ def _c09_02_spec(
         cells[(ref, "0080")] = _wavg_or_null(pd_col, ead_col, pred)
         cells[(ref, "0090")] = _wavg_or_null(lgd_col, ead_col, pred)
         cells[(ref, "0100")] = _wavg_or_null(lgd_col, ead_col, def_pred)
-        cells[(ref, "0105")] = _sum_or_null(ead_col, pred)
+        # ¶87 ULTIMATE-obligor columns: exposure value and RWEA, plus the CRR
+        # supporting-factor adjustments that must foot against 0125. The PD/LGD
+        # averages (0080/0090/0100) and expected loss (0130) stay on the
+        # IMMEDIATE obligor — ¶87 names only the two quantities below, and a
+        # risk parameter is a property of the obligor whose book the row is.
+        cells[(ref, "0105")] = _sum_or_null(ead_col, post_pred)
         if "0107" in column_refs and ead_col is not None:
-            cells[(ref, "0107")] = CellSpec(Sum(ead_col), predicate=def_pred)
+            cells[(ref, "0107")] = CellSpec(Sum(ead_col), predicate=post_def_pred)
         if "0110" in column_refs:
-            cells[(ref, "0110")] = _sum_or_null(rwa_pre_col, pred)
+            cells[(ref, "0110")] = _sum_or_null(rwa_pre_col, post_pred)
         if rwa_col is not None:
-            cells[(ref, "0120")] = CellSpec(Sum(rwa_col), predicate=def_pred)
+            cells[(ref, "0120")] = CellSpec(Sum(rwa_col), predicate=post_def_pred)
         if "0121" in column_refs:
             cells[(ref, "0121")] = _c09_sf_adjustment_cell(
-                pred, cols, "sme_supporting_factor_applied", "is_sme"
+                post_pred, cols, "sme_supporting_factor_applied", "is_sme"
             )
             cells[(ref, "0122")] = _c09_sf_adjustment_cell(
-                pred, cols, "infrastructure_factor_applied", "is_infrastructure"
+                post_pred, cols, "infrastructure_factor_applied", "is_infrastructure"
             )
-        cells[(ref, "0125")] = _sum_or_null(rwa_col, pred)
+        cells[(ref, "0125")] = _sum_or_null(rwa_col, post_pred)
         cells[(ref, "0130")] = CellSpec(Sum("expected_loss"), predicate=pred)
     spec = TemplateSpec(
         name="c09_02", rows=rows, column_refs=column_refs, cells=cells, empty_cell="zero"
@@ -889,10 +938,10 @@ def _render_sheet(
     all-null inert/empty rows, an optional value-dependent ``post`` step
     (C 09.02's unweighted-mean fallback), and the Annex II §1.3 "(-)" negation."""
     frame = execute(spec, country_df)
-    frame = _null_empty_rows(frame, country_df, row_preds)
+    frame = null_empty_rows(frame, country_df, row_preds)
     if post is not None:
         frame = post(frame, country_df)
-    return _negate_deduction_cols(frame)
+    return negate_deduction_cols(frame, _C09_NEGATIVE_COLS)
 
 
 def _class_union(*classes: str, col: str = "reporting_class_origin") -> RowPredicate:
@@ -940,6 +989,11 @@ def _narrow(pred: RowPredicate, *terms: tuple[str, str | bool]) -> RowPredicate:
     class-union) predicate, preserving its any_of limbs (the variadic
     ``_conjoin`` used by the RE sub-row predicates)."""
     return RowPredicate(equals=(*pred.equals, *terms), any_of=pred.any_of)
+
+
+def _narrow_opt(pred: RowPredicate | None, term: tuple[str, str | bool]) -> RowPredicate | None:
+    """``_narrow`` for a predicate the row cascade may decline to build."""
+    return None if pred is None else _narrow(pred, term)
 
 
 def _sum_or_null(col: str | None, pred: RowPredicate) -> CellSpec:
@@ -1048,36 +1102,6 @@ def _defaulted_expr(cols: set[str]) -> pl.Expr:
     return pl.lit(value=False)
 
 
-def _null_empty_rows(
-    frame: pl.DataFrame,
-    country_df: pl.DataFrame,
-    row_preds: Mapping[str, RowPredicate | None],
-) -> pl.DataFrame:
-    """Render dead rows (no predicate) and empty class subsets ALL-NULL —
-    the Total row (no equals/any_of terms) is never nulled."""
-    constrained = {
-        ref: pred
-        for ref, pred in row_preds.items()
-        if pred is not None and (pred.equals or pred.any_of)
-    }
-    counts = matched_counts(country_df, constrained)
-    null_refs = [
-        ref
-        for ref, pred in row_preds.items()
-        if pred is None or ((pred.equals or pred.any_of) and counts[ref] == 0)
-    ]
-    if not null_refs:
-        return frame
-    value_cols = [col for col in frame.columns if col not in ("row_ref", "row_name")]
-    return frame.with_columns(
-        pl.when(pl.col("row_ref").is_in(null_refs))
-        .then(pl.lit(None, dtype=pl.Float64))
-        .otherwise(pl.col(col))
-        .alias(col)
-        for col in value_cols
-    )
-
-
 def _apply_overrides(
     frame: pl.DataFrame, overrides: dict[str, dict[str, float | None]]
 ) -> pl.DataFrame:
@@ -1104,25 +1128,3 @@ def _apply_overrides(
 def _mean_or_none(series: pl.Series) -> float | None:
     vals = series.drop_nulls()
     return float(cast("float", vals.mean())) if len(vals) > 0 else None
-
-
-def _negate_deduction_cols(frame: pl.DataFrame) -> pl.DataFrame:
-    """COREP Annex II §1.3: emit the CRR "(-)"-labelled supporting-factor
-    adjustment columns as negative figures (after the pre/post pair captured the
-    positive magnitudes). Intersected with the frame's columns, so it is an
-    absent-column no-op on B31 sheets. Identical expression to C 07.00 /
-    C 08.01's negation pass: a zero deduction is normalised to +0.0, null stays
-    null."""
-    targets = [col for col in frame.columns if col in _C09_NEGATIVE_COLS]
-    if not targets:
-        return frame
-    return frame.with_columns(_negate_expr(col) for col in targets)
-
-
-def _negate_expr(col: str) -> pl.Expr:
-    """Negate a "(-)"-labelled deduction column, normalising a zero to +0.0.
-
-    Plain ``-pl.col(col)`` flips the IEEE sign bit, so a ``0.0`` cell would
-    serialise as ``-0.0``; the explicit zero branch keeps a zero deduction as
-    ``+0.0``. Null stays null."""
-    return pl.when(pl.col(col) == 0.0).then(pl.lit(0.0)).otherwise(-pl.col(col)).alias(col)

--- a/src/rwa_calc/reporting/corep/c09.py
+++ b/src/rwa_calc/reporting/corep/c09.py
@@ -8,25 +8,69 @@ Pipeline position:
 
 Cell semantics (recorded decisions, this slice):
 
-- C 09.01's PRIMARY columns key the APPLIED Art. 112 class
+- BOTH templates split BY COLUMN on the basis Annex II §3.4 ¶87 names.
+  ¶86: "This concept can be applied on an immediate-obligor basis and on
+  an ultimate-risk basis. Hence, CRM techniques with substitution effects
+  can change the allocation of an exposure to a country." ¶87: "Data
+  regarding 'original exposure pre-conversion factors' shall be reported
+  referring to the country of residence of the IMMEDIATE obligor. Data
+  regarding 'exposure value' and 'Risk-weighted exposure amounts' shall be
+  reported as of the country of residence of the ULTIMATE obligor." So the
+  pre-conversion original exposure and the provisions columns (C 09.01
+  0010/0020/0050/0055, C 09.02 0010/0030/0050/0055) key the IMMEDIATE
+  obligor and the exposure-value / RWEA columns (C 09.01 0075/0080/0081/
+  0082/0090, C 09.02 0105/0107/0110/0120/0121/0122/0125) key the ULTIMATE
+  one — on BOTH axes at once, the row (class) and the sheet (country),
+  since a beneficial substitution moves both together. Each cell carries
+  its own population flag, its own class key and its own country flag;
+  widening the frame to both populations WITHOUT that per-cell
+  discrimination is the measured failure mode (a prototype inflated
+  C 09.01 col 0010 by 61% and broke the row-0170 total).
+- C 09.01's IMMEDIATE-obligor columns key the APPLIED Art. 112 class
   (``reporting_class_origin`` — recorded fix 2026-07-12: the Annex II
   instructions define them "same as the CR SA template", so a defaulted
   SA exposure moves to row 0100 exactly as C 07.00 assigns it), while the
   0020 "Defaulted exposures" MEMORANDUM keys the raw ORIGINAL class (the
-  instruction's counterfactual "would have been" row) — a two-basis
-  template like Pillar 3 CR4. C 09.02 keys the sealed
-  ``reporting_class_origin`` (== raw ``exposure_class`` for the IRB
-  book — number-neutral convergence; the IRB template has no default
-  row by design) over the ``reporting_approach_origin`` population.
+  instruction's counterfactual "would have been" row) — a THREE-predicate
+  row, since the ULTIMATE-obligor columns key the sealed
+  ``reporting_class`` over the post-substitution population as well.
+  C 09.02 keys the same pair over the ``reporting_approach_origin`` /
+  ``reporting_approach`` IRB books (its origin key == raw
+  ``exposure_class`` for that book — number-neutral convergence; the IRB
+  template has no default row by design).
+  The rows 0071-0073 SA specialised-lending "of which" cells take one
+  extra POST-basis-only term: a covered part substituted onto a provider's
+  risk weight stops applying its own Art. 122B treatment and leaves those
+  rows, exactly as C 07.00's rows 0021-0026 do (``_SL_OWN_RW_COL``).
   Under B31 the RE reporting classes (retail_mortgage /
   residential_mortgage / commercial_mortgage — the Art. 124A standalone
   RE class plus the loan-splitter's secured legs) key the "Real estate
   exposures" row 0090 and its regulatory-RRE / regulatory-CRE / other-RE
   / ADC / SME "of which" sub-rows (0091-0095); the SA specialised-lending
   "of which" sub-rows (0071-0073) key sl_type (rectification R7).
-- C 09.01 shares C 07.00's population (``c07_population`` — the SA book
-  plus BOTH counterparty-credit-risk populations: FCCM SFT synthetic rows
-  and SA-CCR derivative netting sets, admitted by ``risk_type``). That
+- The COUNTRY axis is the SAME two-basis machinery as the class axis, run
+  on the country as the sheet key (``_GEO_BASIS`` over
+  ``kernel/bases.py::sheet_axis`` / ``sheet_frame``). A beneficially
+  guaranteed cross-border leg therefore sits on TWO country sheets at
+  once: its obligor's, reporting the pre-conversion original exposure, and
+  its guarantor's, reporting the exposure value and RWEA. The keys are the
+  sealed ``reporting_country`` / ``reporting_country_origin`` twins
+  (aggregator ``_add_reporting_projection``, gated identically to the
+  class twin — a DECLINED guarantee moves neither), degrading to the raw
+  ``cp_country_code`` on a frame that seals neither. ``TOTAL`` is the
+  all-geographies sheet and carries every leg on both geographical flags;
+  a null country still partitions into no country sheet.
+- C 09.01 shares C 07.00's population (``c07_population(both_bases=True)``
+  — the SA book on the OBLIGOR's approach unioned with the SA book on the
+  post-substitution approach, plus BOTH counterparty-credit-risk
+  populations: FCCM SFT synthetic rows and SA-CCR derivative netting sets,
+  admitted by ``risk_type``). The post limb is what carries an IRB-origin
+  leg guaranteed by an SA protection provider onto this template — its
+  exposure value and RWEA belong on the guarantor's class under Art. 235,
+  which is where C 07.00's col 0100 already routes its inflow, and the
+  cross-template rules v5746_q-v5772_q / boe_b0191-b0224 tie C 09.01's
+  ¶87 columns straight to C 07.00's own post-substitution cols
+  0200/0215/0220. That
   shared population is why the Basel 3.1 institution row is now populated:
   the derivative netting sets used to be dropped by the
   ``standardised_ccr`` output-floor relabel and never reached either
@@ -104,17 +148,20 @@ Cell semantics (recorded decisions, this slice):
   No provision_held fallback ladder on either template; provisions are the
   (unsealed) SCRA/GCRA carriers.
 - Lineage-instrumented (R25): ``c09_01_plans`` / ``c09_02_plans`` expose the
-  per-COUNTRY execution plans (``TOTAL`` first, then one sheet per sorted non-null
-  ``cp_country_code``), sharing ``_c09_01_prepared`` / ``_c09_02_prepared`` +
+  per-COUNTRY execution plans (``TOTAL`` first, then one sheet per sorted country
+  key contributed by EITHER basis), sharing ``_c09_01_prepared`` /
+  ``_c09_02_prepared`` +
   ``_country_frames`` with the reported generators so a cell's plan and its
   reported value key identically. Both pass ``_C09_NEGATIVE_COLS`` explicitly —
   the first C 09-family sign-aware sweep, so the CRR supporting-factor adjustment
   columns (0081/0082, 0121/0122) reconcile against their legs' positive
-  magnitudes. The two-basis C 09.01 row model drills correctly: a PRIMARY cell
-  (e.g. 0010/0090) runs the APPLIED-class predicate (``reporting_class_origin``)
-  while the 0020 defaulted MEMO runs the ORIGINAL-class predicate
-  (``exposure_class`` + defaulted), so on a defaulted leg whose applied class
-  moved the two cells drill different legs. C 09.02's ``_c09_02_avg_postfix`` is a
+  magnitudes. The multi-basis C 09.01 row model drills correctly: an
+  IMMEDIATE-obligor cell (0010) runs the APPLIED-class predicate
+  (``reporting_class_origin``), the 0020 defaulted MEMO runs the ORIGINAL-class
+  predicate (``exposure_class`` + defaulted) and an ULTIMATE-obligor cell
+  (0075/0090) runs the post-substitution predicate (``reporting_class``), so on
+  a defaulted or a guaranteed leg the three cells of one row drill different
+  legs. C 09.02's ``_c09_02_avg_postfix`` is a
   value-dependent GENERATE post-step (an unweighted-mean fallback when a subset's
   total EAD is non-positive) on the reported frame the drill-down reads: it does
   not change a cell's legs (the same subset feeds the WeightedAvg or its
@@ -125,7 +172,9 @@ Cell semantics (recorded decisions, this slice):
 
 References:
 - Regulation (EU) 2021/451, Annex I/II (C 09.01 / C 09.02)
-- PRA PS1/26 Annex I/II (OF 09.01 / OF 09.02); CRR Art. 112 / Art. 147
+- PRA PS1/26 Annex I/II (OF 09.01 / OF 09.02), §3.4 ¶86/¶87 — the
+  immediate-obligor / ultimate-obligor column basis; CRR Art. 112 / Art. 147
+- CRR Art. 235 (risk-weight substitution) — what moves the class AND the country
 - docs/plans/phase7-declarative-reporting.md §3.2/§6 (S8)
 """
 
@@ -156,7 +205,7 @@ from rwa_calc.reporting.corep.templates import (
     get_c09_02_columns,
     get_c09_02_rows,
 )
-from rwa_calc.reporting.kernel import TwoBasis, pick, population_flags
+from rwa_calc.reporting.kernel import TwoBasis, pick, population_flags, sheet_axis, sheet_frame
 from rwa_calc.reporting.metadata import ReportingContext
 from rwa_calc.reporting.plans import SheetPlan
 
@@ -178,8 +227,31 @@ _IRB_APPROACHES: tuple[str, ...] = ("foundation_irb", "advanced_irb", "slotting"
 # says so outright ("CRM techniques with substitution effects can change the
 # allocation of an exposure to a country").
 _C09_BASIS: TwoBasis = TwoBasis("c09")
+# C 09.01's population flags, materialised by ``c07_population(both_bases=True)``
+# under C 07.00's own namespace — C 09.01 IS a geographical cut of that
+# population, so it must read the same two membership flags rather than
+# re-deriving them (an SA-guarantor leg whose obligor is IRB is in the POST
+# population only, and is exactly what the ¶87 columns exist to report).
+_C07_BASIS: TwoBasis = TwoBasis("c07")
 # The sealed post-substitution class twin (the ULTIMATE obligor of ¶87).
 _POST_CLASS_COL: str = "reporting_class"
+
+# The per-COUNTRY sheet axis, run on the SAME two-basis machinery as the class
+# axis (``kernel/bases.py``) — a country IS the sheet key here. ¶86 states it
+# outright: "CRM techniques with substitution effects can change the allocation
+# of an exposure to a country", so a beneficially guaranteed leg sits on TWO
+# country sheets at once (its obligor's for the pre-conversion original
+# exposure, its guarantor's for the exposure value and RWEA) exactly as it sits
+# on two class sheets. The keys are the sealed ``reporting_country`` twins,
+# degrading to the raw ``cp_country_code`` on a frame that seals neither, which
+# is what keeps the split number-neutral on a book that never substitutes across
+# a border.
+_GEO_BASIS: TwoBasis = TwoBasis("c09_geo")
+_COUNTRY_ORIGIN_COL: str = "reporting_country_origin"
+_COUNTRY_POST_COL: str = "reporting_country"
+#: The raw per-exposure country the sealed twins are derived from, and the
+#: fallback both keys degrade to on a synthetic frame that seals neither.
+_RAW_COUNTRY_COL: str = "cp_country_code"
 
 # C 09.02 row keys that map directly to a single exposure_class value.
 _C09_02_DIRECT_EC: frozenset[str] = frozenset(
@@ -260,6 +332,26 @@ _C09_01_SL_TYPE_MAP: dict[str, str] = {
     "sl_project_finance": "project_finance",
 }
 
+# The CRM decline flag on the sealed ledger (``inject=False``, so it is simply
+# absent on a run with no guarantee sub-step), and the derived "does this leg
+# still apply its OWN Art. 122B risk weight?" gate it drives.
+#
+# ``sl_type`` is the OBLIGOR's characteristic and the CRM split never reassigns
+# it, so a covered part substituted onto a protection provider's risk weight
+# carries the obligor's ``sl_type`` into the post-basis columns. Annex II admits
+# an exposure to a specialised-lending "of which" row on THREE conjunctive
+# conditions, the third being the applied risk weight ("apply the risk weight
+# treatment in accordance with Articles 122B(2)(c) or 122B(4)" — PS1/26 Annex II
+# p.89), and ¶43 says the substitution effect "shall reflect the risk weighting
+# treatment effectively applicable to the covered part of the exposure". The
+# covered part applies the PROVIDER's Art. 122 weight, so it fails that third
+# condition and belongs in none of rows 0071-0073. This is C 07.00's own
+# ``_SL_OWN_RW_COL`` gate (rows 0021-0026), applied to the geographical twin of
+# the rows it protects — the two must agree or the cross-template rules
+# (boe_b0975 / boe_b0977) break in whichever direction only one of them moved.
+_BENEFICIAL_COL: str = "is_guarantee_beneficial"
+_SL_OWN_RW_COL: str = "c09_sl_own_rw"
+
 # COREP Annex II §1.3 "(-)"-labelled deduction columns, negated post-execute:
 # the CRR-only SME / Infrastructure supporting-factor adjustment columns on
 # C 09.01 (0081/0082) and C 09.02 (0121/0122). Reported negative so the pre-SF
@@ -334,10 +426,11 @@ def _c09_01_prepared(
     reported frames) so both run the SAME predicate over the SAME prepared frame.
     Returns ``None`` (preserving the generator's error contract) when a required
     column is missing or the C 07.00 population is empty. ``row_preds`` carries
-    each row's COMBINED two-basis emptiness predicate (the ``_either_pred`` of the
-    applied-class primary and the original-class 0020 memo) — an ``any_of`` union
-    that ``SheetPlan.row_terms`` cannot express, so the generate post-passes read
-    it from here rather than the plan."""
+    each row's COMBINED emptiness predicate — the ``_either_pred`` union of the
+    immediate-obligor primary, the original-class 0020 memo and the
+    ultimate-obligor post predicate — an ``any_of`` union that
+    ``SheetPlan.row_terms`` cannot express, so the generate post-passes read it
+    from here rather than the plan."""
     if pick(cols, "exposure_class") is None:
         errors.append("C09.01: Missing required column (exposure_class)")
         return None
@@ -346,12 +439,13 @@ def _c09_01_prepared(
             "C09.01: Missing cp_country_code column — cannot produce geographical breakdown"
         )
         return None
-    sa_df = c07_population(results, cols).collect()
+    sa_df = c07_population(results, cols, both_bases=True).collect()
     if sa_df.height == 0:
         return None
     sa_cols = set(sa_df.columns)
     rwa_col = pick(sa_cols, "rwa_final", "rwa")
     data = sa_df.with_columns(_c09_01_derived_exprs(sa_cols, rwa_col))
+    data = data.with_columns(_geo_keys(sa_cols, _C07_BASIS))
     spec, row_preds = _c09_01_spec(set(data.columns), framework, rwa_col)
     return data, spec, row_preds
 
@@ -364,9 +458,10 @@ def c09_01_plans(
 ) -> dict[str, SheetPlan]:
     """Build the per-COUNTRY C 09.01 / OF 09.01 execution plans for lineage.
 
-    Keys the per-country plans on the sealed ``cp_country_code`` (``TOTAL`` first,
-    the whole population, then one sheet per sorted non-null country) over the
-    SHARED C 07.00 population — the standardised book plus BOTH counterparty-
+    Keys the per-country plans on the sealed ``reporting_country`` twins
+    (``TOTAL`` first, the whole population, then one sheet per sorted country
+    contributed by EITHER basis — §3.4 ¶86/¶87) over the SHARED C 07.00
+    population on BOTH bases — the standardised book plus BOTH counterparty-
     credit-risk populations (FCCM SFT rows and SA-CCR derivative netting sets),
     admitted by ``risk_type``. Every country plan shares the one framework spec
     (the row-selection differs only by the country frame). Passes
@@ -426,6 +521,16 @@ def _c09_01_derived_exprs(cols: set[str], rwa_col: str | None) -> list[pl.Expr]:
     ]
     if "is_qualifying_re" in cols:
         exprs.append(pl.col("is_qualifying_re").fill_null(value=True).alias("c09_re_qualifying"))
+    if _BENEFICIAL_COL in cols:
+        # The post-basis specialised-lending gate (see _SL_OWN_RW_COL), read the
+        # same null-safe way C 07.00 reads it: an unknown benefit is not a
+        # substitution, so the leg keeps applying its own Art. 122B weight.
+        exprs.append(
+            (pl.col(_BENEFICIAL_COL) == True)  # noqa: E712 - null-safe, see _SL_OWN_RW_COL
+            .fill_null(value=False)
+            .not_()
+            .alias(_SL_OWN_RW_COL)
+        )
     if {"exposure_type", "reporting_gross_drawn", "reporting_gross_undrawn"} <= cols:
         exprs.append(
             pl.when(
@@ -480,6 +585,40 @@ def _c09_01_row_pred(row_def: COREPRow, basis_col: str) -> RowPredicate | None:
     return union if parent is None else _narrow(union, ("c09_sme", True))
 
 
+def _post_class_col(cols: set[str]) -> str:
+    """The ¶87 ULTIMATE-obligor class key, DEGRADING to the origin twin.
+
+    ``kernel/bases.py::class_keys``'s rule applied to a CELL key rather than a
+    sheet key, and it is load-bearing for exactly the reason recorded there: the
+    post-basis terms compile to presence-TOLERANT ``equals``, so on a frame that
+    seals no ``reporting_class`` a hardcoded name yields an EMPTY subset and
+    silently zeroes every exposure-value and RWEA cell on the template. Every
+    synthetic unit frame in the COREP estate is such a frame. Degrading instead
+    makes those frames report the same class under both bases — the split is
+    number-neutral wherever nothing substitutes, which is the whole basis on
+    which it is safe to apply it estate-wide.
+    """
+    return _POST_CLASS_COL if _POST_CLASS_COL in cols else "reporting_class_origin"
+
+
+def _post_sl_gate(row_def: COREPRow, cols: set[str]) -> tuple[tuple[str, str | bool], ...]:
+    """The POST-basis-only narrowing of the specialised-lending rows 0071-0073.
+
+    Those rows key ``sl_type`` alone, which the CRM split leaves on the covered
+    part, so on the post basis they would report a leg that has stopped applying
+    its own Art. 122B risk weight — see ``_SL_OWN_RW_COL`` for the Annex II
+    basis and C 07.00's ``_post_sl_terms`` for the row-0021-0026 twin of this.
+
+    Empty when no substitution gate is sealed: the frame then carries no
+    beneficially-substituted leg to exclude, and a presence-tolerant term on an
+    underived column would zero the SL rows of every synthetic unit frame.
+    """
+    key = row_def.exposure_class_value
+    if key not in _C09_01_SL_TYPE_MAP or _BENEFICIAL_COL not in cols:
+        return ()
+    return ((_SL_OWN_RW_COL, True),)
+
+
 def _c09_01_re_sl_pred(key: str, basis_col: str) -> RowPredicate | None:
     """The B31-only real-estate (rows 0090-0095) and SA specialised-lending
     (rows 0071-0073) predicates — the retired reverse-map short-circuited these
@@ -518,15 +657,38 @@ def _c09_01_spec(
     rows = tuple(_Row(row_def.ref, row_def.name) for row_def in row_defs)
     row_preds: dict[str, RowPredicate | None] = {}
     cells: dict[tuple[str, str], CellSpec] = {}
+    origin_terms = _basis_terms(_C07_BASIS.pop_origin, _GEO_BASIS.basis_origin)
+    post_terms = _basis_terms(_C07_BASIS.pop_post, _GEO_BASIS.basis_post)
     for row_def in row_defs:
-        # Primary columns: the APPLIED Art. 112 class (the sealed obligor
-        # applied ladder — defaulted exposures sit in row 0100, as C 07.00).
-        pred = _c09_01_row_pred(row_def, "reporting_class_origin")
+        # Annex II §3.4 ¶87 splits this template BY COLUMN, so each row carries
+        # TWO class predicates plus the 0020 memo's third. ``pred`` is the
+        # IMMEDIATE obligor (origin class over the origin population, on the
+        # obligor's country sheet) for the pre-conversion original exposure and
+        # the provisions columns; ``post_pred`` is the ULTIMATE obligor (the
+        # sealed post-substitution class over the post population, on the
+        # guarantor's country sheet) for the exposure value and the RWEA.
+        #
+        # EVERY predicate carries its OWN population and country flags. Widening
+        # the frame to both populations without that per-ROW discrimination is
+        # the measured failure mode: an origin-keyed cell silently absorbs the
+        # post-only legs (a prototype inflated col 0010 by 61% and broke the
+        # row-0170 total by 4,900,000 that way).
+        pred = _narrow_opt(_c09_01_row_pred(row_def, "reporting_class_origin"), *origin_terms)
         # 0020 memo: the raw ORIGINAL class + defaulted (the counterfactual
-        # "would have been" row of the instruction).
-        memo_pred = _c09_01_row_pred(row_def, "exposure_class")
-        row_preds[row_def.ref] = _either_pred(pred, memo_pred)
-        if pred is None:
+        # "would have been" row of the instruction) — an ORIGIN-basis column,
+        # so it takes the origin population and the obligor's country.
+        memo_pred = _narrow_opt(_c09_01_row_pred(row_def, "exposure_class"), *origin_terms)
+        post_pred = _narrow_opt(
+            _c09_01_row_pred(row_def, _post_class_col(cols)),
+            *post_terms,
+            *_post_sl_gate(row_def, cols),
+        )
+        # The all-null post-pass counts the UNION of all three: keyed on the
+        # origin basis alone it nulls the very rows the post columns exist to
+        # publish (an inflow-only sheet — CGCB here — has no origin-basis leg at
+        # all, yet must report the exposure value and RWEA that arrived on it).
+        row_preds[row_def.ref] = _either_pred(_either_pred(pred, memo_pred), post_pred)
+        if pred is None or post_pred is None:
             continue
         ref = row_def.ref
         cells[(ref, "0010")] = _bind_or_null(gross_pre_ccf, pred)
@@ -543,16 +705,23 @@ def _c09_01_spec(
         cells[(ref, "0055")] = CellSpec(Sum("scra_provision_amount"), predicate=pred)
         for null_ref in ("0040", "0060", "0061", "0070"):
             cells[(ref, null_ref)] = CellSpec(Formula(refs=(), fn=_const(None)))
-        cells[(ref, "0075")] = _sum_or_null(ead_col, pred)
+        # ¶87 ULTIMATE-obligor columns: the exposure value (0075) and the RWEA
+        # (0080/0090), plus the CRR supporting-factor adjustments that must foot
+        # 0080 + 0081 + 0082 = 0090. These are the columns v5746_q-v5772_q /
+        # boe_b0191-b0224 tie to C 07.00's own post-substitution cols
+        # 0200/0215/0220, so leaving them on the origin basis asserted that the
+        # covered part had left the obligor's class on one template and stayed
+        # on the other.
+        cells[(ref, "0075")] = _sum_or_null(ead_col, post_pred)
         if "0080" in column_refs:
-            cells[(ref, "0080")] = _sum_or_null(rwa_pre_col, pred)
+            cells[(ref, "0080")] = _sum_or_null(rwa_pre_col, post_pred)
             cells[(ref, "0081")] = _c09_sf_adjustment_cell(
-                pred, cols, "sme_supporting_factor_applied", "is_sme"
+                post_pred, cols, "sme_supporting_factor_applied", "is_sme"
             )
             cells[(ref, "0082")] = _c09_sf_adjustment_cell(
-                pred, cols, "infrastructure_factor_applied", "is_infrastructure"
+                post_pred, cols, "infrastructure_factor_applied", "is_infrastructure"
             )
-        cells[(ref, "0090")] = _sum_or_null(rwa_col, pred)
+        cells[(ref, "0090")] = _sum_or_null(rwa_col, post_pred)
     spec = TemplateSpec(
         name="c09_01", rows=rows, column_refs=column_refs, cells=cells, empty_cell="zero"
     )
@@ -574,10 +743,12 @@ def _c09_02_prepared(
 
     Shared by ``c09_02_plans`` and ``generate_c09_02``. Returns ``None``
     (preserving the error contract) when a required column is missing or the IRB
-    population is empty. Keys the sealed ``reporting_class_origin`` over the
-    ``reporting_approach_origin`` IRB book INCLUDING slotting (slotting stays IN
-    the population). The spec is built cols-aware from the ORIGINAL sealed set
-    (derived discriminators are bound by name for the executor)."""
+    population is empty. Keys the sealed ``reporting_class_origin`` /
+    ``reporting_class`` pair and the ``reporting_country`` pair over the
+    ``reporting_approach_origin`` / ``reporting_approach`` IRB books INCLUDING
+    slotting (slotting stays IN the population). The spec is built cols-aware
+    from the ORIGINAL sealed set (derived discriminators are bound by name for
+    the executor)."""
     if pick(cols, "exposure_class") is None:
         errors.append("C09.02: Missing required column (exposure_class)")
         return None
@@ -592,6 +763,7 @@ def _c09_02_prepared(
     approach_col = pick(cols, "reporting_approach_origin", "approach")
     rwa_col = pick(cols, "rwa_final", "rwa")
     data = _c09_02_prepare(irb_df, cols, approach_col, rwa_col)
+    data = data.with_columns(_geo_keys(set(irb_df.columns), _C09_BASIS))
     spec, row_preds = _c09_02_spec(cols, framework, approach_col, rwa_col)
     return data, spec, row_preds
 
@@ -604,8 +776,9 @@ def c09_02_plans(
 ) -> dict[str, SheetPlan]:
     """Build the per-COUNTRY C 09.02 / OF 09.02 execution plans for lineage.
 
-    Keys the per-country plans on ``cp_country_code`` (``TOTAL`` first, then one
-    sheet per sorted non-null country) over the IRB book (F-IRB / A-IRB / slotting
+    Keys the per-country plans on the sealed ``reporting_country`` twins
+    (``TOTAL`` first, then one sheet per sorted country contributed by EITHER
+    basis — §3.4 ¶86/¶87) over the IRB book (F-IRB / A-IRB / slotting
     — slotting stays IN the population). Passes ``_C09_NEGATIVE_COLS`` explicitly
     so the CRR supporting-factor adjustment columns (0121/0122) reconcile with the
     sign convention. The value-dependent unweighted-mean fallback (see
@@ -793,14 +966,18 @@ def _c09_02_spec(
         # exposure value and RWEA. Each is narrowed to its own population, or a
         # leg that left the IRB book post-substitution would leak into the
         # origin-keyed columns — the C 09.01 prototype measured that leak at a
-        # 61% inflation of the original-exposure column.
+        # 61% inflation of the original-exposure column. Each also carries its
+        # own COUNTRY basis (¶86: substitution changes the allocation of an
+        # exposure to a country), so a cross-border guarantee moves the exposure
+        # value and RWEA onto the guarantor's sheet while the original exposure
+        # stays on the obligor's.
         pred = _narrow_opt(
             _c09_02_row_pred(row_def, cols, approach_col, "reporting_class_origin"),
-            (_C09_BASIS.pop_origin, True),
+            *_basis_terms(_C09_BASIS.pop_origin, _GEO_BASIS.basis_origin),
         )
         post_pred = _narrow_opt(
-            _c09_02_row_pred(row_def, cols, approach_col, _POST_CLASS_COL),
-            (_C09_BASIS.pop_post, True),
+            _c09_02_row_pred(row_def, cols, approach_col, _post_class_col(cols)),
+            *_basis_terms(_C09_BASIS.pop_post, _GEO_BASIS.basis_post),
         )
         # The all-null post-pass must count the UNION: keying it on the origin
         # basis alone nulls the very rows the post columns exist to populate.
@@ -892,22 +1069,55 @@ def _c09_02_avg_postfix(
 # =============================================================================
 
 
+def _geo_keys(cols: set[str], population: TwoBasis) -> list[pl.Expr]:
+    """The per-COUNTRY sheet keys, on the template's own population flags.
+
+    Materialises ``_GEO_BASIS`` — the country axis expressed in the same
+    ``TwoBasis`` vocabulary the class axis uses, so ``sheet_axis`` /
+    ``sheet_frame`` partition countries with no second implementation. The two
+    "class" keys are the sealed ``reporting_country`` twins and the two
+    population flags are ALIASES of the template's own (C 07.00's for C 09.01,
+    C 09.02's for itself), so a leg is on a country sheet only if it is in that
+    basis's population to begin with.
+
+    Both keys degrade to the raw ``cp_country_code`` on a frame that seals no
+    country twin (every synthetic unit frame in the COREP estate), which reports
+    the same country under both bases instead of emptying the ¶87 columns — the
+    same degradation rule ``kernel/bases.py::class_keys`` applies to the class
+    key, and for the same reason.
+    """
+    origin_col = _COUNTRY_ORIGIN_COL if _COUNTRY_ORIGIN_COL in cols else _RAW_COUNTRY_COL
+    post_col = _COUNTRY_POST_COL if _COUNTRY_POST_COL in cols else origin_col
+    return [
+        pl.col(population.pop_origin).alias(_GEO_BASIS.pop_origin),
+        pl.col(population.pop_post).alias(_GEO_BASIS.pop_post),
+        pl.col(origin_col).alias(_GEO_BASIS.class_origin),
+        pl.col(post_col).alias(_GEO_BASIS.class_post),
+    ]
+
+
 def _country_frames(data: pl.DataFrame) -> list[tuple[str, pl.DataFrame]]:
-    """The per-country (key, frame) split: TOTAL first (the whole population,
-    null-country rows included), then one frame per sorted distinct non-null
-    cp_country_code. Shared by the plans builder and the reported generator so a
-    cell's plan and its reported value are keyed identically."""
-    frames: list[tuple[str, pl.DataFrame]] = [("TOTAL", data)]
-    countries = (
-        data.select(pl.col("cp_country_code"))
-        .filter(pl.col("cp_country_code").is_not_null())
-        .unique()
-        .sort("cp_country_code")
-        .to_series()
-        .to_list()
+    """The per-country (key, frame) split, each frame tagged with its two bases.
+
+    ``TOTAL`` first — the whole population, null-country rows included, both
+    geographical flags True because every leg is in the all-geographies total on
+    the basis it belongs to (its population flag still discriminates). Then one
+    frame per sorted distinct country key contributed by EITHER basis, carrying
+    the legs on that country under either and tagging which — so the guarantor's
+    sheet gains the exposure value and RWEA of a leg whose original exposure
+    stays reported on the obligor's.
+
+    Shared by the plans builder and the reported generator so a cell's plan and
+    its reported value are keyed identically.
+    """
+    total = data.with_columns(
+        pl.lit(value=True).alias(_GEO_BASIS.basis_origin),
+        pl.lit(value=True).alias(_GEO_BASIS.basis_post),
     )
+    frames: list[tuple[str, pl.DataFrame]] = [("TOTAL", total)]
     frames.extend(
-        (country, data.filter(pl.col("cp_country_code") == country)) for country in countries
+        (country, sheet_frame(_GEO_BASIS, data, country))
+        for country in sorted(sheet_axis(_GEO_BASIS, data))
     )
     return frames
 
@@ -951,33 +1161,51 @@ def _class_union(*classes: str, col: str = "reporting_class_origin") -> RowPredi
 
 
 def _either_pred(primary: RowPredicate | None, memo: RowPredicate | None) -> RowPredicate | None:
-    """The row-emptiness basis for C 09.01: a row is null only when BOTH
-    its primary (applied-class) and memo (original-class) subsets are
-    empty — a class row whose only exposures defaulted keeps its 0020
-    memo while the primary columns move to row 0100.
+    """The row-emptiness basis: a row is null only when EVERY basis it publishes
+    a column on has an empty subset — a class row whose only exposures defaulted
+    keeps its 0020 memo while the primary columns move to row 0100, and an
+    inflow-only sheet's row keeps the exposure value and RWEA that arrived on it
+    while having no origin-basis leg at all.
 
-    An RE sub-row carries a basis-KEYED class union (any_of over
-    reporting_class_origin vs exposure_class) alongside basis-INDEPENDENT
-    discriminator terms (property_type / qualifying / ADC / SME in equals).
-    Those discriminators are shared across the two bases, so the combined
-    emptiness predicate keeps them (equals) and unions only the class limbs
-    (any_of) — dropping the discriminators here would wrongly un-null a
-    residential sub-row whenever any commercial RE existed."""
+    This is a true DISJUNCTION, computed by distributing each operand's shared
+    ``equals`` into its own ``any_of`` limbs (``RowPredicate`` forbids nesting an
+    ``any_of`` inside a limb, so a flat union is the only representable form).
+    Keeping one operand's ``equals`` at the top — the shape this had while both
+    operands were origin-basis and their ``equals`` therefore identical — silently
+    imposes the FIRST basis's population and country flags on the second's limbs,
+    which is precisely how the two-basis prototype nulled the row it had just
+    populated. An RE sub-row's basis-INDEPENDENT discriminators (property_type /
+    qualifying / ADC / SME) ride along inside every distributed limb, so a
+    residential sub-row still cannot be un-nulled by commercial RE.
+
+    An operand with no terms at all constrains nothing, so its union with
+    anything constrains nothing either (returned as the constraint-free
+    predicate, never as the other operand)."""
     if primary is None:
         return memo
     if memo is None:
         return primary
-    if primary.equals and (primary.any_of or memo.any_of):
-        return RowPredicate(equals=primary.equals, any_of=(*primary.any_of, *memo.any_of))
-    limbs: list[RowPredicate] = []
-    for pred in (primary, memo):
-        if pred.any_of:
-            limbs.extend(pred.any_of)
-        elif pred.equals:
-            limbs.append(RowPredicate(equals=pred.equals))
-    if not limbs:
+    if not _is_constrained(primary) or not _is_constrained(memo):
         return RowPredicate()
-    return RowPredicate(any_of=tuple(limbs))
+    limbs = [*_flat_limbs(primary), *_flat_limbs(memo)]
+    return limbs[0] if len(limbs) == 1 else RowPredicate(any_of=tuple(limbs))
+
+
+def _is_constrained(pred: RowPredicate) -> bool:
+    """Does this predicate select a strict subset? (The Total rows do not.)"""
+    return bool(pred.equals or pred.any_of)
+
+
+def _flat_limbs(pred: RowPredicate) -> list[RowPredicate]:
+    """``pred`` as a list of pure-conjunction limbs whose union is ``pred``.
+
+    Only the two fields the C 09 predicates ever populate (``equals`` /
+    ``any_of``) are carried — the sealed-column fields are unused on this
+    template, which keys its classes through presence-tolerant ``equals`` terms
+    so the two-basis class column can vary per cell."""
+    if not pred.any_of:
+        return [pred]
+    return [RowPredicate(equals=(*pred.equals, *limb.equals)) for limb in pred.any_of]
 
 
 def _conjoin(pred: RowPredicate, term: tuple[str, str | bool]) -> RowPredicate:
@@ -991,9 +1219,19 @@ def _narrow(pred: RowPredicate, *terms: tuple[str, str | bool]) -> RowPredicate:
     return RowPredicate(equals=(*pred.equals, *terms), any_of=pred.any_of)
 
 
-def _narrow_opt(pred: RowPredicate | None, term: tuple[str, str | bool]) -> RowPredicate | None:
+def _narrow_opt(pred: RowPredicate | None, *terms: tuple[str, str | bool]) -> RowPredicate | None:
     """``_narrow`` for a predicate the row cascade may decline to build."""
-    return None if pred is None else _narrow(pred, term)
+    return None if pred is None else _narrow(pred, *terms)
+
+
+def _basis_terms(population: str, geography: str) -> tuple[tuple[str, str | bool], ...]:
+    """The two flags that pin one cell to ONE basis: the template's population
+    membership on that basis, and the country sheet it keys on that basis.
+
+    Both are derived Boolean columns and both are always materialised on the
+    frames the executor sees, so they are read through the presence-TOLERANT
+    ``equals`` channel like every other derived discriminator here."""
+    return ((population, True), (geography, True))
 
 
 def _sum_or_null(col: str | None, pred: RowPredicate) -> CellSpec:

--- a/src/rwa_calc/reporting/corep/crm_substitution.py
+++ b/src/rwa_calc/reporting/corep/crm_substitution.py
@@ -259,8 +259,9 @@ def irb_origin_inflows(
     carrier on a declined leg, so the ``> 0`` filter below drops it. What entitles
     the covered part to the GUARANTOR's sheet is Art. 235 risk-weight substitution
     having FIRED; a positive ``guaranteed_portion`` only says protection was
-    ATTACHED. Recognition is permissive (Art. 213), so the calculators decline a
-    guarantee that would raise capital and leave the leg on the borrower basis
+    ATTACHED. Art. 193(1) bars a guarantee from RAISING the RWEA and Art. 193(3)
+    makes amending the calculation an election, so the calculators DECLINE such a
+    guarantee and leave the leg on the borrower basis
     (``is_guarantee_beneficial=False``). Booking an inflow for one of those
     published the BORROWER's risk weight on the guarantor's sheet, because the
     band split (:func:`_band_split`) reads ``risk_weight``, which on a declined
@@ -401,8 +402,15 @@ def _decline_gate(cols: set[str], magnitude: pl.Expr) -> pl.Expr:
     """Zero a protection magnitude where the engine DECLINED the guarantee.
 
     A guarantee the engine DECLINED (``is_guarantee_beneficial`` false/null — it
-    would have RAISED capital, CRR Art. 213) produces NO substitution effect: the
-    RWA stays on the borrower basis. Annex II heads this block "CRM TECHNIQUES
+    would have RAISED capital, which CRR Art. 193(1) forbids) produces NO
+    substitution effect: the RWA stays on the borrower basis. This gate moves no
+    RWA itself; what it reports is the DECLINE MECHANISM, not merely the
+    Art. 193(1) outcome — an apply-and-cap implementation reaches the same
+    capital under CRR and WOULD book these flows, so this gate is correct only
+    because the calculators decline. That election and the CRR-conditionality of
+    its capital-neutrality are recorded on
+    ``engine/sa/rw_adjustments.py::apply_guarantee_substitution``.
+    Annex II heads this block "CRM TECHNIQUES
     WITH SUBSTITUTION EFFECTS ON THE EXPOSURE", so a declined guarantee does not
     belong in it, and reporting one booked a phantom outflow against a phantom
     inflow. Gating the carrier here gates BOTH sides at once — the substitution
@@ -510,9 +518,10 @@ def irb_protection_exprs(cols: set[str]) -> list[pl.Expr]:
 
     A DECLINED GUARANTEE IS NOT IN THE BLOCK AT ALL. The heading is "CRM
     TECHNIQUES **WITH SUBSTITUTION EFFECTS ON THE EXPOSURE**", and a guarantee the
-    calculator declined has none — Art. 213 recognition is permissive, so where
-    the guarantor's risk does not beat the obligor's the engine leaves the RWA on
-    the borrower basis. :func:`_decline_gate` therefore zeroes the unfunded
+    calculator declined has none — Art. 193(1) bars a guarantee from raising the
+    RWEA and Art. 193(3) leaves amending the calculation an election, so where the
+    guarantor's risk does not beat the obligor's the engine leaves the RWA on the
+    borrower basis. :func:`_decline_gate` therefore zeroes the unfunded
     magnitude on both the col 0040/0050 twin and the col 0070 subtotal, which also
     removes the leg from the col 0080 inflow (it binds
     :data:`IRB_UNFUNDED_COL`). The Art. 232 OFCP carriers are deliberately NOT

--- a/src/rwa_calc/reporting/corep/crm_substitution.py
+++ b/src/rwa_calc/reporting/corep/crm_substitution.py
@@ -106,6 +106,11 @@ _DESTINATION_CLASS_COL: str = "post_crm_exposure_class_guaranteed"
 # The raw covered-part carrier. Its PRESENCE gates the whole mechanism; its VALUE
 # is never summed directly — see :data:`IRB_UNFUNDED_COL`.
 _COVERED_COL: str = "guaranteed_portion"
+# The calculators' "the substitution was actually applied" flag
+# (``engine/sa/rw_adjustments.py`` / ``engine/irb/guarantee.py``). CONDITIONAL on
+# the aggregator exit (``inject=False``), and absent altogether from the synthetic
+# unit frames, so every read of it is presence-tolerant. See :func:`_decline_gate`.
+_BENEFICIAL_COL: str = "is_guarantee_beneficial"
 # The covered part of the original exposure pre-conversion factors, AS REPORTED —
 # i.e. after the Annex II block cap. Reading the RAW ``guaranteed_portion`` here
 # instead created money: the outflow sheds proportionally when the protection
@@ -249,14 +254,32 @@ def irb_origin_inflows(
     aggregator rule ever grows a branch that maps an SA origin to an IRB
     destination, this docstring and ``_sa_inflows`` are the two places to revisit.
 
+    ONLY LEGS WHOSE SUBSTITUTION WAS ACTUALLY APPLIED PRODUCE AN INFLOW, and that
+    needs no filter here: :func:`_decline_gate` has already zeroed the covered
+    carrier on a declined leg, so the ``> 0`` filter below drops it. What entitles
+    the covered part to the GUARANTOR's sheet is Art. 235 risk-weight substitution
+    having FIRED; a positive ``guaranteed_portion`` only says protection was
+    ATTACHED. Recognition is permissive (Art. 213), so the calculators decline a
+    guarantee that would raise capital and leave the leg on the borrower basis
+    (``is_guarantee_beneficial=False``). Booking an inflow for one of those
+    published the BORROWER's risk weight on the guarantor's sheet, because the
+    band split (:func:`_band_split`) reads ``risk_weight``, which on a declined
+    leg is still the obligor's: a slotting project-finance leg that declined a
+    100%-RW sovereign guarantee landed 10,000,000 on the
+    ``central_govt_central_bank`` sheet banded at its own 70% slotting weight — a
+    weight no SA sovereign row can carry in either framework. Gating the carrier
+    rather than this filter is what keeps the outflow and the inflow off the SAME
+    decision, so a declined guarantee cannot leave one template without arriving
+    on the other.
+
     Returns ``{guarantor exposure class: covered amount}`` as POSITIVE magnitudes
     measured on the CAPPED carrier (see :data:`IRB_UNFUNDED_COL`), empty when the
     frame carries no substitution carriers. Legs with no destination class are
     dropped rather than grouped under a null key: the sheet axis has no null
-    member, so a null-keyed inflow could only be silently lost. Every leg with a
-    positive covered part is counted — including one whose guarantor sits in the
-    obligor's own class (Annex II "Inflows and outflows within the same exposure
-    classes ... shall also be considered").
+    member, so a null-keyed inflow could only be silently lost. Every REMAINING
+    leg with a positive covered part is counted — including one whose guarantor
+    sits in the obligor's own class (Annex II "Inflows and outflows within the
+    same exposure classes ... shall also be considered").
     """
     if not {_COVERED_COL, _DESTINATION_CLASS_COL} <= cols:
         return {}
@@ -309,11 +332,18 @@ def _band_split(
     ``band_expr`` is supplied by the CALLER because the band ladder is that
     template's own regime-shaped axis (``corep/c07.py::_rw_band_expr`` over
     ``get_sa_risk_weight_bands``) — the same expression its own rows key on, so a
-    banded inflow lands on a row that exists. It is measured on the SOURCE leg's
-    ``risk_weight``, which on a guaranteed leg IS the guarantor's substituted
-    weight (CRR Art. 235 risk-weight substitution), i.e. the weight the
-    destination sheet should report the inflow at. The ladder ends in an "Other
-    risk weights" catch-all, so no leg can be silently dropped.
+    banded inflow lands on a row that exists. The ladder ends in an "Other risk
+    weights" catch-all, so no leg can be silently dropped.
+
+    IT IS MEASURED ON THE SOURCE LEG'S ``risk_weight``, and that is the
+    guarantor's substituted weight (CRR Art. 235) ONLY BECAUSE ``migrated`` HAS
+    ALREADY BEEN FILTERED TO BENEFICIALLY-SUBSTITUTED LEGS — a precondition the
+    caller establishes, not a property of guaranteed legs in general. On a leg
+    whose guarantee the engine declined, ``risk_weight`` is still the OBLIGOR's,
+    and banding it here is exactly what leaked a 70% slotting weight onto the
+    ``central_govt_central_bank`` sheet (see :func:`irb_origin_inflows`). Any
+    future caller that widens the filter must supply the substituted weight
+    itself rather than rely on this equivalence.
     """
     if band_expr is None:
         return {}
@@ -365,6 +395,24 @@ def _slotting(cols: set[str]) -> pl.Expr:
     if _DESTINATION_APPROACH_COL not in cols:
         return pl.lit(value=False)
     return (pl.col(_DESTINATION_APPROACH_COL) == "slotting").fill_null(value=False)
+
+
+def _decline_gate(cols: set[str], magnitude: pl.Expr) -> pl.Expr:
+    """Zero a protection magnitude where the engine DECLINED the guarantee.
+
+    A guarantee the engine DECLINED (``is_guarantee_beneficial`` false/null — it
+    would have RAISED capital, CRR Art. 213) produces NO substitution effect: the
+    RWA stays on the borrower basis. Annex II heads this block "CRM TECHNIQUES
+    WITH SUBSTITUTION EFFECTS ON THE EXPOSURE", so a declined guarantee does not
+    belong in it, and reporting one booked a phantom outflow against a phantom
+    inflow. Gating the carrier here gates BOTH sides at once — the substitution
+    inflow binds this same column — so conservation is preserved by construction
+    rather than by two gates agreeing. Absent column = the CRM guarantee sub-step
+    never ran, so there is nothing to decline and the gate is a no-op.
+    """
+    if _BENEFICIAL_COL not in cols:
+        return magnitude
+    return pl.when(pl.col(_BENEFICIAL_COL) == True).then(magnitude).otherwise(pl.lit(0.0))  # noqa: E712
 
 
 def irb_block_cap_scale(cols: set[str], block_total: pl.Expr) -> pl.Expr:
@@ -460,6 +508,17 @@ def irb_protection_exprs(cols: set[str]) -> list[pl.Expr]:
     pipeline (a 1,500,000 guarantee deducted twice from a 51,100,000 corporate
     sheet), and it is now fixed in ``_crm_waterfall``, not deferred.
 
+    A DECLINED GUARANTEE IS NOT IN THE BLOCK AT ALL. The heading is "CRM
+    TECHNIQUES **WITH SUBSTITUTION EFFECTS ON THE EXPOSURE**", and a guarantee the
+    calculator declined has none — Art. 213 recognition is permissive, so where
+    the guarantor's risk does not beat the obligor's the engine leaves the RWA on
+    the borrower basis. :func:`_decline_gate` therefore zeroes the unfunded
+    magnitude on both the col 0040/0050 twin and the col 0070 subtotal, which also
+    removes the leg from the col 0080 inflow (it binds
+    :data:`IRB_UNFUNDED_COL`). The Art. 232 OFCP carriers are deliberately NOT
+    gated: they are not the guarantee whose benefit was measured, and no
+    beneficial flag speaks for them.
+
     Returns the ``c08_prot_*`` twins for whichever raw carriers the frame has,
     plus the ``c08_prot_block`` subtotal — a constant 0.0 on a frame with no
     protection carrier at all, so col 0070 reports the same zero deduction as the
@@ -480,6 +539,7 @@ def irb_protection_exprs(cols: set[str]) -> list[pl.Expr]:
             if "protection_type" in cols
             else gp
         )
+        unfunded = _decline_gate(cols, unfunded)
         parts.append(unfunded)
     if not parts:
         return [pl.lit(0.0).alias(IRB_BLOCK_COL), pl.lit(0.0).alias(IRB_UNFUNDED_COL)]
@@ -490,8 +550,16 @@ def irb_protection_exprs(cols: set[str]) -> list[pl.Expr]:
         if col in cols
     ]
     if unfunded is not None:
+        # Cols 0040/0050 bind this ONE twin and make their guarantee /
+        # credit-derivative split by cell PREDICATE, so it stays raw of the
+        # protection_type gate — but it must carry the DECLINE gate, or col 0070
+        # (the ``IRB_BLOCK_COL`` subtotal, which does) would shed a declined
+        # guarantee that cols 0040/0050 still report and break the live identity
+        # ``{c0070} = {c0040} + {c0050} + {c0060}`` (``v1663_m`` / ``v1665_m``).
         exprs.append(
-            (pl.col("guaranteed_portion").fill_null(0.0) * scale).alias("c08_prot_guaranteed")
+            (_decline_gate(cols, pl.col("guaranteed_portion").fill_null(0.0)) * scale).alias(
+                "c08_prot_guaranteed"
+            )
         )
     # The col 0070 subtotal: the SAME capped magnitudes cols 0040/0050/0060 sum,
     # added up once per leg. ``unfunded`` already carries the protection_type

--- a/src/rwa_calc/reporting/corep/postpass.py
+++ b/src/rwa_calc/reporting/corep/postpass.py
@@ -297,3 +297,41 @@ def provisions_postfix(
     for row_ref, value in fixes.items():
         expr = pl.when(pl.col("row_ref") == row_ref).then(pl.lit(value)).otherwise(expr)
     return frame.with_columns(expr.alias(ref))
+
+
+def c08_06_zero_row(column_refs: tuple[str, ...], rw_display: str) -> dict[str, float | None]:
+    """C 08.06: the zero-fill for an empty non-Total row: every cell 0.0
+    except 0070 = the row definition's display risk weight ("50%" -> 0.5;
+    unparseable/blank -> None)."""
+    values: dict[str, float | None] = dict.fromkeys(column_refs, 0.0)
+    if rw_display:
+        try:
+            values["0070"] = float(rw_display.replace("%", "").strip()) / 100.0
+        except ValueError:
+            values["0070"] = None
+    else:
+        values["0070"] = None
+    return values
+
+
+def c08_06_apply_overrides(
+    frame: pl.DataFrame, overrides: dict[str, dict[str, float | None]]
+) -> pl.DataFrame:
+    if not overrides:
+        return frame
+    exprs: list[pl.Expr] = []
+    value_cols = [col for col in frame.columns if col not in ("row_ref", "row_name")]
+    for col in value_cols:
+        expr = pl.col(col)
+        touched = False
+        for row_ref, values in overrides.items():
+            if col in values:
+                expr = (
+                    pl.when(pl.col("row_ref") == row_ref)
+                    .then(pl.lit(values[col], dtype=pl.Float64))
+                    .otherwise(expr)
+                )
+                touched = True
+        if touched:
+            exprs.append(expr.alias(col))
+    return frame.with_columns(exprs) if exprs else frame

--- a/src/rwa_calc/reporting/corep/postpass.py
+++ b/src/rwa_calc/reporting/corep/postpass.py
@@ -1,0 +1,299 @@
+"""
+COREP post-execute passes shared by C 07.00, C 08.01/02 and C 09.01/02.
+
+Pipeline position:
+    cellspec.execute() -> these passes, on the REPORTED frame -> the bundle
+    (the drill-down reads a cell's value from the reported frame, so it honours
+    every pass here)
+
+Key responsibilities:
+- Render inert rows and rows with EMPTY subsets all-null (``null_empty_rows``).
+- Emit the Annex II §1.3 "(-)"-labelled deduction columns as negative figures
+  (``negate_deduction_cols``).
+- Swap a provisions cell to the best available carrier when its base sum nets
+  to ~0 (``provisions_postfix``, C 08.01/02/03/06).
+- Fill the two C 08.01/02 columns the executor cannot bind — the off-balance-
+  sheet slice of the col 0090 waterfall (``c08_off_bs_pre_ccf``) and the
+  after-all-CRM total (``c08_after_all_crm``).
+
+WHY HERE AND NOT IN ``reporting/kernel``: ``null_empty_rows`` reads
+``RowPredicate`` / ``matched_counts`` from ``reporting/cellspec.py``, which
+itself imports ``reporting/kernel`` — putting it under the kernel would invert
+that layering. ``corep/`` is where every caller already lives, alongside the
+other cross-template helper (``corep/crm_substitution.py``).
+
+Each template module previously carried its own copy of both. They had already
+converged term-for-term (each docstring said so), so the copies are folded into
+one implementation per pass with the per-template scope passed in — the
+``negative_cols`` set and the ``keep`` exemptions stay template-owned, because
+those ARE the per-template decisions.
+
+References:
+- Reg (EU) 2021/451 Annex II §1.3 (the "(-)" sign convention)
+- PRA PS1/26 Annex II §1.3 (the same convention on the OF templates)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import polars as pl
+
+from rwa_calc.reporting.cellspec import matched_counts, subset_rows
+from rwa_calc.reporting.corep.crm_substitution import IRB_BLOCK_COL
+from rwa_calc.reporting.kernel import safe_sum
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from rwa_calc.reporting.cellspec import RowPredicate
+
+_LABEL_COLS: tuple[str, str] = ("row_ref", "row_name")
+
+
+def null_empty_rows(
+    frame: pl.DataFrame,
+    class_df: pl.DataFrame,
+    row_preds: Mapping[str, RowPredicate | None],
+    keep: frozenset[str] = frozenset(),
+) -> pl.DataFrame:
+    """Render inert rows and rows with EMPTY subsets all-null.
+
+    The retired per-template ``_null_row`` contract: the COREP zero policy
+    applies only to POPULATED rows' unbound cells. A ``None`` predicate is an
+    inert row; a constrained predicate matching nothing is an empty one; a
+    constraint-free predicate (the Total row, no ``equals`` / ``any_of``) is
+    never nulled.
+
+    ``keep`` exempts rows whose content is a cross-sheet INFLOW: their own
+    subset is legitimately empty (the money lives in other sheets), so nulling
+    them would delete the component the published row sums need — visibly so on
+    an inflow-only sheet, where EVERY constrained subset is empty.
+
+    ON A TWO-BASIS TEMPLATE THE COUNT IS OVER THE UNION OF BOTH BASES, and that
+    falls out rather than being coded: ``class_df`` is the sheet frame (the legs
+    on this sheet under EITHER basis — ``kernel/bases.py::sheet_frame``) and the
+    predicates passed here are the BASIS-FREE row terms, so a row is nulled only
+    when it is empty on the origin basis AND on the post basis. Keying it on one
+    basis would null out the very cells the split exists to publish — an
+    inflow-only sheet's rows have no origin-basis leg at all, yet must report the
+    exposure value and RWEA that arrived on them. The converse costs a
+    fully-outflowed row a null it used to get: it reports real zeros in its
+    exposure-value / RWEA columns against its real gross, which is what the
+    ``{exposure value} <= {gross}`` family of published rules asks of it.
+    """
+    constrained = {
+        ref: pred
+        for ref, pred in row_preds.items()
+        if pred is not None and (pred.equals or pred.any_of)
+    }
+    counts = matched_counts(class_df, constrained)
+    null_refs = [
+        ref
+        for ref, pred in row_preds.items()
+        if ref not in keep and (pred is None or ((pred.equals or pred.any_of) and counts[ref] == 0))
+    ]
+    if not null_refs:
+        return frame
+    value_cols = [col for col in frame.columns if col not in _LABEL_COLS]
+    return frame.with_columns(
+        pl.when(pl.col("row_ref").is_in(null_refs))
+        .then(pl.lit(None, dtype=pl.Float64))
+        .otherwise(pl.col(col))
+        .alias(col)
+        for col in value_cols
+    )
+
+
+def negate_deduction_cols(frame: pl.DataFrame, negative_cols: frozenset[str]) -> pl.DataFrame:
+    """Annex II §1.3: emit the "(-)"-labelled deduction columns as negatives.
+
+    Runs AFTER the template's waterfalls have consumed the positive magnitudes.
+    Intersecting with the frame's columns makes the framework-specific members
+    (B31's C 08.01 cols 0035/0102/0103, CRR's 0256/0257) absent-column no-ops in
+    the regime that lacks them.
+
+    A zero deduction is normalised to ``+0.0``: plain ``-pl.col(col)`` flips the
+    IEEE sign bit, so a ``0.0`` cell would serialise as ``-0.0`` (``+ 0.0`` does
+    NOT clear it in Polars). Null stays null — ``== 0.0`` is null on a null row,
+    so the ``otherwise`` branch returns ``-null``.
+    """
+    targets = [col for col in frame.columns if col in negative_cols]
+    if not targets:
+        return frame
+    return frame.with_columns(
+        pl.when(pl.col(col) == 0.0).then(pl.lit(0.0)).otherwise(-pl.col(col)).alias(col)
+        for col in targets
+    )
+
+
+def c08_off_bs_pre_ccf(
+    frame: pl.DataFrame,
+    class_df: pl.DataFrame,
+    row_preds: Mapping[str, RowPredicate | None],
+) -> pl.DataFrame:
+    """Fill C 08.01/02 col 0100 with the off-BS slice of the 0090 waterfall.
+
+    Col 0100 ("of which: off balance sheet") sits in the POST-CRM PRE-CCF
+    column group (the 0090 "Exposure after CRM substitution pre CCFs"
+    waterfall), so it reports the off-BS share of that PRE-conversion-factor
+    quantity — NOT the post-CCF exposure value (that is col 0120). The
+    executor has no intra-row sub-waterfall verb, so 0100 is derived here per
+    row over the row's ``c08_bs == "off"`` legs, mirroring ``_value_cells`` +
+    ``crm_substitution.crm_waterfall`` term-for-term:
+
+        0100 = off-BS gross (0020: the sealed reporting_gross_off_bs carrier)
+             - off-BS substitution outflow (0070: the ``c08_prot_block``
+               subtotal cols 0040/0050/0060 break down)
+
+    It carries the waterfall's OWN correction: reading the breakdown columns AND
+    the outflow subtotal — as this did before — deducts the same covered part
+    twice, exactly as ``crm_waterfall`` did. Binding the same per-leg subtotal
+    col 0070 binds keeps the memo a true slice of 0090 by construction rather
+    than by two derivations agreeing.
+
+    THE B31 COL 0035 TERM IS DELIBERATELY ABSENT, and that is load-bearing rather
+    than an oversight: col 0035 is the Art. 166(3) on-balance-sheet netting of
+    loans and deposits, so it has no off-balance-sheet share to slice. The BoE
+    scoping says the same thing structurally — ``boe_b0746_1`` drops the 0035 term
+    from the col 0090 waterfall on exactly the off-balance-sheet row family
+    (``crm_substitution.C08_01_NETTING_EXEMPT_ROWS``), so an off-BS memo that
+    subtracted it would contradict the published rule for row 0030 while claiming
+    to be its slice. Do not "restore" it for symmetry with the on-BS rows.
+
+    It is computed on POSITIVE magnitudes read from the raw ``class_df`` (so
+    the result is independent of the later ``_negate`` sign pass). The 0080
+    substitution INFLOW is EXCLUDED: it is a total-row cross-sheet scalar
+    (``ReportingContext.substitution_inflow``, a per-destination-class
+    aggregate with no leg-level on/off-BS attribution), so an off-BS memo
+    cannot claim a share of it — recorded decision, matching 0090's own
+    convention that the inflow only lands on the (constraint-free) total row.
+
+    Every leg is either on- or off-BS (``c08_bs``) and the outflow carrier is a
+    leg-level amount pro-rated across the two-leg guarantee split, so summing it
+    over the off-BS legs is the EXACT slice. Inert (None-predicate) rows are left
+    as the null placeholder for ``_null_empty_rows``; C 08.02 has none.
+    """
+    if "0100" not in frame.columns:
+        return frame
+    cols = set(class_df.columns)
+    if "c08_bs" not in cols:
+        return frame
+    active = {ref: pred for ref, pred in row_preds.items() if pred is not None}
+    if not active:
+        return frame
+    fixes: dict[str, float] = {}
+    for row_ref, subset in subset_rows(class_df, active).items():
+        off = subset.filter(pl.col("c08_bs") == "off")
+        off_cols = set(off.columns)
+        gross = safe_sum(off, off_cols, "reporting_gross_off_bs")
+        fixes[row_ref] = gross - safe_sum(off, off_cols, IRB_BLOCK_COL)
+    expr: pl.Expr = pl.col("0100")
+    for row_ref, value in fixes.items():
+        expr = (
+            pl.when(pl.col("row_ref") == row_ref)
+            .then(pl.lit(value, dtype=pl.Float64))
+            .otherwise(expr)
+        )
+    return frame.with_columns(expr.alias("0100"))
+
+
+def c08_after_all_crm(frame: pl.DataFrame) -> pl.DataFrame:
+    """Fill C 08.01/02 col 0104 — exposure after ALL CRM, pre-conversion factors.
+
+    PS1/26 Annex II (OF 08.01 col 0104): "Institutions shall report the value
+    reported in column 0090 after adjusting for the reduction in exposure due to
+    the Financial Collateral Comprehensive Method reported in columns 0101-0103."
+    The published identity (boe_b1040) states it additively over the REPORTED
+    (signed) cells::
+
+        0104 = 0090 + 0101 + 0102
+
+    — col 0103 is an "of which" sub-item of 0102 and is excluded, and 0102 is a
+    "(-)"-labelled deduction, so on the POSITIVE magnitudes this pass sees (it
+    runs before ``_negate``) the arithmetic is ``0090 + 0101 - 0102``.
+
+    Cols 0101-0103 apply to slotting exposures only ("An institution shall only
+    report values for exposures subject to the slotting approach") and are
+    structural nulls today — no FCCM-under-slotting carrier is sealed — so 0104
+    currently reproduces 0090 on every row. The subtraction is written out
+    anyway so the cell stays truthful the day a carrier is wired.
+
+    This is a post-execute pass and not a ``Formula`` cell because 0090, 0101 and
+    0102 are themselves ``Formula`` cells and the executor refuses a formula that
+    references another formula. A null 0090 (an inert row) keeps 0104 null for
+    ``_null_empty_rows``; a frame without col 0104 (CRR, which has no FCCM
+    column block) is left untouched.
+    """
+    if "0104" not in frame.columns or "0090" not in frame.columns:
+        return frame
+    total = pl.col("0090").fill_null(0.0)
+    if "0101" in frame.columns:
+        total = total + pl.col("0101").fill_null(0.0)
+    if "0102" in frame.columns:
+        total = total - pl.col("0102").fill_null(0.0)
+    return frame.with_columns(
+        pl.when(pl.col("0090").is_null())
+        .then(pl.lit(None, dtype=pl.Float64))
+        .otherwise(total)
+        .alias("0104")
+    )
+
+
+def provisions_postfix(
+    frame: pl.DataFrame,
+    class_df: pl.DataFrame,
+    row_preds: Mapping[str, RowPredicate | None],
+    cols: set[str],
+    *,
+    ref: str,
+) -> pl.DataFrame:
+    """The provisions ladder: when the SCRA/GCRA base sum nets to ~0, swap the
+    whole cell to the best available provisions carrier for the row subset (a
+    value-dependent, PER-CELL branch — the recorded C 08 granularity, distinct
+    from C 07.00's per-row ladder).
+
+    The fallback carrier is ``provision_held`` when the frame carries it (the
+    synthetic COREP unit frames supply it), else the sealed ``provision_allocated``
+    (R10b). The retired ``provision_held``-only fallback was DEAD on every real
+    submission: ``provision_held`` is an input pass-through the aggregator seal
+    strips, so ``"provision_held" not in cols`` returned early and the provisions
+    cells (C 08.01/02 col 0290, C 08.03 col 0110, C 08.06 col 0100) rendered a
+    hard 0.0. ``provision_allocated`` is the sealed provisions carrier that IS
+    meaningful on the IRB book: unlike C 07.00's ``provision_deducted`` (R9), the
+    Art. 111(2) drawn-first deduction is SA-only (engine/crm/provisions.py —
+    IRB/Slotting: provision_on_drawn = 0, provision_on_nominal = 0, so
+    provision_deducted is STRUCTURALLY 0.0 on every IRB/slotting leg), whereas
+    provision_allocated is tracked for all approaches (it feeds the IRB EL
+    shortfall/excess). scra/gcra stay the preferred base; a book that supplies
+    them non-degenerately keeps that granular figure."""
+    fallback_col = (
+        "provision_held"
+        if "provision_held" in cols
+        else "provision_allocated"
+        if "provision_allocated" in cols
+        else None
+    )
+    if ref not in frame.columns or fallback_col is None:
+        return frame
+    needed: dict[str, RowPredicate | None] = {}
+    for row_ref, pred in row_preds.items():
+        if pred is None:
+            continue
+        current = frame.filter(pl.col("row_ref") == row_ref)
+        if current.height == 0 or current[ref][0] is None:
+            continue
+        if abs(current[ref][0]) >= 1e-9:
+            continue
+        needed[row_ref] = pred
+    fixes: dict[str, float] = {}
+    for row_ref, subset in subset_rows(class_df, needed).items():
+        if subset.height == 0:
+            continue
+        fixes[row_ref] = float(subset[fallback_col].fill_null(0.0).sum())
+    if not fixes:
+        return frame
+    expr: pl.Expr = pl.col(ref)
+    for row_ref, value in fixes.items():
+        expr = pl.when(pl.col("row_ref") == row_ref).then(pl.lit(value)).otherwise(expr)
+    return frame.with_columns(expr.alias(ref))

--- a/src/rwa_calc/reporting/kernel/__init__.py
+++ b/src/rwa_calc/reporting/kernel/__init__.py
@@ -27,6 +27,7 @@ References:
 from __future__ import annotations
 
 from rwa_calc.reporting.kernel.bases import (
+    POST_APPROACH_SOURCE,
     TwoBasis,
     class_keys,
     population_flags,
@@ -55,6 +56,7 @@ from rwa_calc.reporting.kernel.rows import null_row
 from rwa_calc.reporting.kernel.sums import col_sum, safe_sum, safe_sum_or_none
 
 __all__ = [
+    "POST_APPROACH_SOURCE",
     "TwoBasis",
     "available_columns",
     "class_keys",

--- a/src/rwa_calc/reporting/kernel/__init__.py
+++ b/src/rwa_calc/reporting/kernel/__init__.py
@@ -8,6 +8,7 @@ Pipeline position:
 Key responsibilities:
 - Column discovery and candidate-name resolution (``columns``)
 - Approach and balance-sheet-side row filters (``filters``)
+- The origin / post-substitution two-basis discriminators (``bases``)
 - Null-safe column summation primitives (``sums``)
 - Template row-dict construction (``rows``)
 - Excel sheet writing with a readable-name header band (``excel``)
@@ -25,6 +26,13 @@ References:
 
 from __future__ import annotations
 
+from rwa_calc.reporting.kernel.bases import (
+    TwoBasis,
+    class_keys,
+    population_flags,
+    sheet_axis,
+    sheet_frame,
+)
 from rwa_calc.reporting.kernel.columns import (
     available_columns,
     ensure_gross_side_carriers,
@@ -47,7 +55,9 @@ from rwa_calc.reporting.kernel.rows import null_row
 from rwa_calc.reporting.kernel.sums import col_sum, safe_sum, safe_sum_or_none
 
 __all__ = [
+    "TwoBasis",
     "available_columns",
+    "class_keys",
     "col_sum",
     "column_name_map",
     "ensure_gross_side_carriers",
@@ -58,9 +68,12 @@ __all__ = [
     "gross_carriers",
     "null_row",
     "pick",
+    "population_flags",
     "safe_sum",
     "safe_sum_or_none",
     "sanitise_sheet_name",
+    "sheet_axis",
+    "sheet_frame",
     "write_metadata_sheet",
     "write_template_sheet",
 ]

--- a/src/rwa_calc/reporting/kernel/bases.py
+++ b/src/rwa_calc/reporting/kernel/bases.py
@@ -1,0 +1,197 @@
+"""
+The two-basis (origin / post-substitution) discriminators shared by C 07.00 and C 08.01.
+
+Pipeline position:
+    sealed aggregator-exit ledger -> {c07_plans, c08_01_plans} -> the derived
+    flag columns every basis-split cell predicate reads -> cellspec.execute()
+
+Key responsibilities:
+- Derive the two POPULATION-membership flags for one template (the obligor's
+  own approach book, and the same book measured on the sealed
+  post-substitution approach).
+- Derive the two SHEET keys (the obligor's class, and the guarantor's).
+- Build the sheet AXIS as the union of both bases, and tag one sheet's frame
+  with which basis each leg sits on.
+
+WHY EVERY SHEET IS TWO POPULATIONS. Annex II makes the front of C 07.00 /
+C 08.01 and the back of them answer different questions. The gross exposure and
+the CRM substitution block belong to the OBLIGOR's book — that is where the
+covered part is "deducted from the obligor's exposure class" — while the
+exposure value and the RWEA are defined "after taking into account ... ALL
+CREDIT RISK MITIGANTS", and substitution is a credit risk mitigant, so the
+covered part must leave the obligor's sheet and land on the protection
+provider's. One frame per sheet carrying both populations, each leg tagged,
+lets one cell read the obligor's own book while its neighbour reads the
+post-substitution one.
+
+WHY DERIVED BOOLEAN COLUMNS AND NOT ``RowPredicate`` FIELDS. ``classes`` /
+``classes_origin`` are per-CELL keys against the sealed ledger, while a basis is
+a per-SHEET question ("is this leg on THIS sheet, on THIS basis?") answered
+against a class that varies sheet by sheet. Expressing it as derived booleans
+keeps ONE spec shared across every sheet, keeps the population definition in one
+place, and — decisively — lets the post basis DEGRADE to the origin basis on a
+frame that seals no post-substitution columns. A strict predicate term cannot
+degrade: it would either raise on the missing column or (as a tolerant
+``equals``) silently zero the exposure-value and RWEA columns of every synthetic
+unit frame in the COREP / Pillar 3 estate.
+
+References:
+- Reg (EU) 2021/451 Annex II: C 07.00 cols 0090/0100/0200, C 08.01 cols
+  0070/0080/0110/0260
+- PRA PS1/26 Annex II: OF 07.00 / OF 08.01, same column blocks
+- CRR Art. 235 (risk-weight substitution), Art. 161 (parameter substitution)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import polars as pl
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+# The sealed post-substitution twins the post basis reads (``reporting_class`` =
+# the guarantor's class on a beneficially-guaranteed leg, ``reporting_approach``
+# = the approach that leg is treated under). Absent -> post degrades to origin.
+POST_CLASS_SOURCE: str = "reporting_class"
+POST_APPROACH_SOURCE: str = "reporting_approach"
+ORIGIN_APPROACH_SOURCE: str = "reporting_approach_origin"
+
+
+@dataclass(frozen=True)
+class TwoBasis:
+    """The six derived-column names carrying one template's two-basis split.
+
+    ``prefix`` is the template's own column namespace (``"c07"`` / ``"c08"``), so
+    two templates materialising both bases on the same frame cannot collide.
+    """
+
+    prefix: str
+
+    @property
+    def pop_origin(self) -> str:
+        """Membership of the ORIGIN-approach population (frame-wide)."""
+        return f"{self.prefix}_pop_origin"
+
+    @property
+    def pop_post(self) -> str:
+        """Membership of the POST-substitution population (frame-wide)."""
+        return f"{self.prefix}_pop_post"
+
+    @property
+    def class_origin(self) -> str:
+        """The obligor's sheet key."""
+        return f"{self.prefix}_class_origin"
+
+    @property
+    def class_post(self) -> str:
+        """The guarantor's sheet key."""
+        return f"{self.prefix}_class_post"
+
+    @property
+    def basis_origin(self) -> str:
+        """Per-SHEET: in the origin population AND keyed to THIS sheet."""
+        return f"{self.prefix}_basis_origin"
+
+    @property
+    def basis_post(self) -> str:
+        """Per-SHEET: in the post population AND keyed to THIS sheet."""
+        return f"{self.prefix}_basis_post"
+
+
+def population_flags(
+    basis: TwoBasis,
+    cols: set[str],
+    approaches: tuple[str, ...],
+    *,
+    admit: pl.Expr | None = None,
+) -> list[pl.Expr]:
+    """The two population-membership flags for a template keyed on *approaches*.
+
+    Mirrors ``filter_by_approach``'s missing-column rule — no approach
+    discriminator means an EMPTY population, never a silent pass-through. The
+    post limb falls back to the ORIGIN approach when no post-substitution
+    approach is sealed, so a synthetic frame reports the same figures under both
+    bases instead of zeroing its exposure-value columns.
+
+    ``admit`` is an optional extra limb admitted to BOTH bases regardless of
+    approach (C 07.00's counterparty-credit-risk rows: substitution does not
+    move them, so they belong to both populations).
+    """
+    origin = _in_approaches(cols, ORIGIN_APPROACH_SOURCE, approaches)
+    post = (
+        _in_approaches(cols, POST_APPROACH_SOURCE, approaches)
+        if POST_APPROACH_SOURCE in cols
+        else origin
+    )
+    if admit is not None:
+        origin, post = origin | admit, post | admit
+    return [origin.alias(basis.pop_origin), post.alias(basis.pop_post)]
+
+
+def class_keys(
+    basis: TwoBasis,
+    cols: set[str],
+    origin_class_col: str,
+    *,
+    key: Callable[[str], pl.Expr] | None = None,
+) -> list[pl.Expr]:
+    """The two sheet keys, degrading the post key to the origin key.
+
+    ``key`` is the template's own sheet-key transform applied to BOTH keys (C
+    07.00 merges specialised lending into corporate under Art. 112 Table A2, so
+    an SL guarantor keys a sheet that template actually has); ``None`` keys the
+    raw class. Degrading the post key on a frame sealing no ``reporting_class``
+    is what makes the split number-neutral wherever nothing substitutes.
+    """
+    post_col = POST_CLASS_SOURCE if POST_CLASS_SOURCE in cols else origin_class_col
+    shape = key if key is not None else pl.col
+    return [
+        shape(origin_class_col).alias(basis.class_origin),
+        shape(post_col).alias(basis.class_post),
+    ]
+
+
+def sheet_axis(basis: TwoBasis, data: pl.DataFrame) -> set[str]:
+    """The sheet keys BOTH bases contribute (a null key partitions into NO sheet).
+
+    The post-basis limb is belt-and-braces where the caller also unions in the
+    substitution inflow keys — a beneficially-substituted leg's guarantor class
+    is an inflow key too. Without it, a leg whose inflow the Annex II block cap
+    shed to zero would drop its exposure value and RWEA out of the template
+    silently.
+    """
+    keys: set[str] = set()
+    for population, class_col in (
+        (basis.pop_origin, basis.class_origin),
+        (basis.pop_post, basis.class_post),
+    ):
+        keys |= set(data.filter(pl.col(population))[class_col].drop_nulls().unique().to_list())
+    return keys
+
+
+def sheet_frame(basis: TwoBasis, data: pl.DataFrame, exposure_class: str) -> pl.DataFrame:
+    """One sheet's frame: the legs on it under EITHER basis, each tagged with which.
+
+    A leg on neither basis is dropped, so the frame is never wider than the
+    sheet, and every cell predicate carries its own basis flag — an unflagged
+    predicate would silently sum both populations.
+    """
+    tagged = data.with_columns(
+        (pl.col(basis.pop_origin) & (pl.col(basis.class_origin) == exposure_class))
+        .fill_null(value=False)
+        .alias(basis.basis_origin),
+        (pl.col(basis.pop_post) & (pl.col(basis.class_post) == exposure_class))
+        .fill_null(value=False)
+        .alias(basis.basis_post),
+    )
+    return tagged.filter(pl.col(basis.basis_origin) | pl.col(basis.basis_post))
+
+
+def _in_approaches(cols: set[str], approach_col: str, approaches: tuple[str, ...]) -> pl.Expr:
+    """Is this leg in *approaches* under ``approach_col``? (Absent column = no.)"""
+    if approach_col not in cols:
+        return pl.lit(value=False)
+    return pl.col(approach_col).is_in(list(approaches)).fill_null(value=False)

--- a/src/rwa_calc/reporting/lineage.py
+++ b/src/rwa_calc/reporting/lineage.py
@@ -978,9 +978,12 @@ LINEAGE_PLANS: dict[str, _Provider] = {
         generate=generate_cr10,
         scope=(
             "Each subtemplate draws its OWN population. CR10.1-4 read the ORIGIN "
-            "slotting book (reporting_approach_origin == slotting) — a guaranteed "
-            "slotting exposure's covered leg leaves the slotting approach, so the "
-            "origin basis IS the obligor basis; the sheet is narrowed by sl_type (CRR "
+            "slotting book (reporting_approach_origin == slotting) — a beneficially "
+            "guaranteed slotting leg KEEPS reporting_approach_origin == slotting "
+            "(only reporting_approach moves to the guarantor's), so it stays IN this "
+            "population, which is why cols d/e narrow further to the POST approach: "
+            "the grid is the obligor's book by origination but its exposure value and "
+            "RWEA are no longer Art. 153(5) quantities; the sheet is narrowed by sl_type (CRR "
             "groups IPRE + HVCRE under CR10.2, Basel 3.1 splits HVCRE onto CR10.5). "
             "The CRR CR10.5 equity sheet reads the Art. 155(2) simple-RW equity legs "
             "(reporting_approach_origin == equity AND equity_method == irb_simple — "

--- a/src/rwa_calc/reporting/pillar3/cr10.py
+++ b/src/rwa_calc/reporting/pillar3/cr10.py
@@ -122,6 +122,25 @@ _EQUITY_RW_TOL = 0.05
 _CR10_IS_SHORT = "cr10_is_short"
 
 
+def _post_slotting(member: RowPredicate) -> RowPredicate:
+    """The band predicate narrowed to the POST-substitution slotting book.
+
+    Cols d/e (exposure amount, RWEA) take the same treatment as C 08.06 cols
+    0040/0080: a leg whose guarantee substituted onto an SA guarantor is no
+    longer risk-weighted under Art. 153(5), so it leaves the category grid for
+    the value columns. Col a (on-balance-sheet gross) stays on the ORIGIN book,
+    mirroring C 08.06 col 0010 — the grid is the obligor's slotting book by
+    origination. Col c is the FIXED supervisory weight and is bound NOWHERE (a
+    post-step injects it), so it cannot drift with the population.
+
+    Uses ``RowPredicate.approaches``, which DEGRADES to
+    ``reporting_approach_origin`` where no post-substitution approach is sealed;
+    a tolerant ``equals`` term would instead match nothing and blank both
+    columns on every synthetic frame.
+    """
+    return RowPredicate(equals=member.equals, any_of=member.any_of, approaches=("slotting",))
+
+
 def _slotting_row_cells(category: str | None, is_short: bool | None) -> dict[str, CellSpec]:
     """The Float64 column bindings for one CR10 (category x maturity) slotting
     row (col c is a post-step).
@@ -144,8 +163,8 @@ def _slotting_row_cells(category: str | None, is_short: bool | None) -> dict[str
         # reclassifies facility_undrawn off-BS).
         "a": CellSpec(Sum("reporting_gross_on_bs"), predicate=member, empty_cell="zero"),
         "b": CellSpec(Sum("reporting_gross_off_bs"), predicate=member, empty_cell="zero"),
-        "d": CellSpec(Sum("reporting_ead"), predicate=member),
-        "e": CellSpec(Sum("rwa_final"), predicate=member),
+        "d": CellSpec(Sum("reporting_ead"), predicate=_post_slotting(member)),
+        "e": CellSpec(Sum("rwa_final"), predicate=_post_slotting(member)),
         "f": CellSpec(Sum("expected_loss"), predicate=member),
     }
 

--- a/src/rwa_calc/reporting/pillar3/ov1.py
+++ b/src/rwa_calc/reporting/pillar3/ov1.py
@@ -137,7 +137,18 @@ if TYPE_CHECKING:
 # canonical name (see reporting.plans / _resolve_sheet_key single_frame path).
 _SHEET_KEY = "ov1"
 
-# Rows whose column ``a`` sums one origin approach (0.0 when absent).
+# Rows whose column ``a`` sums one POST-SUBSTITUTION approach (0.0 when absent).
+#
+# These are "of which" splits of row 1 by the approach the RWEA was actually
+# calculated under after CRM. CRR Art. 235 makes the covered part of a
+# guaranteed exposure a direct exposure to the protection provider, treated
+# under the PROVIDER's approach, so a slotting exposure fully guaranteed by an
+# SA counterparty contributes to row 2, not row 4 — keying the origin approach
+# disclosed the whole RWEA under "Supervisory slotting" for an exposure that is
+# no longer slotted. Row 1 (their parent) is a flat non-CCR sum and is basis-
+# independent, so the split moves between rows without changing their total.
+# Moved with COREP C 02.00 rows 0060/0220, which make the same disclosure
+# (f94be554 put C 07.00's exposure-value and RWEA columns on this basis first).
 _APPROACH_REFS: dict[str, tuple[str, ...]] = {
     "2": ("standardised", "equity"),
     "3": ("foundation_irb",),
@@ -242,10 +253,11 @@ def _row_a_cell(ref: str) -> CellSpec | None:
     if ref == "27":
         return CellSpec(SideContext("of_adj"))
     if ref in _APPROACH_REFS:
-        # An "of which" of row 1 inherits row 1's CCR exclusion.
+        # An "of which" of row 1 inherits row 1's CCR exclusion. POST-substitution
+        # approach — see the module docstring and _APPROACH_REFS.
         return CellSpec(
             Sum("rwa_final"),
-            predicate=RowPredicate(approaches_origin=_APPROACH_REFS[ref], equals=_NON_CCR.equals),
+            predicate=RowPredicate(approaches=_APPROACH_REFS[ref], equals=_NON_CCR.equals),
             empty_cell="zero",
         )
     return None

--- a/src/rwa_calc/reporting/tieouts.py
+++ b/src/rwa_calc/reporting/tieouts.py
@@ -39,18 +39,22 @@ The comparable ties (all hold on both frameworks on a real IRB+SA pipeline run):
 - ``irb_rwea_c08_01_vs_ov1``   Σ C 08.01 sheets [0010][0260] == OV1 [3]+[4]+[5]
                                (F-IRB + slotting + A-IRB).
 
-THE TWO IRB TIES SPAN A BASIS MIGRATION IN PROGRESS. Their right-hand sides
-(C 02.00 row 0220, OV1 rows 3/4/5) moved to the POST-substitution approach with
-the C 02.00 / OV1 slice; their left-hand side (C 08.01 col 0260) still keys the
-obligor's origin approach and moves with the C 08.01 slice. Both ties are still
-the RIGHT assertion — the IRB RWEA a firm discloses must be the same number on
-every template — so neither is weakened here; they are what will detect the
-C 08.01 slice being incomplete. Until it lands they hold only while no
-beneficially-substituted leg crosses the SA/IRB boundary carrying non-zero RWEA.
-Measured, not assumed: an F-IRB corporate leg guaranteed by a 0%-RW SA
-counterparty leaves both ties green (the crossing RWEA is 0), and the SAME leg
-against a 50%-RW SA guarantor breaks BOTH by exactly the substituted
-1,000,000.
+THE TWO IRB TIES SPANNED A BASIS MIGRATION, AND BOTH SIDES HAVE NOW CROSSED.
+Their right-hand sides (C 02.00 row 0220, OV1 rows 3/4/5) moved to the
+POST-substitution approach with the C 02.00 / OV1 slice; their left-hand side
+(C 08.01 col 0260) followed one commit later, together with C 02.00's IRB CLASS
+key. Neither tie was ever weakened — the IRB RWEA a firm discloses must be the
+same number on every template — and they are what DETECTED the C 08.01 slice
+being incomplete.
+
+A 0%-RW GUARANTOR CANNOT VERIFY THESE TIES, and that is the trap to remember:
+the crossing RWEA is then zero, so both sides agree whichever basis they sit on
+and green means nothing. Verified against a NON-ZERO-RW guarantor, measured
+both ways — S3's F-IRB corporate leg re-run with a CQS2 SA institution
+guarantor crosses 2,450,000 of RWEA under CRR (Art. 120: 50%) and 1,470,000
+under Basel 3.1 (ECRA: 30%). With one side migrated, BOTH ties break by exactly
+that amount in both regimes; with both migrated, both are green. Any future
+change to either basis must be re-measured the same way.
 
 References:
 - CRR Art. 92(3) (own-funds requirement roll-up); COREP Annex II C 02.00 /
@@ -208,12 +212,14 @@ def check_cross_template_consistency(
 # identity here and the extraction mechanics separately.
 #
 # Basis note for the C 02.00 ties (sa_rwea_c07_vs_c02 / irb_rwea_c08_01_vs_c02):
-# C 02.00 keys the APPLIED approach (approach_applied) while C 07.00 / C 08.01
-# key the ORIGIN approach (reporting_approach_origin). These coincide today
-# because CRM substitution does NOT retarget an exposure's approach (the open
-# F-decision recorded in the c07/cr4 module docstrings). If that retarget ever
-# lands, these two ties may legitimately diverge and must be re-derived — unlike
-# the obligor-basis pairs below, which diverge by REGULATION even today.
+# both sides now key the POST-SUBSTITUTION twins. The retarget this note once
+# called an open F-decision HAS LANDED: ``reporting_approach`` /
+# ``reporting_class`` (the aggregator's ``approach_post_crm`` /
+# ``exposure_class_post_crm``) carry Art. 235/236 substitution, C 07.00 and
+# C 08.01 key them on their exposure-value and RWEA columns, and C 02.00 keys
+# them on all three of its breakdowns. So the ties no longer "coincide" — they
+# hold by construction. The pairs recorded below still diverge by REGULATION,
+# which is a different thing and is not affected by any of this.
 
 
 TIE_OUTS: list[TieOut] = [
@@ -269,11 +275,11 @@ TIE_OUTS: list[TieOut] = [
     TieOut(
         name="irb_rwea_c08_01_vs_c02",
         description=(
-            "Aggregate IRB RWEA across the C 08.01 obligor-class sheets equals "
-            "the C 02.00 IRB of-which line (row 0220). Row 0220 keys the "
-            "POST-substitution approach; C 08.01 still keys the obligor's "
-            "origin approach until its own slice lands — see the module "
-            "docstring on the basis migration these two ties span."
+            "Aggregate IRB RWEA across the C 08.01 class sheets equals the "
+            "C 02.00 IRB of-which line (row 0220). BOTH sides key the "
+            "POST-substitution approach. Verify any change to either with a "
+            "NON-zero-RW guarantor — a 0%-RW one crosses no RWEA and cannot "
+            "tell a correct basis from an incomplete one."
         ),
         regulatory_reference=(
             "CRR Art. 92(3)(a); COREP Annex II C 08.01 col 0260 / C 02.00 row "
@@ -288,11 +294,11 @@ TIE_OUTS: list[TieOut] = [
     TieOut(
         name="irb_rwea_c08_01_vs_ov1",
         description=(
-            "Aggregate IRB RWEA across the C 08.01 obligor-class sheets equals "
-            "the Pillar 3 OV1 IRB rows (F-IRB row 3 + slotting row 4 + A-IRB "
-            "row 5). OV1 keys the POST-substitution approach; C 08.01 still "
-            "keys the obligor's origin approach until its own slice lands — see "
-            "the module docstring on the basis migration these two ties span."
+            "Aggregate IRB RWEA across the C 08.01 class sheets equals the "
+            "Pillar 3 OV1 IRB rows (F-IRB row 3 + slotting row 4 + A-IRB row "
+            "5). BOTH sides key the POST-substitution approach. Verify any "
+            "change to either with a NON-zero-RW guarantor — a 0%-RW one "
+            "crosses no RWEA and cannot tell correct from incomplete."
         ),
         regulatory_reference=(
             "COREP Annex II C 08.01 col 0260; Pillar 3 OV1 rows 3/4/5 "

--- a/src/rwa_calc/reporting/tieouts.py
+++ b/src/rwa_calc/reporting/tieouts.py
@@ -37,7 +37,20 @@ The comparable ties (all hold on both frameworks on a real IRB+SA pipeline run):
 - ``irb_rwea_c08_01_vs_c02``   Σ C 08.01 sheets [0010][0260] == C 02.00 [0220]
                                (IRB of-which line).
 - ``irb_rwea_c08_01_vs_ov1``   Σ C 08.01 sheets [0010][0260] == OV1 [3]+[4]+[5]
-                               (F-IRB + slotting + A-IRB) — same origin basis.
+                               (F-IRB + slotting + A-IRB).
+
+THE TWO IRB TIES SPAN A BASIS MIGRATION IN PROGRESS. Their right-hand sides
+(C 02.00 row 0220, OV1 rows 3/4/5) moved to the POST-substitution approach with
+the C 02.00 / OV1 slice; their left-hand side (C 08.01 col 0260) still keys the
+obligor's origin approach and moves with the C 08.01 slice. Both ties are still
+the RIGHT assertion — the IRB RWEA a firm discloses must be the same number on
+every template — so neither is weakened here; they are what will detect the
+C 08.01 slice being incomplete. Until it lands they hold only while no
+beneficially-substituted leg crosses the SA/IRB boundary carrying non-zero RWEA.
+Measured, not assumed: an F-IRB corporate leg guaranteed by a 0%-RW SA
+counterparty leaves both ties green (the crossing RWEA is 0), and the SAME leg
+against a 50%-RW SA guarantor breaks BOTH by exactly the substituted
+1,000,000.
 
 References:
 - CRR Art. 92(3) (own-funds requirement roll-up); COREP Annex II C 02.00 /
@@ -257,7 +270,10 @@ TIE_OUTS: list[TieOut] = [
         name="irb_rwea_c08_01_vs_c02",
         description=(
             "Aggregate IRB RWEA across the C 08.01 obligor-class sheets equals "
-            "the C 02.00 IRB of-which line (row 0220)."
+            "the C 02.00 IRB of-which line (row 0220). Row 0220 keys the "
+            "POST-substitution approach; C 08.01 still keys the obligor's "
+            "origin approach until its own slice lands — see the module "
+            "docstring on the basis migration these two ties span."
         ),
         regulatory_reference=(
             "CRR Art. 92(3)(a); COREP Annex II C 08.01 col 0260 / C 02.00 row "
@@ -274,7 +290,9 @@ TIE_OUTS: list[TieOut] = [
         description=(
             "Aggregate IRB RWEA across the C 08.01 obligor-class sheets equals "
             "the Pillar 3 OV1 IRB rows (F-IRB row 3 + slotting row 4 + A-IRB "
-            "row 5) — the same reporting-approach-origin basis."
+            "row 5). OV1 keys the POST-substitution approach; C 08.01 still "
+            "keys the obligor's origin approach until its own slice lands — see "
+            "the module docstring on the basis migration these two ties span."
         ),
         regulatory_reference=(
             "COREP Annex II C 08.01 col 0260; Pillar 3 OV1 rows 3/4/5 "

--- a/tests/acceptance/reporting/test_crm_substitution_flows.py
+++ b/tests/acceptance/reporting/test_crm_substitution_flows.py
@@ -140,29 +140,47 @@ class TestPublishedIdentitiesEndToEnd:
 
 class TestPerScenarioInflowLandsOnce:
     """Every scenario's guaranteed amount arrives on its recorded destination
-    (template, class) as an inflow of exactly the covered amount — driven
-    generically off ``SUBSTITUTION_INFLOW_DESIGN`` so a sixth scenario added
-    to the fixture is covered without a code change here."""
+    (template, class) as an inflow — driven generically off
+    ``SUBSTITUTION_INFLOW_DESIGN`` so an eighth scenario added to the fixture
+    is covered without a code change here.
+
+    Two or more scenarios may legitimately share one destination (S1 and S7
+    both land on institution/C 08.01 — see the fixture module docstring), so
+    the assertion is grouped by (template, class) and compares the sheet's
+    inflow cell against the SUM of every scenario's ``guaranteed_amount``
+    that the design table maps to that destination — not any single
+    scenario's amount in isolation. "Lands once" is still enforced by that
+    grouping, not diluted by it: the comparison is exact equality against the
+    sum of ONLY the entries recorded for that one destination, so it still
+    fails if a leg's inflow lands on the wrong sheet (its true destination's
+    sum comes up short), lands twice (its destination's sum comes up long —
+    equality, not `>=`, catches this), or never lands at all (its
+    destination's sum comes up short, including a destination with exactly
+    one design entry, which is the original one-to-one case degenerating out
+    of the general grouped one)."""
 
     @pytest.mark.parametrize("regime_key", list(_REGIMES))
     def test_destination_inflow_equals_the_guaranteed_amount(self, regime_key: str) -> None:
         _results, corep = _run(regime_key)
 
-        for guar_ref, design in SUBSTITUTION_INFLOW_DESIGN.items():
-            template = design["destination_template"]
-            dest_class = design["destination_class"]
-            amount = design["guaranteed_amount"]
+        destination_totals: dict[tuple[str, str], float] = {}
+        for design in SUBSTITUTION_INFLOW_DESIGN.values():
+            key = (design["destination_template"], design["destination_class"])
+            destination_totals[key] = destination_totals.get(key, 0.0) + design["guaranteed_amount"]
+
+        for (template, dest_class), expected_amount in destination_totals.items():
             _gross_ref, _outflow_ref, inflow_ref, _net_ref = _TEMPLATE_COLS[template]
 
             sheets = _sheets(corep, template)
             assert dest_class in sheets, (
-                f"{regime_key}/{guar_ref}: no {template} sheet for destination class "
+                f"{regime_key}: no {template} sheet for destination class "
                 f"{dest_class!r} — the inflow has nowhere to land"
             )
             total = _total_row(sheets[dest_class])
-            assert total[inflow_ref][0] == pytest.approx(amount), (
-                f"{regime_key}/{guar_ref}: {template}[{dest_class}] col {inflow_ref} "
-                f"expected {amount}, got {total[inflow_ref][0]}"
+            assert total[inflow_ref][0] == pytest.approx(expected_amount), (
+                f"{regime_key}: {template}[{dest_class}] col {inflow_ref} expected "
+                f"{expected_amount} (sum of every scenario mapped to this destination "
+                f"in SUBSTITUTION_INFLOW_DESIGN), got {total[inflow_ref][0]}"
             )
 
 

--- a/tests/contracts/data/citation_snapshot.json
+++ b/tests/contracts/data/citation_snapshot.json
@@ -468,7 +468,8 @@
     "CRR Art. 222"
   ],
   "rwa_calc.engine.sa.rw_adjustments::apply_guarantee_substitution": [
-    "CRR Art. 213"
+    "CRR Art. 193",
+    "CRR Art. 235"
   ],
   "rwa_calc.engine.sa.rw_adjustments::apply_intragroup_zero_rw": [
     "CRR Art. 113"

--- a/tests/expected_outputs/reporting/validation_known_breaks.json
+++ b/tests/expected_outputs/reporting/validation_known_breaks.json
@@ -110,24 +110,24 @@
       "templates_covered": 11
     },
     "crr/crm-substitution": {
-      "PASS": 114,
+      "PASS": 135,
       "FAIL": 3,
-      "VACUOUS": 94,
-      "NOT_EVALUATED": 530,
+      "VACUOUS": 83,
+      "NOT_EVALUATED": 520,
       "rules_enforced": 741,
-      "rules_executed": 211,
-      "templates_emitted": 10,
-      "templates_covered": 10
-    },
-    "b31/crm-substitution": {
-      "PASS": 162,
-      "FAIL": 13,
-      "VACUOUS": 173,
-      "NOT_EVALUATED": 460,
-      "rules_enforced": 808,
-      "rules_executed": 348,
+      "rules_executed": 221,
       "templates_emitted": 11,
       "templates_covered": 11
+    },
+    "b31/crm-substitution": {
+      "PASS": 175,
+      "FAIL": 11,
+      "VACUOUS": 171,
+      "NOT_EVALUATED": 451,
+      "rules_enforced": 808,
+      "rules_executed": 357,
+      "templates_emitted": 12,
+      "templates_covered": 12
     }
   },
   "known_broken_rules": [
@@ -139,8 +139,10 @@
       "portfolios": [
         "crm-substitution"
       ],
-      "failing_coordinates": 3,
+      "failing_coordinates": 5,
       "coordinates": [
+        "OF08.01.01.01[specialised_lending][c0050]",
+        "OF08.01.01.01[specialised_lending][c0070]",
         "OF08.01.01.01[corporate][c0040]",
         "OF08.01.01.01[corporate][c0050]",
         "OF08.01.01.01[corporate][c0070]"
@@ -162,40 +164,6 @@
         "OF08.01.01.01[corporate][c0070]"
       ],
       "expression": "{t: OF08.01.01.01, r: 0200} <= {t: OF08.01.01.01, r: 0190}"
-    },
-    {
-      "regime": "b31",
-      "rule_id": "boe_b0471",
-      "severity": "ERROR",
-      "reason": "GENUINE DEFECT in our output - NOT a published-rule artifact, and NOT the same family as the boe_b0378/boe_b0379 entries sitting next to it (those are a genuine null-vs-negated-column limitation of the rule; this is wrong output). What is wrong: C 07.00 col 0200 ('exposure value after CRM substitution effects, post-conversion factors') is bound to Sum(ead_col) over the origin/obligor population only (reporting/corep/c07.py), so it never reflects the CRM-substitution outflow leaving or the inflow arriving, while cols 0100->0110->0150 correctly net it through the waterfall and, since the risk-weight-banding fix, correctly band it per row too. Evidence: the CGCB inflow-only sheet's Total row shows 0100=0110=0150=4,900,000 but c0200=0.0; institution's 30% risk-weight-band row shows 0100=0110=0150=4,300,000 but c0200=1,500,000 (the native leg's EAD only, missing the 2,800,000 inflow); corporate's 30% band row shows 0100=0110=0150=0 (fully outflowed under substitution) but c0200=2,800,000 (the guaranteed leg's raw EAD, still counted at its origin sheet/row). Why not fixed here (notes.caution_on_plan_doc_definitions): F3 does NOT decide that col 0200 stays origin-basis - it does the opposite. F3's own text (docs/plans/phase7-declarative-reporting.md:573-576, the CR4/CR5 tranche) reads 'CR4 cols c/d/e/f and ALL CR5 rows key on `reporting_class` (post-substitution - C 07.00 col 0200 basis; the covered leg lands in the protection provider's row)' - it cites 'C 07.00 col 0200 basis' AS THE DEFINITION of the post-substitution basis, i.e. it assumed col 0200 already implemented it. CONSEQUENCE, CONFIRMED in the code, not just the plan doc: reporting/cellspec.py's shared RowPredicate binds two DELIBERATELY DIFFERENT fields - `classes=` to `pl.col('reporting_class')` (post-substitution) and `classes_origin=` to `pl.col('reporting_class_origin')` (origin). reporting/pillar3/cr4.py uses `classes_origin` for cols a/b and `classes` for cols c/d/e/f (an explicit origin/post-substitution split within one template); reporting/pillar3/cr5.py uses `classes` for every row and `classes_origin` NOWHERE (grep count: reporting_class x2, reporting_class_origin x0) - CR5's own recorded-limitation comment confirms a guaranteed `__G_` leg bands in the GUARANTOR'S row, not the obligor's. So CR4 cols c-f and ALL of CR5 are GENUINELY on the post-substitution basis F3 names. C 07.00's col 0200 is not: its binding is `CellSpec(Sum(ead_col), predicate=member)` (reporting/corep/c07.py) against the SHEET's own origin-class membership, with no substitution-netting Formula anywhere in it (contrast cols 0110/0150, which ARE Formulas over the waterfall). CR4 cols c-f / CR5 and C 07.00 col 0200 are therefore CONFIRMED on different bases, despite F3 citing one as the definition of the other. The actual gap is in F4 (S8-C07.00, same doc), which built C 07.00 and made only the 0040/0110/0150 waterfall substitution-aware; col 0200 and the CCF-bucket columns 0160-0190 were never brought into that treatment. This is a BUILD SHORTFALL against a recorded decision, not a recorded decision with a measured cost - this portfolio is the first to expose it. Why still not fixed in this PR: the remedy is not a one-line rebinding - col 0200 feeds the CCF-bucket identities (cols 0150-0180) this same rule tests, and the C 08.01 cousins (cols 0110/0260) sit on the same origin basis, so moving col 0200 alone risks making the return internally inconsistent in a different place. It needs its own scoped change with its own golden regen; the implementer has been made aware.",
-      "portfolios": [
-        "crm-substitution"
-      ],
-      "failing_coordinates": 6,
-      "coordinates": [
-        "OF07.00.01.01[central_govt_central_bank][r0010]",
-        "OF07.00.01.01[central_govt_central_bank][r0140]",
-        "OF07.00.01.01[institution][r0010]",
-        "OF07.00.01.01[institution][r0182]",
-        "OF07.00.01.01[corporate][r0010]"
-      ],
-      "expression": "{t: OF07.00.01.01, c: 0200} = {t: OF07.00.01.01, c: 0150} - (0.9 * {t: OF07.00.01.01, c: 0160}) - (0.8 * {t: OF07.00.01.01, c: 0170}) - (0.6 * {t: OF07.00.01.01, c: 0171}) - (0.5 * {t: OF07.00.01.01, c: 0180})"
-    },
-    {
-      "regime": "b31",
-      "rule_id": "boe_b0556",
-      "severity": "WARNING",
-      "reason": "GENUINE DEFECT in our output - NOT a published-rule artifact, and NOT the boe_b0378/boe_b0379 family. The weaker inequality form of boe_b0471/v0308_m - see that entry for the full mechanism: col 0200 sums raw EAD off the origin population, oblivious to CRM substitution, while col 0150 is post-substitution; F3 assumed col 0200 already implemented that basis (it defines 'post-substitution' BY REFERENCE to col 0200) rather than deciding col 0200 should stay origin-basis, so this is a build shortfall against F3/F4, not F3's decision, and it leaves C 07.00 col 0200 inconsistent with Pillar 3 CR4 cols c-f and ALL of CR5 (reporting/pillar3/cr4.py, cr5.py), confirmed in the code (reporting/cellspec.py's `classes=` vs `classes_origin=` RowPredicate split) to key on the SAME cited 'C 07.00 col 0200 basis' and DO correctly route a guaranteed leg to the protection provider's row. Fails wherever the sign flips: corporate's 30% risk-weight-band row reports c0200=2,800,000 (the guaranteed leg's raw EAD) against c0150=0 (fully outflowed under substitution), so 0200 <= 0150 is violated. Remedy: same as boe_b0471, and scoped together with it (col 0200's CCF-bucket dependents and the C 08.01 cousins on the same basis mean this needs its own change and golden regen, not a one-line rebinding). Not fixed in this PR.",
-      "portfolios": [
-        "crm-substitution"
-      ],
-      "failing_coordinates": 3,
-      "coordinates": [
-        "OF07.00.01.01[corporate][r0010]",
-        "OF07.00.01.01[corporate][r0070]",
-        "OF07.00.01.01[corporate][r0182]"
-      ],
-      "expression": "{t: OF07.00.01.01, c: 0200} <= {t: OF07.00.01.01, c: 0150}"
     },
     {
       "regime": "b31",
@@ -371,28 +339,11 @@
     },
     {
       "regime": "crr",
-      "rule_id": "v0308_m",
-      "severity": "ERROR",
-      "reason": "GENUINE DEFECT in our output - NOT a published-rule artifact. The CRR twin of boe_b0471 (same identity, coarser CCF-bucket coefficients: no 0171/0.6 term). What is wrong: C 07.00 col 0200 is bound to Sum(ead_col) over the origin/obligor population only (reporting/corep/c07.py), so it never reflects the CRM-substitution outflow leaving or the inflow arriving, while cols 0100->0110->0150 correctly net it through the waterfall. Evidence: the CGCB inflow-only sheet's Total/0% band rows show 0100=0110=0150=4,900,000 but c0200=0.0; corporate's Total row shows 0110=0150=5,200,000 (net of the 2,800,000 outflow) but c0200=8,000,000 (both legs' raw EAD, unreduced by the outflow). Why not fixed here (notes.caution_on_plan_doc_definitions): F3 does NOT decide that col 0200 stays origin-basis - it does the opposite. F3's own text (docs/plans/phase7-declarative-reporting.md:573-576, the CR4/CR5 tranche) reads 'CR4 cols c/d/e/f and ALL CR5 rows key on `reporting_class` (post-substitution - C 07.00 col 0200 basis; the covered leg lands in the protection provider's row)' - it cites 'C 07.00 col 0200 basis' AS THE DEFINITION of the post-substitution basis, i.e. it assumed col 0200 already implemented it. CONSEQUENCE, CONFIRMED in the code, not just the plan doc: reporting/cellspec.py's shared RowPredicate binds two DELIBERATELY DIFFERENT fields - `classes=` to `pl.col('reporting_class')` (post-substitution) and `classes_origin=` to `pl.col('reporting_class_origin')` (origin). reporting/pillar3/cr4.py uses `classes_origin` for cols a/b and `classes` for cols c/d/e/f (an explicit origin/post-substitution split within one template); reporting/pillar3/cr5.py uses `classes` for every row and `classes_origin` NOWHERE (grep count: reporting_class x2, reporting_class_origin x0) - CR5's own recorded-limitation comment confirms a guaranteed `__G_` leg bands in the GUARANTOR'S row, not the obligor's. So CR4 cols c-f and ALL of CR5 are GENUINELY on the post-substitution basis F3 names. C 07.00's col 0200 is not: its binding is `CellSpec(Sum(ead_col), predicate=member)` (reporting/corep/c07.py) against the SHEET's own origin-class membership, with no substitution-netting Formula anywhere in it (contrast cols 0110/0150, which ARE Formulas over the waterfall). CR4 cols c-f / CR5 and C 07.00 col 0200 are therefore CONFIRMED on different bases, despite F3 citing one as the definition of the other. The actual gap is in F4 (S8-C07.00, same doc), which built C 07.00 and made only the 0040/0110/0150 waterfall substitution-aware; col 0200 and the CCF-bucket columns were never brought into that treatment. This is a BUILD SHORTFALL against a recorded decision, not a recorded decision with a measured cost - this portfolio is the first to expose it. Why still not fixed in this PR: the remedy is not a one-line rebinding - col 0200 feeds the CCF-bucket identities this same rule tests, and the C 08.01 cousins (cols 0110/0260) sit on the same origin basis, so moving col 0200 alone risks making the return internally inconsistent in a different place. It needs its own scoped change with its own golden regen; the implementer has been made aware.",
-      "portfolios": [
-        "crm-substitution"
-      ],
-      "failing_coordinates": 6,
-      "coordinates": [
-        "C 07.00.a[central_govt_central_bank][r0010]",
-        "C 07.00.a[central_govt_central_bank][r0140]",
-        "C 07.00.a[corporate][r0010]",
-        "C 07.00.a[corporate][r0200]",
-        "C 07.00.a[institution][r0010]"
-      ],
-      "expression": "{c0200} = {c0150} - {c0160} - (0.8 * {c0170}) - (0.5 * {c0180})"
-    },
-    {
-      "regime": "crr",
       "rule_id": "v09782_m",
       "severity": "WARNING",
       "reason": "unattributed - needs investigation: C 08.06 total rows 0110/0120 do not foot their slotting-category rows. The rule is columns_scope '(All)', so the publisher asserts the identity on c0070 'Risk weight' too, where our total row carries an exposure-weighted average rather than a sum of the category risk weights. Not established whether our total is wrong or the identity is impractical on a parameter column",
       "portfolios": [
+        "crm-substitution",
         "rich"
       ],
       "failing_coordinates": 1,
@@ -407,6 +358,7 @@
       "severity": "WARNING",
       "reason": "unattributed - needs investigation: C 08.06 total rows 0110/0120 do not foot their slotting-category rows. The rule is columns_scope '(All)', so the publisher asserts the identity on c0070 'Risk weight' too, where our total row carries an exposure-weighted average rather than a sum of the category risk weights. Not established whether our total is wrong or the identity is impractical on a parameter column",
       "portfolios": [
+        "crm-substitution",
         "rich"
       ],
       "failing_coordinates": 1,
@@ -455,21 +407,6 @@
         "C 07.00.a[defaulted][c0060]"
       ],
       "expression": "{r0015} = empty"
-    },
-    {
-      "regime": "crr",
-      "rule_id": "v8726_m",
-      "severity": "WARNING",
-      "reason": "GENUINE DEFECT in our output - NOT a published-rule artifact. The weaker inequality form of v0308_m - see that entry for the full mechanism: col 0200 sums raw EAD off the origin population, oblivious to CRM substitution, while col 0150 is post-substitution; F3 assumed col 0200 already implemented that basis (it defines 'post-substitution' BY REFERENCE to col 0200) rather than deciding col 0200 should stay origin-basis, so this is a build shortfall against F3/F4, not F3's decision, and it leaves C 07.00 col 0200 inconsistent with Pillar 3 CR4 cols c-f and ALL of CR5 (reporting/pillar3/cr4.py, cr5.py), confirmed in the code (reporting/cellspec.py's `classes=` vs `classes_origin=` RowPredicate split) to key on the SAME cited 'C 07.00 col 0200 basis' and DO correctly route a guaranteed leg to the protection provider's row. Fails on corporate's Total row: c0200=8,000,000 (both legs' raw EAD) against c0150=5,200,000 (net of the 2,800,000 outflow), so 0200 <= 0150 is violated. Remedy: same as v0308_m, and scoped together with it (col 0200's CCF-bucket dependents and the C 08.01 cousins on the same basis mean this needs its own change and golden regen, not a one-line rebinding). Not fixed in this PR.",
-      "portfolios": [
-        "crm-substitution"
-      ],
-      "failing_coordinates": 2,
-      "coordinates": [
-        "C 07.00.a[corporate][r0010]",
-        "C 07.00.a[corporate][r0200]"
-      ],
-      "expression": "{c0200} <= {c0150}"
     }
   ],
   "known_uncovered_templates": [

--- a/tests/fixtures/reporting_crm_substitution_portfolio.py
+++ b/tests/fixtures/reporting_crm_substitution_portfolio.py
@@ -10,9 +10,14 @@ Why this portfolio: every substitution cell (C 07.00 cols 0050/0060/0090/0100,
 C 08.01 cols 0040/0050/0070/0080, C 08.02 col 0080) is exactly 0.0 in every one of
 the 70+ frozen golden ndjson files under ``tests/expected_outputs/reporting/`` —
 no golden portfolio contains a guaranteed exposure that migrates exposure class.
-This portfolio closes that blind spot with five guarantee legs, each on a
+This portfolio closes that blind spot with guarantee legs, each on a
 distinct obligor/guarantor pair with a distinct round guaranteed amount so a
-mis-posted cell is identifiable on sight.
+mis-posted cell is identifiable on sight. S1-S5 are all BENEFICIALLY substituted
+(``is_guarantee_beneficial`` derives True); S6 adds the DECLINED complement
+(Finding 4 / ``engine/aggregator/aggregator.py::_beneficial_gate``) — a guarantee
+that exists (``is_guaranteed=True``, positive ``guaranteed_portion``) but must
+NOT migrate class/approach or book any outflow/inflow, because the guarantor's
+risk weight is no better than the obligor's own.
 
 CRM substitution physically splits a guaranteed loan into a ``__G_<guarantor>``
 guaranteed leg and a ``__REM`` retained leg (``engine/crm/guarantees.py``). The
@@ -28,6 +33,19 @@ per leg:
         therefore never appears as a ROW on the guarantor's own class sheet —
         it stays on the obligor's ORIGIN sheet, contributing to that sheet's
         outflow column (C 07.00 col 0090 / C 08.01 col 0070).
+        NO LONGER TRUE FOR C 07.00 as of task #8 (landed): C 07.00's exposure
+        value / RWEA columns (0200/0210/0211/0215/0216/0217/0220/0230/0235 +
+        the CCF buckets) now read a per-sheet UNION of the origin and
+        post-substitution populations (``c07_basis_origin`` /
+        ``c07_basis_post`` in ``reporting/corep/c07.py::_prepare``), so a
+        beneficially-substituted leg DOES appear as a row on the guarantor's
+        own C 07.00 sheet for those columns — the flow/gross columns still
+        key on the origin population alone, so the SENTENCE'S ORIGIN-sheet-
+        KEYING claim (which sheet a leg's outflow posts to) remains true; only
+        the stronger "never appears as a row at all" reading is now false.
+        Kept rather than deleted because the keying half still holds and the
+        distinction is easy to miss. C 08.01 is unaffected (task #8 scoped to
+        C 07.00 only; see task #9/S3 for the equivalent C 08.01 work).
     reporting_class / reporting_approach = the POST-substitution twin
         (``exposure_class_post_crm`` / ``approach_post_crm``) — the guarantor's
         class on the ``__G_`` leg. This is NOT a sheet key; it feeds the
@@ -47,9 +65,14 @@ per leg:
         complement and routes to C 07.00 — independent of which population
         the OUTFLOW leg itself sits in, so an IRB-origin obligor with an
         SA-treated guarantor puts the outflow on C 08.01 and the inflow on
-        C 07.00 (see S3 below). Every leg with a positive
-        ``guaranteed_portion`` is counted, including one whose guarantor sits
-        in the obligor's own class (see S5 below).
+        C 07.00 (see S3 below). Every BENEFICIALLY-SUBSTITUTED leg is
+        counted (``is_guarantee_beneficial`` True — the guarantor's risk
+        weight beats the obligor's own), including one whose guarantor sits
+        in the obligor's own class (see S5 below); a DECLINED leg (guarantor
+        no better than the obligor — see S6 below) is NOT counted and
+        produces no outflow/inflow at all despite keeping a positive
+        ``guaranteed_portion`` (Finding 4 /
+        ``engine/aggregator/aggregator.py::_beneficial_gate``).
 
 ``substitution_inflows`` retired the two former per-template helpers
 (``c07.py``'s and ``c08.py``'s own class-inequality-gated inflow builders,
@@ -57,7 +80,7 @@ each keyed to its OWN approach-filtered population) precisely because that
 split could report an outflow on one template and land its inflow on
 NEITHER — the defect S3 isolates — and its class-inequality gate excluded a
 same-class migration from both sides at once — the defect S5 isolates. This
-is what makes the five scenarios below orthogonal rather than redundant:
+is what makes the scenarios below orthogonal rather than redundant:
 
     ref    | obligor        | guarantor              | outflow | inflow  | what it exercises
     -------|----------------|-------------------------|---------|---------|------------------------------
@@ -89,6 +112,25 @@ is what makes the five scenarios below orthogonal rather than redundant:
            |                |                          |         |         | destination sheet IS the
            |                |                          |         |         | origin sheet, not merely a
            |                |                          |         |         | sheet that happens to exist
+    S6     | slotting       | unrated non-GB sovereign, | none   | none    | DECLINED: guarantor SA RW
+           | (specialised_  | NO own exposure          |         |         | (1.00, CQS.UNRATED) is NOT
+           | lending,       |                          |         |         | better than the slotting
+           | "strong")      |                          |         |         | "strong" weight (0.70), so
+           |                |                          |         |         | ``is_guarantee_beneficial``
+           |                |                          |         |         | derives False through the
+           |                |                          |         |         | real engine path (Art. 213 /
+           |                |                          |         |         | 193(1)) — no migration, no
+           |                |                          |         |         | outflow, no inflow, despite
+           |                |                          |         |         | a positive
+           |                |                          |         |         | ``guaranteed_portion``. Also
+           |                |                          |         |         | the fixture's only slotting-
+           |                |                          |         |         | origin leg (S1-S5 cover only
+           |                |                          |         |         | IRB-graded and SA obligors)
+           |                |                          |         |         | — reproduces Finding 4's
+           |                |                          |         |         | worked example verbatim
+           |                |                          |         |         | (10,000,000 "strong" slotting
+           |                |                          |         |         | loan, unrated non-GB sovereign
+           |                |                          |         |         | guarantor)
 
 S1/S4 are the happy-path pair (one IRB, one SA) proving the mechanism works
 when the destination class already has a native row. S2 isolates the
@@ -104,23 +146,43 @@ where ``pre_crm_exposure_class == post_crm_exposure_class_guaranteed`` and a
 correct implementation must still recognise BOTH an outflow (col 0070 /
 C 07.00 col 0090) and an equal inflow (col 0080 / C 07.00 col 0100) on that
 one sheet, netting to no change in the post-substitution total (col 0090 /
-col 0110) despite nothing leaving the class. This is the fixture-level
-reproduction backing the CRM substitution investigation tracked against
+col 0110) despite nothing leaving the class. S6 isolates a FOURTH, orthogonal
+case none of S1-S5 exercise at all: the guarantee GATE itself. S1-S5 are all
+beneficially substituted by construction, so a reporting-layer regression that
+deleted the ``is_guarantee_beneficial`` check entirely (migrating every
+guarantee regardless of benefit) would move none of their numbers — S6 is the
+only scenario that would move if that gate regressed, and it doubles as the
+fixture's only slotting-origin leg. This is the fixture-level reproduction
+backing the CRM substitution investigation tracked against
 C 07.00/C 08.01/C 08.02; see the module-level ``NOTE`` below for the specific
 behaviour observed when this fixture was built and verified.
 
-NOTE (as observed 2026-08-02, CRR, on ``fix/corep-crm-substitution-waterfall``
-— re-verify against a live run before relying on this as a current-state
-claim, since it was recorded mid-investigation): all five scenarios land
-correctly, and portfolio-wide gross (40,500,000) reconciles exactly to net
-across every sheet with zero leakage. Per sheet, Total row:
+NOTE (as observed 2026-08-04, CRR and B31, via a direct
+``PipelineOrchestrator`` + ``COREPGenerator`` run against the fixture-builder
+verification build — re-verify against a live run before relying on this as a
+current-state claim): all six scenarios land correctly and identically under
+both regimes, and portfolio-wide gross (50,500,000, up from 40,500,000 with
+S6's 10,000,000 added) reconciles exactly to net across every sheet with zero
+leakage. Per sheet, Total row (unchanged from the S1-S5-only figures below —
+S6 perturbs neither, by design):
 
-    c08_01 corporate    : 0020=27,000,000  0040=-12,300,000  0050=-3,300,000  0070=-15,600,000  0080=+5,400,000  0090=16,800,000
-    c08_01 institution   : 0020= 4,000,000                                                        0080=+2,000,000  0090= 6,000,000
-    c08_01 retail_other  : 0020=         0                                                          0080=+3,300,000  0090= 3,300,000   <- S2, inflow-only sheet
-    c07_00 corporate     : 0010= 8,000,000                                    0060=-2,800,000  0090=-2,800,000                    0110= 5,200,000
-    c07_00 institution   : 0010= 1,500,000                                                                          0100=+2,800,000  0110= 4,300,000
-    c07_00 cgcb          : 0010=         0                                                                          0100=+4,900,000  0110= 4,900,000   <- S3, inflow-only sheet
+    c08_01 corporate            : 0020=27,000,000  0040=-12,300,000  0050=-3,300,000  0070=-15,600,000  0080=+5,400,000  0090=16,800,000
+    c08_01 institution           : 0020= 4,000,000                                                        0080=+2,000,000  0090= 6,000,000
+    c08_01 retail_other          : 0020=         0                                                          0080=+3,300,000  0090= 3,300,000   <- S2, inflow-only sheet
+    c08_01 specialised_lending   : 0020=10,000,000                             0070=         0  0080=         0  0090=10,000,000   <- S6, DECLINED
+    c07_00 corporate             : 0010= 8,000,000                                    0060=-2,800,000  0090=-2,800,000                    0110= 5,200,000
+    c07_00 institution           : 0010= 1,500,000                                                                          0100=+2,800,000  0110= 4,300,000
+    c07_00 cgcb                  : 0010=         0                                                                          0100=+4,900,000  0110= 4,900,000   <- S3 ONLY
+
+S6's ``specialised_lending`` sheet has NO outflow and NO inflow (0070/0080
+both 0) — its net (col 0090) equals its gross (col 0020) with nothing having
+moved, and ``rwa_final`` sums to 7,000,000 (== 10,000,000 x 0.70, the
+undiminished slotting weight) under BOTH regimes identically. The ``cgcb``
+sheet's col 0100 stays exactly S3's 4,900,000 — S6's guarantor shares that
+SAME class, so a regression that applied the decline anyway would inflate
+this EXISTING, already-asserted cell to 9,400,000 rather than create a new
+one, which is what makes S6 the sharpest possible pin on the gate (see
+``DECLINED_GUARANTEE_DESIGN`` below).
 
 S5's isolated ``corporate`` sheet Total row (S5 alone, no other scenario on
 the sheet) reports ``0020=9,000,000 / 0040=-5,400,000 / 0070=-5,400,000 /
@@ -129,11 +191,13 @@ Annex II requires), matching ``v1663_m`` ({c0070} = {c0040}+{c0050}+{c0060})
 and the corrected col 0090 waterfall.
 
 Every guarantee is PARTIAL cover (never 100%), so a retained ``__REM`` leg
-genuinely coexists with the ``__G_`` leg on all five scenarios, and every
+genuinely coexists with the ``__G_`` leg on all six scenarios, and every
 guaranteed amount is a distinct round GBP figure so any template cell is
-traceable to exactly one leg. ``protection_type`` covers both values Annex II
-splits (C 08.01 cols 0040/0050): S1/S3/S5 are ``"guarantee"``, S2/S4 are
-``"credit_derivative"``.
+traceable to exactly one leg — including S6, whose decline means that figure
+should appear on NO outflow/inflow cell anywhere; its only footprint is the
+undiminished gross total on its own native sheet. ``protection_type`` covers
+both values Annex II splits (C 08.01 cols 0040/0050): S1/S3/S5/S6 are
+``"guarantee"``, S2/S4 are ``"credit_derivative"``.
 
 No CRR/Basel 3.1 regime divergence is exercised here (deliberately, unlike
 ``reporting_irb_classes_portfolio.py``'s sovereign-class carve-out) — every
@@ -146,23 +210,35 @@ diverge.
 References:
 - CRR Art. 235 / PS1/26 Art. 235: SA risk-weight substitution (RWSM).
 - CRR Art. 161 / CRE22.70-85: IRB parameter substitution (PSM).
+- CRR Art. 153(5) / PS1/26 Art. 153(5): specialised-lending slotting
+  categories and risk weights (S6's obligor).
 - CRR Art. 114(4)/(7) / Art. 235(3): the domestic-currency CGCB 0% RW
-  extension to a centrally-guaranteed exposure (S3's guarantor).
+  extension to a centrally-guaranteed exposure (S3's guarantor); S6's
+  guarantor is a non-GB sovereign specifically so this extension does NOT
+  apply and the unrated CQS fallback (1.00) governs instead.
+- CRR Art. 213 / Art. 193(1) / Art. 113(3): a guarantee must never raise
+  capital — the basis for declining a non-beneficial guarantee (S6). See
+  task #13 (S0-revise) for the citation-basis correction from Art. 213 alone
+  to Art. 193(1) (mandatory, per-exposure) + Art. 113(3) (the permissive
+  amendment hook Art. 235(1) is framed against).
 - CRR Art. 201: eligible-guarantor eligibility gate.
 - COREP Annex II, C 07.00 / C 08.01 / C 08.02: the outflow/inflow columns,
   including the same-exposure-class inflow/outflow requirement (S5).
 - engine/crm/guarantees.py: the ``__G_`` / ``__REM`` physical split.
 - engine/aggregator/aggregator.py: ``_add_reporting_projection`` (the sealed
-  ``reporting_class`` / ``reporting_class_origin`` twins).
+  ``reporting_class`` / ``reporting_class_origin`` twins) and
+  ``_beneficial_gate`` (the S6 decline gate this fixture pins — Finding 4).
 - reporting/corep/c07.py, reporting/corep/c08.py: module docstrings on sheet
   keying (each reads its per-class rows off ``reporting_class_origin``, the
   obligor basis).
 - reporting/corep/crm_substitution.py: ``substitution_inflows`` — the single
   cross-template inflow router keyed on ``reporting_approach`` (S3), which
-  counts every leg with a positive ``guaranteed_portion`` including same-class
-  ones (S5); ``crm_waterfall`` / ``waterfall_refs`` — the C 08.01/02 col 0090
-  identity this fixture also exercises (0090 = 0020 - 0070 + 0080 over
-  positive magnitudes, col 0070 as the single whole-outflow subtotal).
+  counts every BENEFICIALLY-SUBSTITUTED leg (not merely every leg with a
+  positive ``guaranteed_portion`` — S6 has one and is excluded) including
+  same-class ones (S5); ``crm_waterfall`` / ``waterfall_refs`` — the
+  C 08.01/02 col 0090 identity this fixture also exercises (0090 = 0020 -
+  0070 + 0080 over positive magnitudes, col 0070 as the single whole-outflow
+  subtotal).
 """
 
 from __future__ import annotations
@@ -173,7 +249,13 @@ import polars as pl
 
 from rwa_calc.contracts.bundles import RawDataBundle
 from rwa_calc.data.column_spec import dtypes_of
-from rwa_calc.data.schemas import COUNTERPARTY_SCHEMA, GUARANTEE_SCHEMA, LOAN_SCHEMA, RATINGS_SCHEMA
+from rwa_calc.data.schemas import (
+    COUNTERPARTY_SCHEMA,
+    GUARANTEE_SCHEMA,
+    LOAN_SCHEMA,
+    RATINGS_SCHEMA,
+    SPECIALISED_LENDING_SCHEMA,
+)
 from tests.fixtures.irb_test_helpers import create_full_irb_model_permissions
 from tests.fixtures.raw_bundle import make_raw_bundle
 
@@ -217,6 +299,15 @@ GTOR_S5: str = "CSUB-CP-GTOR-S5"
 LN_S5: str = "CSUB-LN-S5"
 GUAR_S5: str = "CSUB-GUAR-S5"
 
+# -- S6: slotting obligor, unrated non-GB sovereign guarantor -- DECLINED ---
+# (guarantor SA RW >= the slotting weight, so ``is_guarantee_beneficial``
+# derives False through the real engine path; no own exposure needed since
+# a declined guarantee never creates an inflow to pre-establish a sheet for).
+OB_S6: str = "CSUB-CP-OB-S6"
+GTOR_S6: str = "CSUB-CP-GTOR-S6"
+LN_S6: str = "CSUB-LN-S6"
+GUAR_S6: str = "CSUB-GUAR-S6"
+
 #: Drawn amounts (GBP), each a distinct round figure. EAD = drawn_amount (no
 #: facility / CCF machinery involved — every row is a plain drawn term loan).
 DRAWN_S1: float = 5_000_000.0
@@ -226,14 +317,21 @@ DRAWN_S3: float = 7_000_000.0
 DRAWN_S4: float = 8_000_000.0
 DRAWN_S4_GTOR_OWN: float = 1_500_000.0
 DRAWN_S5: float = 9_000_000.0
+#: Matches Finding 4's worked reproduction verbatim (see
+#: ``engine/aggregator/aggregator.py::_beneficial_gate``) — a 10,000,000
+#: project-finance "strong" slotting loan.
+DRAWN_S6: float = 10_000_000.0
 
 #: Guarantee coverage — always PARTIAL, so a retained ``__REM`` leg coexists
-#: with the ``__G_`` leg on every scenario. Distinct percentages per scenario.
+#: with the ``__G_`` leg on every scenario, including the DECLINED S6 (a
+#: decline is not the same thing as no cover — the protection exists, the
+#: engine just must not apply it). Distinct percentages per scenario.
 PCT_COVERED_S1: float = 0.40
 PCT_COVERED_S2: float = 0.55
 PCT_COVERED_S3: float = 0.70
 PCT_COVERED_S4: float = 0.35
 PCT_COVERED_S5: float = 0.60
+PCT_COVERED_S6: float = 0.45
 
 #: amount_covered = drawn_amount * pct_covered, rounded to a clean GBP figure.
 AMOUNT_COVERED_S1: float = DRAWN_S1 * PCT_COVERED_S1  # 2,000,000
@@ -241,6 +339,9 @@ AMOUNT_COVERED_S2: float = DRAWN_S2 * PCT_COVERED_S2  # 3,300,000
 AMOUNT_COVERED_S3: float = DRAWN_S3 * PCT_COVERED_S3  # 4,900,000
 AMOUNT_COVERED_S4: float = DRAWN_S4 * PCT_COVERED_S4  # 2,800,000
 AMOUNT_COVERED_S5: float = DRAWN_S5 * PCT_COVERED_S5  # 5,400,000
+#: S6 is DECLINED, so this figure should appear on NO outflow/inflow cell —
+#: see ``DECLINED_GUARANTEE_DESIGN`` below.
+AMOUNT_COVERED_S6: float = DRAWN_S6 * PCT_COVERED_S6  # 4,500,000
 
 #: Internal PDs (IRB legs only). Each guarantor with an internal PD is a
 #: deliberately IRB-routing signal — see ``_assign_guarantor_approach``
@@ -264,6 +365,17 @@ PD_GTOR_S5: float = 0.0045
 CQS_GTOR_S3: int = 1
 #: CQS 2 institution -> a defined, non-zero SA risk weight.
 CQS_GTOR_S4: int = 2
+#: GTOR_S6 carries NO rating row at all (unrated) — the ``cgcb_risk_weights``
+#: pack table's ``CQS.UNRATED`` entry (1.00, both regimes) then governs, well
+#: above the 0.70 "strong" slotting weight it is compared against. Its
+#: country_code is deliberately non-GB so the Art. 114(4)/(7) domestic-CGCB
+#: 0% short-circuit (S3's path) does NOT apply here — this is the plain
+#: unrated-sovereign fallback, not the domestic carve-out.
+
+#: S6's obligor slotting category (CRR/PS1/26 Art. 153(5) Table A, remaining
+#: maturity >= 2.5y, non-HVCRE): "strong" -> 0.70 under BOTH regimes
+#: (identical entries in ``rulebook/packs/{crr,b31}.py::slotting_rw_base``).
+SLOTTING_CATEGORY_S6: str = "strong"
 
 _VALUE_DATE: date = date(2020, 1, 1)
 #: Beyond both reporting dates under test (CRR 2025-06-30, B31 2027-06-30).
@@ -293,6 +405,12 @@ LOAN_EXPECTED_ORIGIN_SHEET_CRR: dict[str, tuple[str, str]] = {
     LN_S4: ("c07", "corporate"),
     LN_S4_GTOR_OWN: ("c07", "institution"),
     LN_S5: ("c08_01", "corporate"),
+    # Slotting is its OWN IRB exposure class (ExposureClass.SPECIALISED_LENDING),
+    # not merged into "corporate" — that Art. 112 Table A2 merge is a C 07.00
+    # SA-side rule only (``c07.py::_merge_specialised_lending``); C 08.01 keys
+    # slotting-origin legs on the raw class ("C 08.01 does NOT exclude
+    # slotting" — ``c08.py::c08_01_plans``). No S1-S5 loan reaches this sheet.
+    LN_S6: ("c08_01", "specialised_lending"),
 }
 #: No regime divergence is exercised in this portfolio (see module docstring)
 #: — identical to the CRR map.
@@ -378,6 +496,53 @@ SUBSTITUTION_INFLOW_DESIGN: dict[str, dict[str, object]] = {
         "destination_has_native_population": True,
         "same_class": True,
     },
+    # GUAR_S6 is DELIBERATELY ABSENT: it is DECLINED, so it has no
+    # destination — see ``DECLINED_GUARANTEE_DESIGN`` below. Adding it here
+    # with a zero/blank destination would silently corrupt
+    # ``TestPerScenarioInflowLandsOnce`` (``test_crm_substitution_flows.py``),
+    # which iterates this dict generically and asserts the recorded
+    # ``guaranteed_amount`` lands on the recorded destination sheet: S6's
+    # guarantor shares GTOR_S3's class (``central_govt_central_bank``), which
+    # already has a real inflow from S3, so a zero-amount S6 entry would
+    # wrongly assert that shared sheet's inflow column is 0.0.
+}
+
+#: S6's declined-guarantee design intent (Finding 4 /
+#: ``engine/aggregator/aggregator.py::_beneficial_gate``): a guarantee the
+#: engine DECLINES — guarantor SA risk weight no better than the leg's own —
+#: produces NO substitution effect at all. The covered leg keeps the
+#: obligor's basis end to end:
+#:   - ``exposure_class_post_crm`` stays ``exposure_class_applied``
+#:     (no class migration)
+#:   - ``approach_post_crm`` stays ``approach_applied`` (no approach migration)
+#:   - the origin sheet's outflow column (C 08.01 col 0070) gets NO
+#:     contribution from this leg
+#:   - NO guarantor-class sheet anywhere receives an inflow from this leg —
+#:     in particular, GTOR_S6's class (``central_govt_central_bank``) already
+#:     carries a real inflow from S3 (``AMOUNT_COVERED_S3`` on C 07.00 col
+#:     0100); a regression that applied S6 anyway would inflate THAT existing
+#:     cell by exactly ``AMOUNT_COVERED_S6``, not create a new one — the
+#:     sharpest possible pin, since it reuses an already-asserted cell rather
+#:     than an empty one
+#: even though ``is_guaranteed`` stays True and ``guaranteed_portion`` stays
+#: positive throughout (the physical ``__G_`` / ``__REM`` split happens
+#: upstream of the benefit decision — see ``engine/crm/guarantees.py``).
+#: fixture-builder does not assert the engine's CURRENT behaviour here (that
+#: is test-writer's job over a live pipeline run) — this dict only records
+#: the fixture's DESIGN intent, as required by Finding 4 / task #7's fix.
+DECLINED_GUARANTEE_DESIGN: dict[str, dict[str, object]] = {
+    GUAR_S6: {
+        "loan_reference": LN_S6,
+        "guarantor_reference": GTOR_S6,
+        "guaranteed_amount": AMOUNT_COVERED_S6,
+        "origin_class": "specialised_lending",
+        "origin_template": "c08_01",
+        # The class a beneficial substitution WOULD have targeted, and the
+        # sheet that already exists (from S3) to receive it if the gate ever
+        # regresses.
+        "would_be_destination_class": "central_govt_central_bank",
+        "would_be_destination_template": "c07",
+    },
 }
 
 
@@ -412,6 +577,7 @@ def build_reporting_crm_substitution_bundle() -> RawDataBundle:
         loans=_loans(),
         ratings=_ratings(),
         guarantees=_guarantees(),
+        specialised_lending=_specialised_lending(),
         model_permissions=create_full_irb_model_permissions(),
     )
 
@@ -422,16 +588,25 @@ def build_reporting_crm_substitution_bundle() -> RawDataBundle:
 
 
 def _counterparties() -> pl.DataFrame:
-    """Five obligor/guarantor pairs, one per scenario.
+    """Six obligor/guarantor pairs, one per scenario.
 
-    Obligors are all ``corporate`` (S1-S3/S5 above the SME revenue ceiling so
-    the supporting factor never perturbs a substitution cell; S4 unrated so
-    its own-basis SA risk weight is unambiguous). Guarantors span the four SA
-    classes ``ENTITY_TYPE_TO_SA_CLASS`` can reach from a counterparty
-    (``institution`` x2, ``individual`` -> retail_other, ``sovereign`` ->
+    Obligors S1-S3/S5 are ``corporate`` above the SME revenue ceiling so the
+    supporting factor never perturbs a substitution cell; S4 is unrated so its
+    own-basis SA risk weight is unambiguous; S6 is ``corporate`` too — like
+    ``reporting_portfolio.py``'s slotting counterparty, specialised-lending
+    routing comes from the ``specialised_lending`` join row (``_specialised_
+    lending``), NOT from ``entity_type`` — plus a matching ``model_id``-only
+    (no PD) rating so F-IRB/A-IRB stay unavailable and the exposure falls to
+    slotting (CRR Art. 153(5)). Guarantors span the four SA classes
+    ``ENTITY_TYPE_TO_SA_CLASS`` can reach from a counterparty (``institution``
+    x2, ``individual`` -> retail_other, ``sovereign`` x2 ->
     central_govt_central_bank), PLUS a fifth guarantor deliberately in the
     SAME class as its obligor (``corporate`` — S5) — see the module docstring
-    table.
+    table. GTOR_S6 is UNRATED (no rating row at all, like OB_S4) and non-GB
+    (``US``) so neither an ECAI rating nor the Art. 114(4)/(7) domestic-CGCB
+    0% carve-out can make its guarantee beneficial — only the plain
+    ``CQS.UNRATED`` fallback (1.00) applies, strictly above the 0.70 slotting
+    weight it is compared against.
     """
     rows: list[dict] = [
         {
@@ -496,6 +671,19 @@ def _counterparties() -> pl.DataFrame:
             "country_code": "GB",
             "annual_revenue": _LARGE_CORPORATE_REVENUE,
         },
+        {
+            "counterparty_reference": OB_S6,
+            "entity_type": "corporate",
+            "country_code": "GB",
+            "annual_revenue": _LARGE_CORPORATE_REVENUE,
+        },
+        {
+            # Unrated, non-GB: the plain CQS.UNRATED sovereign fallback (1.00)
+            # applies — see the docstring above.
+            "counterparty_reference": GTOR_S6,
+            "entity_type": "sovereign",
+            "country_code": "US",
+        },
     ]
     return pl.DataFrame(rows, schema_overrides=dtypes_of(COUNTERPARTY_SCHEMA))
 
@@ -503,7 +691,10 @@ def _counterparties() -> pl.DataFrame:
 def _ratings() -> pl.DataFrame:
     """Internal PD ratings for IRB legs, external CQS ratings for SA legs.
 
-    OB_S4 is deliberately unrated (no row at all) — a plain Standardised loan.
+    OB_S4 and GTOR_S6 are deliberately unrated (no row at all) — a plain
+    Standardised loan and an unrated sovereign guarantor respectively. OB_S6
+    carries a ``model_id``-only rating (no PD) — see ``_internal_no_pd`` and
+    the ``_counterparties`` docstring.
     """
     rows: list[dict] = [
         _internal(OB_S1, pd=PD_OB_S1),
@@ -515,19 +706,24 @@ def _ratings() -> pl.DataFrame:
         _external(GTOR_S4, cqs=CQS_GTOR_S4),
         _internal(OB_S5, pd=PD_OB_S5),
         _internal(GTOR_S5, pd=PD_GTOR_S5),
+        _internal_no_pd(OB_S6),
     ]
     return pl.DataFrame(rows, schema_overrides=dtypes_of(RATINGS_SCHEMA))
 
 
 def _loans() -> pl.DataFrame:
-    """The five obligor loans plus the two guarantors' own exposures.
+    """The six obligor loans plus the two guarantors' own exposures.
 
-    GTOR_S5 gets NO own loan — S5's whole point is that its class already has
-    an origin sheet (``corporate``, from OB_S1/OB_S2/OB_S3/OB_S5 alike), so no
-    separate own-exposure is needed to pre-establish it.
+    GTOR_S5 and GTOR_S6 get NO own loan — S5's class already has an origin
+    sheet (``corporate``, from OB_S1/OB_S2/OB_S3/OB_S5 alike) and S6 is
+    DECLINED so it never creates an inflow that would need a sheet
+    pre-established for it (see the module docstring).
 
     No ``lgd`` is supplied on any row, so every IRB leg resolves F-IRB
     (supervisory LGD) — consistent with ``reporting_irb_classes_portfolio.py``.
+    LN_S6 is a plain drawn term loan like every other row here — slotting
+    routing comes entirely from the ``specialised_lending`` join
+    (``_specialised_lending``), not from ``product_type``.
     """
     rows: list[dict] = [
         _loan(LN_S1, OB_S1, DRAWN_S1),
@@ -537,19 +733,44 @@ def _loans() -> pl.DataFrame:
         _loan(LN_S4, OB_S4, DRAWN_S4),
         _loan(LN_S4_GTOR_OWN, GTOR_S4, DRAWN_S4_GTOR_OWN),
         _loan(LN_S5, OB_S5, DRAWN_S5),
+        _loan(LN_S6, OB_S6, DRAWN_S6),
     ]
     return pl.DataFrame(rows, schema_overrides=dtypes_of(LOAN_SCHEMA))
 
 
+def _specialised_lending() -> pl.DataFrame:
+    """S6's one project-finance slotting exposure ("strong" category).
+
+    Mirrors ``reporting_portfolio.py``'s ``_specialised_lending`` exactly —
+    the same (``sl_type``, ``slotting_category``, ``is_hvcre``) combination,
+    a PROVEN pattern already exercised by that widely-used golden fixture.
+    """
+    return pl.DataFrame(
+        [
+            {
+                "counterparty_reference": OB_S6,
+                "sl_type": "project_finance",
+                "slotting_category": SLOTTING_CATEGORY_S6,
+                "is_hvcre": False,
+            }
+        ],
+        schema_overrides=dtypes_of(SPECIALISED_LENDING_SCHEMA),
+    )
+
+
 def _guarantees() -> pl.DataFrame:
-    """The five guarantee rows — one per scenario, each partial cover.
+    """The six guarantee rows — one per scenario, each partial cover.
 
     ``protection_type`` alternates ``"guarantee"`` / ``"credit_derivative"``
     so both C 08.01 cols 0040/0050 are exercised. ``includes_restructuring``,
     matched maturity/currency, and both unilateral flags False on every row —
     no eligibility gate or maturity-mismatch haircut should zero any leg (see
     the module docstring; confirmed empirically, not merely asserted, in the
-    fixture-builder verification run).
+    fixture-builder verification run). GUAR_S6's ELIGIBILITY is unaffected by
+    any of this — it is fully eligible protection that the engine correctly
+    declines to APPLY because it would not help (guarantor RW >= own RW),
+    which is a wholly different gate (CRR Art. 213 / Art. 193(1), not
+    Art. 201).
     """
     rows: list[dict] = [
         _guarantee(GUAR_S1, GTOR_S1, LN_S1, AMOUNT_COVERED_S1, PCT_COVERED_S1, "guarantee"),
@@ -557,6 +778,7 @@ def _guarantees() -> pl.DataFrame:
         _guarantee(GUAR_S3, GTOR_S3, LN_S3, AMOUNT_COVERED_S3, PCT_COVERED_S3, "guarantee"),
         _guarantee(GUAR_S4, GTOR_S4, LN_S4, AMOUNT_COVERED_S4, PCT_COVERED_S4, "credit_derivative"),
         _guarantee(GUAR_S5, GTOR_S5, LN_S5, AMOUNT_COVERED_S5, PCT_COVERED_S5, "guarantee"),
+        _guarantee(GUAR_S6, GTOR_S6, LN_S6, AMOUNT_COVERED_S6, PCT_COVERED_S6, "guarantee"),
     ]
     return pl.DataFrame(rows, schema_overrides=dtypes_of(GUARANTEE_SCHEMA))
 
@@ -631,4 +853,19 @@ def _external(counterparty_reference: str, *, cqs: int) -> dict:
         "cqs": cqs,
         "rating_date": _VALUE_DATE,
         "is_solicited": True,
+    }
+
+
+def _internal_no_pd(counterparty_reference: str) -> dict:
+    """Internal rating carrying only ``model_id`` (no PD) — for slotting
+    routing (mirrors ``reporting_portfolio.py``'s helper of the same name):
+    with no internal PD the F-IRB/A-IRB branches are unavailable, so a
+    counterparty with a matching ``specialised_lending`` row falls to
+    slotting (CRR Art. 153(5))."""
+    return {
+        "rating_reference": f"CSUB-RTG-{counterparty_reference}",
+        "counterparty_reference": counterparty_reference,
+        "rating_type": "internal",
+        "model_id": _MODEL_ID,
+        "rating_date": _VALUE_DATE,
     }

--- a/tests/fixtures/reporting_crm_substitution_portfolio.py
+++ b/tests/fixtures/reporting_crm_substitution_portfolio.py
@@ -17,7 +17,33 @@ mis-posted cell is identifiable on sight. S1-S5 are all BENEFICIALLY substituted
 (Finding 4 / ``engine/aggregator/aggregator.py::_beneficial_gate``) — a guarantee
 that exists (``is_guaranteed=True``, positive ``guaranteed_portion``) but must
 NOT migrate class/approach or book any outflow/inflow, because the guarantor's
-risk weight is no better than the obligor's own.
+risk weight is no better than the obligor's own. S7 adds a SECOND blind spot,
+on the COUNTRY axis rather than the class axis: S1-S6, verified by direct
+inspection, put every counterparty that ever reaches a reported leg in GB —
+S6's non-GB (US) guarantor is DECLINED, so its country never reaches a leg at
+all (see the OB_S7/GTOR_S7 constant declarations below). PRA PS1/26 Annex II
+Section 3.4 para 87 (C 09.01/C 09.02 geographical breakdown) requires "original
+exposure pre-conversion factors" to key the country of residence of the
+IMMEDIATE obligor, while "exposure value" and "Risk-weighted exposure amounts"
+key the country of residence of the ULTIMATE obligor — a column-level basis
+split that migrates with a beneficial guarantee exactly as class does (para 86:
+"CRM techniques with substitution effects can change the allocation of an
+exposure to a country"). A GB-only portfolio cannot exercise that split at all:
+immediate and ultimate obligor are the same country on every leg, so the two
+bases are indistinguishable. S7 is a beneficially-substituted guarantee whose
+guarantor sits in a different country from its obligor, closing that gap.
+
+S8 adds a THIRD blind spot, orthogonal to both: no beneficially-substituted
+SLOTTING leg exists anywhere (S6, the fixture's only slotting-origin leg, is
+DECLINED), so COREP C 08.06 / Pillar 3 CR10's per-category risk-weight
+columns are never reached at all. Worse than a coverage gap: a slotting
+category holding BOTH an unguaranteed leg (at the category's own weight) and
+a substituted leg (at the guarantor's) produces a MEANINGLESS EAD-weighted
+BLENDED risk weight that sits inside the category's own band and looks
+plausible rather than obviously wrong — a single fully-guaranteed leg would
+not expose this. S8 reproduces exactly that two-leg shape in its own
+isolated category. See the OB_S8/GTOR_S8 constant declarations below for
+the production-shaped prototype that surfaced this and the full mechanism.
 
 CRM substitution physically splits a guaranteed loan into a ``__G_<guarantor>``
 guaranteed leg and a ``__REM`` retained leg (``engine/crm/guarantees.py``). The
@@ -131,6 +157,59 @@ is what makes the scenarios below orthogonal rather than redundant:
            |                |                          |         |         | (10,000,000 "strong" slotting
            |                |                          |         |         | loan, unrated non-GB sovereign
            |                |                          |         |         | guarantor)
+    S7     | IRB corporate  | IRB institution (Germany),| C 08.01 | C 08.01 | CROSS-BORDER: obligor GB,
+           | (GB)           | NO own exposure          |         |         | guarantor DE — a BENEFICIAL
+           |                |                          |         |         | substitution (like S1-S5) whose
+           |                |                          |         |         | guarantor is NOT in the
+           |                |                          |         |         | obligor's country. Exercises
+           |                |                          |         |         | the COUNTRY axis PS1/26 Annex
+           |                |                          |         |         | II Section 3.4 para 86/87
+           |                |                          |         |         | prescribes for C 09.01/C 09.02
+           |                |                          |         |         | (immediate obligor's country
+           |                |                          |         |         | for "original exposure
+           |                |                          |         |         | pre-conversion factors";
+           |                |                          |         |         | ultimate obligor's country —
+           |                |                          |         |         | i.e. the guarantor's — for
+           |                |                          |         |         | "exposure value"/RWEA once
+           |                |                          |         |         | substituted) — orthogonal to
+           |                |                          |         |         | S1-S6, which never move
+           |                |                          |         |         | country at all (every leg in
+           |                |                          |         |         | S1-S6 that ever reports is GB;
+           |                |                          |         |         | see CROSS_BORDER_GUARANTEE_
+           |                |                          |         |         | DESIGN below). SAME class +
+           |                |                          |         |         | template destination as S1
+           |                |                          |         |         | (institution/C 08.01) —
+           |                |                          |         |         | deliberately: a sovereign
+           |                |                          |         |         | guarantor gives a FRESH
+           |                |                          |         |         | destination but breaks
+           |                |                          |         |         | CRR/B31 regime-uniformity
+           |                |                          |         |         | (PS1/26 Art. 147A forces SA
+           |                |                          |         |         | for CGCB); institution
+           |                |                          |         |         | preserves regime-neutrality
+           |                |                          |         |         | at the cost of reusing S1's
+           |                |                          |         |         | destination cell
+    S8     | slotting       | SA corporate (CQS 1,      | C 08.01 | C 07.00 | BLEND: a "good" (0.90) PF
+           | (project_      | 0.20 SA RW), NO own       |         |         | category holding BOTH an
+           | finance,       | exposure                 |         |         | unguaranteed leg
+           | "good") x2     |                          |         |         | (LN_S8_PLAIN) AND a
+           | loans, one     |                          |         |         | BENEFICIALLY-substituted one
+           | unguaranteed   |                          |         |         | (LN_S8_GTD) — the shape that
+           |                |                          |         |         | exposes C 08.06/CR10's
+           |                |                          |         |         | meaningless EAD-weighted
+           |                |                          |         |         | blended risk weight (see
+           |                |                          |         |         | SLOTTING_BLEND_DESIGN
+           |                |                          |         |         | below). CROSS-TEMPLATE like
+           |                |                          |         |         | S3: a slotting beneficiary's
+           |                |                          |         |         | guarantor is ALWAYS
+           |                |                          |         |         | SA-treated (Art. 201(2)'s
+           |                |                          |         |         | internal-rating limb never
+           |                |                          |         |         | reaches slotting), so the
+           |                |                          |         |         | outflow stays on C 08.01 and
+           |                |                          |         |         | the inflow crosses to
+           |                |                          |         |         | C 07.00[corporate] — a FRESH
+           |                |                          |         |         | destination that happens to
+           |                |                          |         |         | land on S4's ALREADY-
+           |                |                          |         |         | POPULATED native sheet
 
 S1/S4 are the happy-path pair (one IRB, one SA) proving the mechanism works
 when the destination class already has a native row. S2 isolates the
@@ -152,37 +231,127 @@ beneficially substituted by construction, so a reporting-layer regression that
 deleted the ``is_guarantee_beneficial`` check entirely (migrating every
 guarantee regardless of benefit) would move none of their numbers — S6 is the
 only scenario that would move if that gate regressed, and it doubles as the
-fixture's only slotting-origin leg. This is the fixture-level reproduction
-backing the CRM substitution investigation tracked against
-C 07.00/C 08.01/C 08.02; see the module-level ``NOTE`` below for the specific
-behaviour observed when this fixture was built and verified.
+fixture's only slotting-origin leg. S7 isolates a SIXTH, orthogonal case none
+of S1-S6 exercise: the COUNTRY basis a beneficial substitution reports under,
+independent of the CLASS basis S1-S6 already pin. Its guarantor's class and
+template (institution / C 08.01) DELIBERATELY reuse S1's destination cell
+(see the OB_S7/GTOR_S7 constant declarations for why: the natural FRESH
+choice, a sovereign guarantor, breaks CRR/B31 regime-uniformity), so
+``SUBSTITUTION_INFLOW_DESIGN[GUAR_S7]`` and ``[GUAR_S1]`` now share one
+destination — the acceptance suite's generic per-scenario inflow check needs
+generalising to sum contributions per destination rather than assume exactly
+one (flagged to test-writer). S7's entire reason for existing is the country
+pair it carries (``CROSS_BORDER_GUARANTEE_DESIGN`` below), which no prior
+scenario can express (see the "Why this portfolio" GB-only finding above).
+S8 isolates a SEVENTH, orthogonal case: a beneficially-substituted SLOTTING
+leg, which none of S1-S7 exercise (S6 is slotting but DECLINED; S1-S5/S7 are
+beneficial but never slotting). Its own category ("good") is deliberately
+DIFFERENT from S6's ("strong") so the two slotting scenarios stay on
+separate C 08.06/CR10 rows — a blend regression on S8 cannot be confused
+with a decline-gate regression on S6, keeping both independently
+attributable. S8 is a SEPARATE scenario from S7 rather than the same
+cross-border leg (see the OB_S8/GTOR_S8 constant declarations for the full
+reasoning): a slotting guarantor's benefit is always SA-CQS-based, never
+IRB-PD-based, so fusing the two would have forced a redesign of S7's
+already-verified mechanics for uncertain benefit. This is the fixture-level
+reproduction backing the CRM substitution investigation tracked against
+C 07.00/C 08.01/C 08.02/C 08.06/C 09.01/C 09.02/CR10; see the module-level
+``NOTE`` below for the specific behaviour observed when this fixture was
+built and verified.
 
 NOTE (as observed 2026-08-04, CRR and B31, via a direct
-``PipelineOrchestrator`` + ``COREPGenerator`` run against the fixture-builder
-verification build — re-verify against a live run before relying on this as a
-current-state claim): all six scenarios land correctly and identically under
-both regimes, and portfolio-wide gross (50,500,000, up from 40,500,000 with
-S6's 10,000,000 added) reconciles exactly to net across every sheet with zero
-leakage. Per sheet, Total row (unchanged from the S1-S5-only figures below —
-S6 perturbs neither, by design):
+``PipelineOrchestrator`` + ``COREPGenerator``/``Pillar3Generator`` run
+against the fixture-builder verification build — re-verify against a live
+run before relying on this as a current-state claim): all eight scenarios
+land correctly and identically under both regimes, and portfolio-wide gross
+(80,000,000, up from 61,500,000 with S8's 18,500,000 added) reconciles
+exactly to net across every sheet with zero leakage. Per sheet, Total row
+(unchanged from the S1-S7 figures below except ``corporate`` on BOTH
+templates and ``specialised_lending``, which S8 perturbs by design):
 
-    c08_01 corporate            : 0020=27,000,000  0040=-12,300,000  0050=-3,300,000  0070=-15,600,000  0080=+5,400,000  0090=16,800,000
-    c08_01 institution           : 0020= 4,000,000                                                        0080=+2,000,000  0090= 6,000,000
+    c08_01 corporate            : 0020=38,000,000  0040=-12,300,000  0050=-8,800,000  0070=-21,100,000  0080=+5,400,000  0090=22,300,000
+    c08_01 institution           : 0020= 4,000,000                                                        0080=+7,500,000  0090=11,500,000   <- S1 (2,000,000) + S7 (5,500,000)
     c08_01 retail_other          : 0020=         0                                                          0080=+3,300,000  0090= 3,300,000   <- S2, inflow-only sheet
-    c08_01 specialised_lending   : 0020=10,000,000                             0070=         0  0080=         0  0090=10,000,000   <- S6, DECLINED
-    c07_00 corporate             : 0010= 8,000,000                                    0060=-2,800,000  0090=-2,800,000                    0110= 5,200,000
+    c08_01 specialised_lending   : 0020=28,500,000                                    0050=-7,800,000  0070=-7,800,000                     0090=20,700,000   <- S6 (10,000,000, DECLINED) + S8 (18,500,000)
+    c07_00 corporate             : 0010= 8,000,000                                    0060=-2,800,000  0090=-2,800,000  0100=+7,800,000  0110=13,000,000   <- S4 native + S8 inflow
     c07_00 institution           : 0010= 1,500,000                                                                          0100=+2,800,000  0110= 4,300,000
     c07_00 cgcb                  : 0010=         0                                                                          0100=+4,900,000  0110= 4,900,000   <- S3 ONLY
 
-S6's ``specialised_lending`` sheet has NO outflow and NO inflow (0070/0080
-both 0) — its net (col 0090) equals its gross (col 0020) with nothing having
-moved, and ``rwa_final`` sums to 7,000,000 (== 10,000,000 x 0.70, the
-undiminished slotting weight) under BOTH regimes identically. The ``cgcb``
-sheet's col 0100 stays exactly S3's 4,900,000 — S6's guarantor shares that
-SAME class, so a regression that applied the decline anyway would inflate
-this EXISTING, already-asserted cell to 9,400,000 rather than create a new
-one, which is what makes S6 the sharpest possible pin on the gate (see
+``corporate``'s 0020 rises by exactly DRAWN_S7 (11,000,000 — S7's own ORIGIN
+loan, corporate class, same as S1/S2/S3/S5); its col 0050 (the
+``"credit_derivative"`` outflow bucket S2/S4/S7 share) rises by exactly
+AMOUNT_COVERED_S7 (5,500,000: -3,300,000 -> -8,800,000), while col 0040 (the
+``"guarantee"`` bucket) is UNCHANGED — confirming S7's outflow posts to the
+correct protection_type column. ``institution``'s col 0080 is the SUM of
+GUAR_S1's and GUAR_S7's inflows (2,000,000 + 5,500,000 = 7,500,000) —
+DELIBERATELY, since both share this destination (see the OB_S7/GTOR_S7
+constant declarations). ``specialised_lending``'s col 0050 (the
+``"credit_derivative"`` outflow S8 uses) moves by exactly AMOUNT_COVERED_S8
+(-7,800,000: S6 contributes none, being DECLINED); col 0020 rises by
+DRAWN_S8_PLAIN + DRAWN_S8_GTD (18,500,000: 10,000,000 -> 28,500,000).
+``corporate`` on C 07.00 gains an inflow for the FIRST time (col 0100: 0 ->
+7,800,000 = AMOUNT_COVERED_S8, DELIBERATELY landing on S4's already-
+populated native sheet — see the OB_S8/GTOR_S8 constant declarations).
+Every other sheet (retail_other, C 07.00 institution/cgcb) is BYTE-IDENTICAL
+to the S1-S7 figures, confirming S8 perturbs nothing outside its own origin
+(specialised_lending) and destination (corporate, C 07.00) sheets.
+
+S6's ``specialised_lending`` ROW (Category 1 "Strong" on C 08.06/CR10, kept
+separate from S8's Category 2 "Good") has NO outflow and NO inflow (0070/
+0080 both 0) — its net equals its gross with nothing having moved, and
+``rwa_final`` sums to 7,000,000 (== 10,000,000 x 0.70, the undiminished
+slotting weight) under BOTH regimes identically. The ``cgcb`` sheet's col
+0100 stays exactly S3's 4,900,000 — S6's guarantor shares that SAME class,
+so a regression that applied the decline anyway would inflate this
+EXISTING, already-asserted cell to 9,400,000 rather than create a new one,
+which is what makes S6 the sharpest possible pin on the gate (see
 ``DECLINED_GUARANTEE_DESIGN`` below).
+
+S7's guaranteed leg (``CSUB-LN-S7__G_CSUB-CP-GTOR-S7``) confirmed
+``is_guarantee_beneficial = True`` under BOTH regimes: ``guarantor_rw``
+(the substituted institution risk weight, driven by ``PD_GTOR_S7`` = 0.0015)
+came out at 0.62018 (CRR) / 0.52007 (B31), comfortably below
+``risk_weight_irb_original`` (the obligor's own corporate risk weight,
+driven by ``PD_OB_S7`` = 0.0075) at 1.20522 (CRR) / 1.01067 (B31) — the same
+margin direction under both regimes despite the absolute risk weights
+differing (as they do for every other scenario in this fixture). ``cp_
+country_code`` stayed "GB" on BOTH the ``__G_`` and ``__REM`` legs in this
+verification run (the CURRENT single-basis behaviour — see
+``CROSS_BORDER_GUARANTEE_DESIGN`` for the DESIGN intent once C 09.01/C 09.02
+read ``guarantor_country_code`` instead, on the ``__G_`` leg only).
+
+S8's THREE legs confirmed the per-leg mechanics ``SLOTTING_BLEND_DESIGN``
+records, identically under BOTH regimes: LN_S8_PLAIN reports
+``risk_weight=0.90``, ``rwa_final=5,850,000`` (6,500,000 x 0.90);
+LN_S8_GTD's ``__REM`` leg reports the SAME 0.90, ``rwa_final=3,780,000``
+(4,200,000 x 0.90) — the never-guaranteed remainder stays on the category's
+own basis; LN_S8_GTD's ``__G_`` leg confirmed ``is_guarantee_beneficial =
+True`` with ``guarantor_rw=0.20`` (CQS_GTOR_S8=1), ``risk_weight=0.20``,
+``rwa_final=1,560,000`` (7,800,000 x 0.20), ``exposure_class_post_crm=
+"corporate"`` (routing the inflow to C 07.00) while
+``reporting_approach_origin`` stays ``"slotting"`` (keeping the OUTFLOW on
+C 08.01) — the S3-shaped cross-template split, confirmed on a slotting
+beneficiary for the first time. The DEFECT itself reproduces EXACTLY as the
+brief's prototype described, confirmed on C 08.06's own "good" row (Category
+2) and Pillar 3 CR10's own row: C 08.06 col 0070 (risk weight) reports
+0.604865 — EXACTLY ``category_total_rwa_correct_basis`` /
+``category_total_ead`` (11,190,000 / 18,500,000, as ``SLOTTING_BLEND_DESIGN``
+predicts) — a number with no regulatory meaning, sitting inside neither the
+0.90 nor the 0.20 band; CR10's own row prints a FIXED col c = 90.0 (the
+category's nominal weight) directly beside col e = 11,190,000 over col d =
+18,500,000, implying the SAME 60.49% — the exact "fixed 70% next to an
+implied 36.67%" incoherence the brief's prototype reports, reproduced here
+at S8's own numbers. NUANCE the brief's summary does not distinguish: C
+08.06's col 0080 (RWA) already reports the CORRECT total, 11,190,000 — the
+sum of each leg's own (EAD x its own risk weight); it is ONLY the col 0070
+"risk weight" DISPLAY column, derived from that correct RWA divided by the
+category's total EAD, that is meaningless. Capital (RWA) is right; the
+disclosed ratio next to it is not — the same character of defect as Finding
+4's ``_beneficial_gate`` (S6): a pure disclosure defect, not a capital one,
+which is exactly why neither shows up as a capital-conservation failure and
+both need a dedicated fixture leg to surface at all. S6's OWN "strong" row
+(Category 1) stays clean (col 0070 = 0.70, unblended) throughout, confirming
+S8's category is fully isolated and the defect is attributable to S8 alone.
 
 S5's isolated ``corporate`` sheet Total row (S5 alone, no other scenario on
 the sheet) reports ``0020=9,000,000 / 0040=-5,400,000 / 0070=-5,400,000 /
@@ -191,13 +360,13 @@ Annex II requires), matching ``v1663_m`` ({c0070} = {c0040}+{c0050}+{c0060})
 and the corrected col 0090 waterfall.
 
 Every guarantee is PARTIAL cover (never 100%), so a retained ``__REM`` leg
-genuinely coexists with the ``__G_`` leg on all six scenarios, and every
+genuinely coexists with the ``__G_`` leg on all eight scenarios, and every
 guaranteed amount is a distinct round GBP figure so any template cell is
 traceable to exactly one leg — including S6, whose decline means that figure
 should appear on NO outflow/inflow cell anywhere; its only footprint is the
 undiminished gross total on its own native sheet. ``protection_type`` covers
 both values Annex II splits (C 08.01 cols 0040/0050): S1/S3/S5/S6 are
-``"guarantee"``, S2/S4 are ``"credit_derivative"``.
+``"guarantee"``, S2/S4/S7/S8 are ``"credit_derivative"``.
 
 No CRR/Basel 3.1 regime divergence is exercised here (deliberately, unlike
 ``reporting_irb_classes_portfolio.py``'s sovereign-class carve-out) — every
@@ -205,13 +374,24 @@ obligor keeps the same approach under both regimes, so the sheet-routing
 answer is identical for both; the CRR/B31 expected-sheet dicts below are
 provided as a matched pair purely for parity with the sibling fixture's
 convention and because a future regime-conditioned defect fix could make them
-diverge.
+diverge. S7's PD gap (0.0075 obligor vs 0.0015 guarantor, a comfortable ~5x
+margin) is deliberately wide enough that ``is_guarantee_beneficial`` derives
+True under both regimes' IRB risk-weight formulas without needing to tune the
+margin per regime — confirmed empirically (see the dated NOTE below). S8's
+guarantor CQS (1 -> 0.20 SA RW under BOTH ``corporate_cqs_rw`` (CRR) and
+``b31_corporate_risk_weights`` (PS1/26) — comfortably below the "good"
+category's 0.90) is similarly regime-uniform BY CONSTRUCTION, unlike the
+REJECTED sovereign design for S7, which was NOT (see the OB_S7/GTOR_S7
+constant declarations) — confirmed empirically here too (see the dated NOTE).
 
 References:
 - CRR Art. 235 / PS1/26 Art. 235: SA risk-weight substitution (RWSM).
 - CRR Art. 161 / CRE22.70-85: IRB parameter substitution (PSM).
 - CRR Art. 153(5) / PS1/26 Art. 153(5): specialised-lending slotting
-  categories and risk weights (S6's obligor).
+  categories and risk weights (S6's and S8's obligors — Table A "strong"
+  0.70 / "good" 0.90, remaining maturity >= 2.5y, non-HVCRE, identical
+  entries under both regimes in ``rulebook/packs/{crr,b31}.py::
+  slotting_rw_base``).
 - CRR Art. 114(4)/(7) / Art. 235(3): the domestic-currency CGCB 0% RW
   extension to a centrally-guaranteed exposure (S3's guarantor); S6's
   guarantor is a non-GB sovereign specifically so this extension does NOT
@@ -221,9 +401,30 @@ References:
   task #13 (S0-revise) for the citation-basis correction from Art. 213 alone
   to Art. 193(1) (mandatory, per-exposure) + Art. 113(3) (the permissive
   amendment hook Art. 235(1) is framed against).
-- CRR Art. 201: eligible-guarantor eligibility gate.
+- CRR Art. 201: eligible-guarantor eligibility gate; Art. 201(1)(g)/(2)'s
+  rating-based eligibility test applies only to a CORPORATE guarantor
+  (``_assign_guarantor_approach``'s ``is_corporate_guarantor`` check) — an
+  "institution" guarantor (S1, S4, S7) is governed by other Art. 201 limbs
+  and is not gated here, same as GTOR_S1/GTOR_S4. GTOR_S8 IS a corporate
+  guarantor and DOES trip this gate, satisfied by its ECAI CQS rating (Art.
+  201(1)(g) — an internal PD would not satisfy it here, since Art. 201(2)'s
+  internal-rating limb never reaches a slotting beneficiary; see the
+  OB_S8/GTOR_S8 constant declarations).
+- PRA PS1/26 Art. 147A: mandates SA-only treatment for sovereign / quasi-
+  sovereign counterparties at a 0% SA risk weight (CGCB, sovereign-treated
+  RGLAs/PSEs, MDBs, international orgs) REGARDLESS of internal rating —
+  the reason S7's guarantor is "institution", not "sovereign" (see the
+  OB_S7/GTOR_S7 constant declarations for the empirical reproduction).
 - COREP Annex II, C 07.00 / C 08.01 / C 08.02: the outflow/inflow columns,
   including the same-exposure-class inflow/outflow requirement (S5).
+- PRA PS1/26 Annex II Section 3.4 para 86/87 (Regulation (EU) 2021/451,
+  Annex II, C 09.01/C 09.02 instructions worded identically): the
+  geographical-breakdown column basis — immediate obligor's country for
+  "original exposure pre-conversion factors", ultimate obligor's country for
+  "exposure value"/RWEA, migrating with a beneficial substitution exactly as
+  exposure class does (S7; not yet implemented — see task "S2a: C 09.01
+  exposure-value / RWEA columns to the post-substitution basis" and
+  ``CROSS_BORDER_GUARANTEE_DESIGN`` below).
 - engine/crm/guarantees.py: the ``__G_`` / ``__REM`` physical split.
 - engine/aggregator/aggregator.py: ``_add_reporting_projection`` (the sealed
   ``reporting_class`` / ``reporting_class_origin`` twins) and
@@ -239,6 +440,32 @@ References:
   C 08.01/02 col 0090 identity this fixture also exercises (0090 = 0020 -
   0070 + 0080 over positive magnitudes, col 0070 as the single whole-outflow
   subtotal).
+- reporting/corep/c09.py: ``_country_frames`` — the CURRENT single-basis
+  per-country split, keyed on ``cp_country_code`` for every column (S7's gap;
+  see ``CROSS_BORDER_GUARANTEE_DESIGN`` above). ``cp_country_code`` is joined
+  onto every exposure row by its OWN ``counterparty_reference``
+  (``engine/stages/classify/attributes.py::add_counterparty_attributes``),
+  which the CRM splitter never reassigns on the ``__G_`` leg — the raw input
+  the immediate-obligor basis needs is already correct today.
+  ``guarantor_country_code`` — the raw input the ultimate-obligor basis will
+  need — is ALREADY sealed separately, joined by ``guarantor_reference``
+  (``engine/crm/guarantees.py::_join_guarantor_counterparty``); only
+  C 09.01/C 09.02's column bindings do not yet read it.
+- COREP C 08.06 / Pillar 3 CR10: the specialised-lending slotting grid
+  (task "S4: C 08.06 + CR10 slotting grid and lineage correction" —
+  S8's gap; see ``SLOTTING_BLEND_DESIGN`` above). C 08.06's col 0070 /
+  CR10's implied col d/e ratio currently derive a single EAD-weighted-
+  average "risk weight" per category, which is meaningless whenever a
+  category mixes unguaranteed and beneficially-substituted legs (confirmed
+  empirically — see the dated NOTE); C 08.06's col 0080 (RWA total) is
+  UNAFFECTED — it already sums each leg's own correctly-weighted RWA, so
+  this is a disclosure defect, not a capital one.
+- engine/slotting/transforms.py: ``apply_guarantee_substitution`` — the
+  slotting RWSM consumer (Art. 235(1)), reusing the SAME shared SA
+  substitution step (and therefore the same beneficial gate) the
+  ``_assign_guarantor_approach`` SA branch runs; the reason a slotting
+  guarantor is ALWAYS SA-treated (S8's guarantor mechanism, vs S1-S5/S7's
+  IRB-PD-based one).
 """
 
 from __future__ import annotations
@@ -308,6 +535,134 @@ GTOR_S6: str = "CSUB-CP-GTOR-S6"
 LN_S6: str = "CSUB-LN-S6"
 GUAR_S6: str = "CSUB-GUAR-S6"
 
+# -- S7: IRB obligor (GB), IRB institution guarantor (DE) -- CROSS-BORDER ---
+# Beneficially substituted (derives True through the same real engine path as
+# S1 — see PD_OB_S7 / PD_GTOR_S7 below), but with the guarantor incorporated
+# in a DIFFERENT country from the obligor. PRA PS1/26 Annex II Section 3.4
+# para 87 (C 09.01/C 09.02 geographical breakdown): "original exposure
+# pre-conversion factors" keys the IMMEDIATE obligor's country of residence
+# (unaffected by substitution), while "exposure value" and "Risk-weighted
+# exposure amounts" key the ULTIMATE obligor's country once a guarantee
+# substitutes. This portfolio has never exercised that column-level country
+# basis before: every prior BENEFICIAL guarantor (S1-S5) shares the
+# obligor's GB country, and S6's non-GB (US) guarantor is DECLINED, so its
+# country never reaches any exposure-bearing leg at all (GTOR_S6 has no own
+# loan, and a declined guarantee keeps the covered leg on the obligor's own
+# basis end to end — see DECLINED_GUARANTEE_DESIGN). Confirmed by direct
+# inspection of every counterparty row below: GB is, in effect, the ONLY
+# country any leg in S1-S6 ever reports. S7 closes that gap. The obligor
+# deliberately STAYS on the fixture-wide GB default, and the guarantor is
+# "institution" — the SAME entity_type as GTOR_S1, deliberately, changing
+# EXACTLY ONE thing versus S1's already-proven mechanics (the same "change
+# exactly one thing" discipline S6 used for the decline gate): its country.
+# A "sovereign" guarantor (central_govt_central_bank) was tried first and
+# REJECTED, empirically, not merely on paper: PRA PS1/26 Art. 147A mandates
+# SA-only treatment for CGCB (Art. 147(3) sovereign/quasi-sovereign at 0% SA
+# RW) REGARDLESS of the guarantor's internal rating (see
+# ``IRBPermissions.full_irb_b31`` — "Sovereign / quasi-sovereign with 0% SA
+# risk weight: SA only"). A verification run confirmed a sovereign S7 landed
+# on C 08.01[central_govt_central_bank] under CRR (guarantor treated IRB) but
+# C 07.00[central_govt_central_bank] under B31 (guarantor forced SA,
+# ``guarantor_rw`` = 1.0, the CQS.UNRATED SA fallback) — a genuine
+# CRR/Basel 3.1 regime divergence this portfolio's own docstring says it does
+# NOT exercise, and one ``SUBSTITUTION_INFLOW_DESIGN`` (a single, regime-
+# independent dict) cannot express since ``destination_template`` would need
+# to differ by regime for the SAME entry. "institution" carries no such
+# restriction under B31 (``full_irb_b31``: "Institution ... F-IRB only (no
+# A-IRB)" — still IRB-eligible, merely restricted to F-IRB, and
+# ``create_full_irb_model_permissions`` grants F-IRB regardless), so it lands
+# on the SAME (class, template) — C 08.01[institution] — under BOTH regimes,
+# preserving the fixture-wide regime-neutrality invariant. The trade-off:
+# this REUSES GTOR_S1's destination (C 08.01[institution]), which is the
+# SAME reuse-an-existing-cell principle S6 applied to the class axis, now
+# applied a second time — deliberately, since no B31-regime-safe entity_type
+# reachable from a plain counterparty was found with a genuinely FRESH
+# (class, template) pair (every one either shares an existing destination, as
+# institution/corporate/retail_other all do, or breaks regime-uniformity, as
+# sovereign/CGCB does — see CROSS_BORDER_GUARANTEE_DESIGN below).
+# ``SUBSTITUTION_INFLOW_DESIGN[GUAR_S7]`` records this combined cell; the
+# acceptance suite's generic per-scenario check needs generalising to SUM
+# contributions per (class, template) destination rather than assume exactly
+# one — flagged to test-writer, not fixed here (fixture-builder owns
+# ``tests/fixtures/`` only).
+OB_S7: str = "CSUB-CP-OB-S7"
+GTOR_S7: str = "CSUB-CP-GTOR-S7"
+LN_S7: str = "CSUB-LN-S7"
+GUAR_S7: str = "CSUB-GUAR-S7"
+
+# -- S8: slotting "good" obligor with BOTH an unguaranteed leg AND a --------
+# -- BENEFICIALLY-SUBSTITUTED leg in the SAME category ----------------------
+# S6 is the fixture's only slotting-origin leg so far, and it is DECLINED —
+# so no beneficially-substituted slotting leg exists anywhere, and C 08.06 /
+# Pillar 3 CR10's per-category risk-weight columns (``v09782_m`` /
+# ``v09783_m`` and their B31 twins) are never even reached. Worse: a
+# category containing legs on BOTH bases (unguaranteed at the category's own
+# weight, substituted at the guarantor's) produces a MEANINGLESS EAD-weighted
+# BLENDED risk weight that sits inside the category's own band and looks
+# like a plausible number rather than an obviously wrong one — measured on a
+# production-shaped prototype (PF "strong", 5,000,000 unguaranteed @ 70% +
+# 10,000,000 substituted to 20%): C 08.06 reports a blended 0.366667 next to
+# a FIXED-display 70.0 on CR10, with CR10's own d/e columns implying 36.67%
+# — incoherent, and a SINGLE fully-guaranteed leg would not expose it (a
+# clean 20% merely looks wrong, not incoherent). It takes TWO legs in one
+# category — one substituted, one not — and that is what a real slotting
+# book looks like. S8 reproduces this shape as its own, ISOLATED category
+# (CRR/PS1/26 Art. 153(5) Table A "good", 0.90, remaining maturity >= 2.5y,
+# non-HVCRE — deliberately NOT S6's "strong" (0.70): the two scenarios stay
+# on separate rows so a blend regression on one cannot be confused with a
+# decline-gate regression on the other, keeping S6's gate-pin and S8's
+# blend-pin independently attributable). ``specialised_lending`` is a
+# per-COUNTERPARTY join (one row, no ``loan_reference`` column — see
+# ``SPECIALISED_LENDING_SCHEMA``), so ONE obligor (OB_S8) with TWO loans
+# (LN_S8_PLAIN, unguaranteed; LN_S8_GTD, guaranteed) automatically shares one
+# category — no second obligor needed.
+#
+# GTOR_S8 is "corporate" (not "institution"/"sovereign"): a slotting
+# beneficiary is EXCLUDED from the IRB internal-rating eligibility limb
+# (``_assign_guarantor_approach``'s ``beneficiary_is_irb`` check only admits
+# FIRB/AIRB, never slotting — "SLOTTING beneficiaries are deliberately
+# excluded, so the Art. 201(2) internal-rating eligibility limb does not
+# reach them either"), so a slotting guarantor is ALWAYS treated SA
+# regardless of any internal PD — a DIFFERENT mechanism from S1-S5/S7's IRB
+# PD-based substitution, and the reason S8 is a separate scenario from S7
+# rather than the same leg (see the merge-vs-separate note below). A
+# "corporate" guarantor DOES trip the Art. 201(1)(g)/(2) eligibility gate
+# (``is_corporate_guarantor``), so GTOR_S8 carries an ECAI CQS rating (CQS 1
+# -> 0.20 SA RW under BOTH regimes — ``corporate_cqs_rw`` / PS1/26 Table 6
+# CQS1 — comfortably below the "good" category's 0.90) to satisfy it AND to
+# make ``is_guarantee_beneficial`` derive True through the real engine path
+# (``engine/slotting/transforms.py::apply_guarantee_substitution`` — the
+# SAME shared SA substitution step S6's decline reproduces, just with the
+# opposite outcome). "corporate" is ALSO a FRESH C 07.00 destination (S3 ->
+# central_govt_central_bank, S4 -> institution; corporate is unclaimed) that
+# happens to land on an ALREADY-POPULATED, ALREADY-ASSERTED native sheet —
+# C 07.00[corporate]'s Total row already carries S4's OWN obligor gross/
+# outflow numbers — so a basis regression here inflates an EXISTING cell
+# rather than populating an empty one, the same "make it loud" principle S6
+# applied to the class axis, achieved here WITHOUT colliding with any
+# existing ``SUBSTITUTION_INFLOW_DESIGN`` entry's exact-amount assertion
+# (nothing currently claims C 07.00[corporate] as a destination).
+#
+# MERGE-VS-SEPARATE (asked explicitly): kept as its OWN scenario, not fused
+# into S7's cross-border leg, for three reasons. (1) Mechanism mismatch: S7's
+# guarantor benefit is IRB-PD-based (mirrors S1); a slotting guarantor's
+# benefit is ALWAYS SA-CQS-based (see above) — fusing them would force S7's
+# proven, already-regime-verified mechanics to change. (2) The blend needs a
+# SECOND, unguaranteed leg regardless of which obligor carries the
+# cross-border leg, so "one leg, two axes" was never fully available — at
+# least one extra loan is unavoidable either way. (3) Attribution: S7 is
+# fully verified and reported complete; redesigning it around a second axis
+# risks re-breaking a solid, already-reviewed result for uncertain benefit,
+# whereas a fresh S8 stays a pure, minimal-diff extension of S6's proven
+# slotting-benefit mechanism (same gate, opposite outcome) — mirroring the
+# "change exactly one thing" discipline S6 (vs S3) and S7 (vs S1) already
+# established twice.
+OB_S8: str = "CSUB-CP-OB-S8"
+GTOR_S8: str = "CSUB-CP-GTOR-S8"
+LN_S8_PLAIN: str = "CSUB-LN-S8-PLAIN"
+LN_S8_GTD: str = "CSUB-LN-S8-GTD"
+GUAR_S8: str = "CSUB-GUAR-S8"
+
 #: Drawn amounts (GBP), each a distinct round figure. EAD = drawn_amount (no
 #: facility / CCF machinery involved — every row is a plain drawn term loan).
 DRAWN_S1: float = 5_000_000.0
@@ -321,6 +676,10 @@ DRAWN_S5: float = 9_000_000.0
 #: ``engine/aggregator/aggregator.py::_beneficial_gate``) — a 10,000,000
 #: project-finance "strong" slotting loan.
 DRAWN_S6: float = 10_000_000.0
+DRAWN_S7: float = 11_000_000.0
+#: S8's PLAIN (unguaranteed) leg and GTD (guaranteed) leg, same category.
+DRAWN_S8_PLAIN: float = 6_500_000.0
+DRAWN_S8_GTD: float = 12_000_000.0
 
 #: Guarantee coverage — always PARTIAL, so a retained ``__REM`` leg coexists
 #: with the ``__G_`` leg on every scenario, including the DECLINED S6 (a
@@ -332,6 +691,8 @@ PCT_COVERED_S3: float = 0.70
 PCT_COVERED_S4: float = 0.35
 PCT_COVERED_S5: float = 0.60
 PCT_COVERED_S6: float = 0.45
+PCT_COVERED_S7: float = 0.50
+PCT_COVERED_S8: float = 0.65
 
 #: amount_covered = drawn_amount * pct_covered, rounded to a clean GBP figure.
 AMOUNT_COVERED_S1: float = DRAWN_S1 * PCT_COVERED_S1  # 2,000,000
@@ -342,6 +703,8 @@ AMOUNT_COVERED_S5: float = DRAWN_S5 * PCT_COVERED_S5  # 5,400,000
 #: S6 is DECLINED, so this figure should appear on NO outflow/inflow cell —
 #: see ``DECLINED_GUARANTEE_DESIGN`` below.
 AMOUNT_COVERED_S6: float = DRAWN_S6 * PCT_COVERED_S6  # 4,500,000
+AMOUNT_COVERED_S7: float = DRAWN_S7 * PCT_COVERED_S7  # 5,500,000
+AMOUNT_COVERED_S8: float = DRAWN_S8_GTD * PCT_COVERED_S8  # 7,800,000
 
 #: Internal PDs (IRB legs only). Each guarantor with an internal PD is a
 #: deliberately IRB-routing signal — see ``_assign_guarantor_approach``
@@ -357,6 +720,24 @@ PD_OB_S5: float = 0.0090
 #: — the SAME-CLASS defect requires two distinct obligors of one class, not a
 #: self-guarantee.
 PD_GTOR_S5: float = 0.0045
+PD_OB_S7: float = 0.0075
+#: The institution guarantor's internal PD, well below OB_S7's own (a ~0.2x
+#: ratio, a sharper margin than S1's ~0.6x, chosen comfortable rather than
+#: borderline): ``is_guarantee_beneficial`` derives True through the real
+#: engine path (``guarantor_rw < risk_weight_irb_original`` —
+#: ``engine/irb/guarantee.py``) with no ambiguity — confirmed under BOTH
+#: regimes (see the dated NOTE below).
+PD_GTOR_S7: float = 0.0015
+
+#: S7's cross-border pair. The obligor stays on the fixture-wide GB default —
+#: isolating country as the ONLY new variable relative to S1's proven
+#: mechanics (see the OB_S7/GTOR_S7 comment above). The guarantor sits in
+#: Germany: distinct from GB (the obligor, and every other BENEFICIAL
+#: guarantor in this fixture) and from US (S6's guarantor — but that
+#: guarantee is DECLINED and never reaches an exposure-bearing leg, so it
+#: cannot be confused with a genuine cross-border substitution).
+COUNTRY_OB_S7: str = "GB"
+COUNTRY_GTOR_S7: str = "DE"
 
 #: External CQS assignments (SA / non-IRB-rated legs).
 #: CQS 1 sovereign -> 0% RW under both regimes; also triggers the Art.
@@ -371,11 +752,22 @@ CQS_GTOR_S4: int = 2
 #: country_code is deliberately non-GB so the Art. 114(4)/(7) domestic-CGCB
 #: 0% short-circuit (S3's path) does NOT apply here — this is the plain
 #: unrated-sovereign fallback, not the domestic carve-out.
+#: CQS 1 corporate -> 0.20 SA RW under both regimes (``corporate_cqs_rw`` /
+#: PS1/26 Table 6) — comfortably below the "good" slotting weight (0.90) it
+#: is compared against, so GTOR_S8's substitution derives beneficial with no
+#: ambiguity; also satisfies the Art. 201(1)(g)/(2) corporate-guarantor
+#: eligibility gate (an ECAI rating makes it eligible outright).
+CQS_GTOR_S8: int = 1
 
 #: S6's obligor slotting category (CRR/PS1/26 Art. 153(5) Table A, remaining
 #: maturity >= 2.5y, non-HVCRE): "strong" -> 0.70 under BOTH regimes
 #: (identical entries in ``rulebook/packs/{crr,b31}.py::slotting_rw_base``).
 SLOTTING_CATEGORY_S6: str = "strong"
+#: S8's obligor slotting category — deliberately DIFFERENT from S6's
+#: ("good" -> 0.90 under both regimes, vs S6's "strong" -> 0.70) so the two
+#: scenarios sit on separate C 08.06 / CR10 rows and stay independently
+#: attributable (see the OB_S8/GTOR_S8 constant declarations above).
+SLOTTING_CATEGORY_S8: str = "good"
 
 _VALUE_DATE: date = date(2020, 1, 1)
 #: Beyond both reporting dates under test (CRR 2025-06-30, B31 2027-06-30).
@@ -411,6 +803,9 @@ LOAN_EXPECTED_ORIGIN_SHEET_CRR: dict[str, tuple[str, str]] = {
     # slotting-origin legs on the raw class ("C 08.01 does NOT exclude
     # slotting" — ``c08.py::c08_01_plans``). No S1-S5 loan reaches this sheet.
     LN_S6: ("c08_01", "specialised_lending"),
+    LN_S7: ("c08_01", "corporate"),
+    LN_S8_PLAIN: ("c08_01", "specialised_lending"),
+    LN_S8_GTD: ("c08_01", "specialised_lending"),
 }
 #: No regime divergence is exercised in this portfolio (see module docstring)
 #: — identical to the CRR map.
@@ -443,6 +838,16 @@ LOAN_EXPECTED_ORIGIN_SHEET_B31: dict[str, tuple[str, str]] = dict(LOAN_EXPECTED_
 #: is test-writer's job over a live pipeline run) — this dict only records
 #: the fixture's DESIGN intent (confirmed to match observed behaviour in the
 #: fixture-builder verification run — see the dated NOTE above).
+#:
+#: GUAR_S1 and GUAR_S7 DELIBERATELY share one destination
+#: (institution/C 08.01) — see the OB_S7/GTOR_S7 constant declarations for
+#: why (a sovereign guarantor would give S7 a fresh destination but breaks
+#: CRR/B31 regime-uniformity). ``TestPerScenarioInflowLandsOnce``
+#: (``test_crm_substitution_flows.py``), which currently asserts the shared
+#: sheet's inflow column against ONE scenario's ``guaranteed_amount`` in
+#: isolation, needs generalising to sum contributions per (destination_class,
+#: destination_template) pair before both entries can pass simultaneously —
+#: flagged to test-writer, not fixed here.
 SUBSTITUTION_INFLOW_DESIGN: dict[str, dict[str, object]] = {
     GUAR_S1: {
         "loan_reference": LN_S1,
@@ -505,6 +910,41 @@ SUBSTITUTION_INFLOW_DESIGN: dict[str, dict[str, object]] = {
     # guarantor shares GTOR_S3's class (``central_govt_central_bank``), which
     # already has a real inflow from S3, so a zero-amount S6 entry would
     # wrongly assert that shared sheet's inflow column is 0.0.
+    GUAR_S7: {
+        "loan_reference": LN_S7,
+        "guarantor_reference": GTOR_S7,
+        "guaranteed_amount": AMOUNT_COVERED_S7,
+        # DELIBERATELY the SAME (class, template) as GUAR_S1 — see the
+        # OB_S7/GTOR_S7 comment above the constant declarations for why (a
+        # sovereign guarantor would give a fresh destination but breaks
+        # CRR/B31 regime-uniformity). The shared sheet's inflow column
+        # (institution/C 08.01 col 0080) reports AMOUNT_COVERED_S1 +
+        # AMOUNT_COVERED_S7 = 2,000,000 + 5,500,000 = 7,500,000 once both
+        # scenarios are counted correctly — see the module docstring NOTE
+        # and the header comment on this dict for the test-writer follow-up.
+        "destination_class": "institution",
+        "destination_template": "c08_01",
+        "destination_has_native_population": True,
+        "same_class": False,
+    },
+    GUAR_S8: {
+        "loan_reference": LN_S8_GTD,
+        "guarantor_reference": GTOR_S8,
+        "guaranteed_amount": AMOUNT_COVERED_S8,
+        # CROSS-TEMPLATE, mirroring S3: the outflow leg is only ever visible
+        # to C 08.01's origin-slotting population, but the guarantor is
+        # SA-treated (a slotting beneficiary's guarantor always is — see the
+        # OB_S8/GTOR_S8 constant declarations), so the inflow belongs on
+        # C 07.00. "corporate" is a FRESH C 07.00 destination (unlike S3's
+        # central_govt_central_bank or S4's institution) that happens to
+        # land on an ALREADY-POPULATED native sheet — S4's own corporate
+        # loan — so a regression here inflates an EXISTING cell (see the
+        # OB_S8/GTOR_S8 comment for the "make it loud" reasoning).
+        "destination_class": "corporate",
+        "destination_template": "c07",
+        "destination_has_native_population": True,
+        "same_class": False,
+    },
 }
 
 #: S6's declined-guarantee design intent (Finding 4 /
@@ -543,6 +983,101 @@ DECLINED_GUARANTEE_DESIGN: dict[str, dict[str, object]] = {
         "would_be_destination_class": "central_govt_central_bank",
         "would_be_destination_template": "c07",
     },
+}
+
+#: S7's cross-border country-basis design intent (PRA PS1/26 Annex II
+#: Section 3.4 para 86/87 — C 09.01/C 09.02 geographical breakdown). NOT YET
+#: IMPLEMENTED: today ``cp_country_code`` is joined onto every exposure row
+#: (including the ``__G_`` guaranteed leg) by the exposure's OWN
+#: ``counterparty_reference``, which the CRM splitter never reassigns to the
+#: guarantor (``engine/crm/guarantees.py::_build_guarantor_sub_rows`` sets
+#: ``guarantor_reference`` but leaves ``counterparty_reference`` — and
+#: therefore ``cp_country_code`` — on the obligor's own basis throughout, for
+#: every column, on every leg); ``guarantor_country_code`` is ALREADY joined
+#: separately onto every exposure row via ``guarantor_reference``
+#: (``_join_guarantor_counterparty``), so the raw input the fix needs is
+#: already sealed and available — only C 09.01/C 09.02's column bindings
+#: still need to read it (task "S2a: C 09.01 exposure-value / RWEA columns to
+#: the post-substitution basis"). Recorded here as the fixture's DESIGN
+#: intent for that fix, not the engine's CURRENT behaviour — mirroring
+#: ``DECLINED_GUARANTEE_DESIGN`` and ``SUBSTITUTION_INFLOW_DESIGN`` above.
+#: Once built:
+#:   - "original exposure pre-conversion factors" (C 09.01 cols 0010/0020,
+#:     C 09.02 cols 0010/0030) key the IMMEDIATE obligor's country
+#:     (``obligor_country``) UNCONDITIONALLY, on every leg of LN_S7
+#:     (``__G_`` and ``__REM`` alike) — substitution never moves this column,
+#:     only the guaranteed leg's exposure-value / RWEA columns.
+#:   - every other populated column ("exposure value", "Risk-weighted
+#:     exposure amounts") keys the ULTIMATE obligor's country
+#:     (``guarantor_country``) on the beneficially-substituted ``__G_`` leg
+#:     ONLY. The ``__REM`` leg (never guaranteed) stays on
+#:     ``obligor_country`` throughout, as does the WHOLE loan if the
+#:     guarantee were ever declined instead of applied (S6's guarantor
+#:     country never reaches a reported leg at all — the sharpest contrast:
+#:     S6 proves a declined guarantee's country must NOT migrate, S7 proves
+#:     a beneficial one MUST).
+CROSS_BORDER_GUARANTEE_DESIGN: dict[str, dict[str, object]] = {
+    GUAR_S7: {
+        "loan_reference": LN_S7,
+        "guarantor_reference": GTOR_S7,
+        "guaranteed_amount": AMOUNT_COVERED_S7,
+        "obligor_country": COUNTRY_OB_S7,
+        "guarantor_country": COUNTRY_GTOR_S7,
+        # Cross-referenced from SUBSTITUTION_INFLOW_DESIGN[GUAR_S7] — the
+        # (class, template) pair the guaranteed leg's exposure-value / RWEA
+        # columns are also reported under, independent of country. Shared
+        # with GUAR_S1 — see the OB_S7/GTOR_S7 constant declarations.
+        "destination_class": "institution",
+        "destination_template": "c08_01",
+    },
+}
+
+#: S8's slotting-blend design intent (COREP C 08.06 / Pillar 3 CR10 — the
+#: per-category risk-weight columns; task "S4: C 08.06 + CR10 slotting grid
+#: and lineage correction"). Two legs share ONE category (``SLOTTING_
+#: CATEGORY_S8``, "good" -> 0.90 SA-equivalent):
+#:   - LN_S8_PLAIN: unguaranteed, EAD = DRAWN_S8_PLAIN (6,500,000), reports
+#:     at the category's OWN weight, 0.90, UNCONDITIONALLY.
+#:   - LN_S8_GTD: PARTIALLY guaranteed. Its ``__REM`` leg (EAD =
+#:     DRAWN_S8_GTD - AMOUNT_COVERED_S8 = 12,000,000 - 7,800,000 =
+#:     4,200,000) is NEVER guaranteed and stays at the category's OWN
+#:     weight, 0.90 — identical basis to LN_S8_PLAIN. Its ``__G_`` leg (EAD
+#:     = AMOUNT_COVERED_S8 = 7,800,000) is beneficially substituted to
+#:     GTOR_S8's SA risk weight, 0.20 (``CQS_GTOR_S8`` = 1).
+#: A CORRECT per-leg treatment therefore reports THREE risk-weight tiers
+#: within the SAME category (0.90, 0.90, 0.20), not one: total category EAD
+#: 18,500,000, total RWA 6,500,000*0.90 + 4,200,000*0.90 + 7,800,000*0.20 =
+#: 5,850,000 + 3,780,000 + 1,560,000 = 11,190,000. A defective SINGLE
+#: EAD-weighted-average "risk weight" column (the shape this scenario
+#: reproduces — see the OB_S8/GTOR_S8 constant declarations for the
+#: production-shaped prototype that surfaced it) instead reports
+#: 11,190,000 / 18,500,000 ≈ 0.6049 (~60.5%) — a number with NO regulatory
+#: meaning, sitting inside neither the "good" (0.90) nor GTOR_S8's (0.20)
+#: band, while any FIXED-display column elsewhere in the same template
+#: (e.g. a "category" or "weight" column keyed off ``slotting_category``
+#: alone) would print 0.90 next to it — the same incoherence the brief's
+#: worked prototype reproduces, confirmed to reproduce identically here
+#: — see the dated NOTE for the fixture-builder verification run's actual
+#: observed C 08.06/CR10 output (current, pre-fix behaviour) alongside this
+#: recorded correct-basis design intent. fixture-builder does not assert
+#: the engine's CURRENT behaviour here (that is test-writer's job over a
+#: live pipeline run) — this dict only records the fixture's DESIGN intent,
+#: mirroring ``DECLINED_GUARANTEE_DESIGN`` / ``CROSS_BORDER_GUARANTEE_
+#: DESIGN`` above.
+SLOTTING_BLEND_DESIGN: dict[str, object] = {
+    "slotting_category": SLOTTING_CATEGORY_S8,
+    "plain_loan_reference": LN_S8_PLAIN,
+    "plain_ead": DRAWN_S8_PLAIN,
+    "plain_risk_weight": 0.90,
+    "guaranteed_loan_reference": LN_S8_GTD,
+    "guaranteed_remainder_ead": DRAWN_S8_GTD - AMOUNT_COVERED_S8,  # 4,200,000
+    "guaranteed_remainder_risk_weight": 0.90,
+    "guaranteed_substituted_ead": AMOUNT_COVERED_S8,  # 7,800,000
+    "guaranteed_substituted_risk_weight": 0.20,
+    "category_total_ead": DRAWN_S8_PLAIN + DRAWN_S8_GTD,  # 18,500,000
+    "category_total_rwa_correct_basis": (
+        DRAWN_S8_PLAIN * 0.90 + (DRAWN_S8_GTD - AMOUNT_COVERED_S8) * 0.90 + AMOUNT_COVERED_S8 * 0.20
+    ),  # 11,190,000
 }
 
 
@@ -588,25 +1123,37 @@ def build_reporting_crm_substitution_bundle() -> RawDataBundle:
 
 
 def _counterparties() -> pl.DataFrame:
-    """Six obligor/guarantor pairs, one per scenario.
+    """Eight obligor/guarantor pairs, one per scenario (S8 adds a NINTH row —
+    its obligor carries two loans in one category, no second obligor needed).
 
-    Obligors S1-S3/S5 are ``corporate`` above the SME revenue ceiling so the
-    supporting factor never perturbs a substitution cell; S4 is unrated so its
-    own-basis SA risk weight is unambiguous; S6 is ``corporate`` too — like
-    ``reporting_portfolio.py``'s slotting counterparty, specialised-lending
-    routing comes from the ``specialised_lending`` join row (``_specialised_
-    lending``), NOT from ``entity_type`` — plus a matching ``model_id``-only
-    (no PD) rating so F-IRB/A-IRB stay unavailable and the exposure falls to
-    slotting (CRR Art. 153(5)). Guarantors span the four SA classes
-    ``ENTITY_TYPE_TO_SA_CLASS`` can reach from a counterparty (``institution``
-    x2, ``individual`` -> retail_other, ``sovereign`` x2 ->
+    Obligors S1-S3/S5/S7 are ``corporate`` above the SME revenue ceiling so
+    the supporting factor never perturbs a substitution cell; S4 is unrated so
+    its own-basis SA risk weight is unambiguous; S6 is ``corporate`` too —
+    like ``reporting_portfolio.py``'s slotting counterparty, specialised-
+    lending routing comes from the ``specialised_lending`` join row
+    (``_specialised_lending``), NOT from ``entity_type`` — plus a matching
+    ``model_id``-only (no PD) rating so F-IRB/A-IRB stay unavailable and the
+    exposure falls to slotting (CRR Art. 153(5)). Guarantors span the four SA
+    classes ``ENTITY_TYPE_TO_SA_CLASS`` can reach from a counterparty
+    (``institution`` x2, ``individual`` -> retail_other, ``sovereign`` x2 ->
     central_govt_central_bank), PLUS a fifth guarantor deliberately in the
     SAME class as its obligor (``corporate`` — S5) — see the module docstring
     table. GTOR_S6 is UNRATED (no rating row at all, like OB_S4) and non-GB
     (``US``) so neither an ECAI rating nor the Art. 114(4)/(7) domestic-CGCB
     0% carve-out can make its guarantee beneficial — only the plain
     ``CQS.UNRATED`` fallback (1.00) applies, strictly above the 0.70 slotting
-    weight it is compared against.
+    weight it is compared against. GTOR_S7 is a THIRD ``institution`` (after
+    GTOR_S1 and GTOR_S4), IRB-rated (an internal PD, not an ECAI CQS) and
+    incorporated in Germany rather than GB — see the OB_S7/GTOR_S7 comment
+    above the constant declarations for why "institution" (not "sovereign",
+    which was tried first and empirically broke CRR/B31 regime-uniformity)
+    and why "DE". OB_S8 is the fixture's SECOND slotting-origin counterparty
+    (after OB_S6), also ``corporate`` with a ``model_id``-only rating so it
+    falls to slotting too; GTOR_S8 is ``corporate`` (not "institution", to
+    keep it distinct from GTOR_S1/S4/S7) with a CQS rating, NOT an internal
+    PD — a slotting beneficiary's guarantor is always SA-treated regardless
+    of any internal rating, so an internal PD on GTOR_S8 would be inert; see
+    the OB_S8/GTOR_S8 comment above the constant declarations.
     """
     rows: list[dict] = [
         {
@@ -684,6 +1231,38 @@ def _counterparties() -> pl.DataFrame:
             "entity_type": "sovereign",
             "country_code": "US",
         },
+        {
+            "counterparty_reference": OB_S7,
+            "entity_type": "corporate",
+            "country_code": COUNTRY_OB_S7,
+            "annual_revenue": _LARGE_CORPORATE_REVENUE,
+        },
+        {
+            # IRB-rated (internal PD, not an ECAI CQS) and non-GB, non-US —
+            # the cross-border BENEFICIAL substitution. "institution", not
+            # "sovereign" — see the OB_S7/GTOR_S7 comment above the constant
+            # declarations for the empirical CRR/B31 regime-uniformity reason.
+            "counterparty_reference": GTOR_S7,
+            "entity_type": "institution",
+            "country_code": COUNTRY_GTOR_S7,
+        },
+        {
+            # Second slotting-origin obligor (after OB_S6) — see the
+            # ``_specialised_lending`` join, which carries the category for
+            # BOTH of this counterparty's loans (LN_S8_PLAIN, LN_S8_GTD).
+            "counterparty_reference": OB_S8,
+            "entity_type": "corporate",
+            "country_code": "GB",
+            "annual_revenue": _LARGE_CORPORATE_REVENUE,
+        },
+        {
+            # CQS-rated (not internal-PD) — a slotting beneficiary's
+            # guarantor is always SA-treated. See the OB_S8/GTOR_S8 comment
+            # above the constant declarations.
+            "counterparty_reference": GTOR_S8,
+            "entity_type": "corporate",
+            "country_code": "GB",
+        },
     ]
     return pl.DataFrame(rows, schema_overrides=dtypes_of(COUNTERPARTY_SCHEMA))
 
@@ -707,23 +1286,34 @@ def _ratings() -> pl.DataFrame:
         _internal(OB_S5, pd=PD_OB_S5),
         _internal(GTOR_S5, pd=PD_GTOR_S5),
         _internal_no_pd(OB_S6),
+        _internal(OB_S7, pd=PD_OB_S7),
+        _internal(GTOR_S7, pd=PD_GTOR_S7),
+        _internal_no_pd(OB_S8),
+        _external(GTOR_S8, cqs=CQS_GTOR_S8),
     ]
     return pl.DataFrame(rows, schema_overrides=dtypes_of(RATINGS_SCHEMA))
 
 
 def _loans() -> pl.DataFrame:
-    """The six obligor loans plus the two guarantors' own exposures.
+    """The nine obligor loans (S8 contributes two) plus the two guarantors'
+    own exposures.
 
-    GTOR_S5 and GTOR_S6 get NO own loan — S5's class already has an origin
-    sheet (``corporate``, from OB_S1/OB_S2/OB_S3/OB_S5 alike) and S6 is
-    DECLINED so it never creates an inflow that would need a sheet
-    pre-established for it (see the module docstring).
+    GTOR_S5, GTOR_S6, GTOR_S7 and GTOR_S8 get NO own loan — S5's class
+    already has an origin sheet (``corporate``, from OB_S1/OB_S2/OB_S3/OB_S5
+    alike), S6 is DECLINED so it never creates an inflow that would need a
+    sheet pre-established for it, S7's destination class (``institution``)
+    already has a native C 08.01 population from GTOR_S1's own loan
+    (LN_S1_GTOR_OWN) — see the module docstring on why S7 deliberately
+    reuses that sheet rather than pre-establishing a fresh one of its own —
+    and S8's destination class (``corporate``) already has a native C 07.00
+    population from OB_S4's own loan (see the OB_S8/GTOR_S8 constant
+    declarations for the same "make it loud" reasoning).
 
     No ``lgd`` is supplied on any row, so every IRB leg resolves F-IRB
     (supervisory LGD) — consistent with ``reporting_irb_classes_portfolio.py``.
-    LN_S6 is a plain drawn term loan like every other row here — slotting
-    routing comes entirely from the ``specialised_lending`` join
-    (``_specialised_lending``), not from ``product_type``.
+    LN_S6/LN_S8_PLAIN/LN_S8_GTD are plain drawn term loans like every other
+    row here — slotting routing comes entirely from the ``specialised_
+    lending`` join (``_specialised_lending``), not from ``product_type``.
     """
     rows: list[dict] = [
         _loan(LN_S1, OB_S1, DRAWN_S1),
@@ -734,16 +1324,26 @@ def _loans() -> pl.DataFrame:
         _loan(LN_S4_GTOR_OWN, GTOR_S4, DRAWN_S4_GTOR_OWN),
         _loan(LN_S5, OB_S5, DRAWN_S5),
         _loan(LN_S6, OB_S6, DRAWN_S6),
+        _loan(LN_S7, OB_S7, DRAWN_S7),
+        _loan(LN_S8_PLAIN, OB_S8, DRAWN_S8_PLAIN),
+        _loan(LN_S8_GTD, OB_S8, DRAWN_S8_GTD),
     ]
     return pl.DataFrame(rows, schema_overrides=dtypes_of(LOAN_SCHEMA))
 
 
 def _specialised_lending() -> pl.DataFrame:
-    """S6's one project-finance slotting exposure ("strong" category).
+    """S6's and S8's project-finance slotting exposures — DIFFERENT
+    categories ("strong" / "good") so their C 08.06 / CR10 rows stay
+    independently attributable (see the OB_S8/GTOR_S8 constant
+    declarations).
 
-    Mirrors ``reporting_portfolio.py``'s ``_specialised_lending`` exactly —
-    the same (``sl_type``, ``slotting_category``, ``is_hvcre``) combination,
-    a PROVEN pattern already exercised by that widely-used golden fixture.
+    ``specialised_lending`` is a per-COUNTERPARTY join (no ``loan_reference``
+    column in ``SPECIALISED_LENDING_SCHEMA``), so OB_S8's single row here
+    applies to BOTH of its loans (LN_S8_PLAIN, LN_S8_GTD) — one obligor, two
+    facilities, one category. Mirrors ``reporting_portfolio.py``'s
+    ``_specialised_lending`` exactly — the same (``sl_type``,
+    ``slotting_category``, ``is_hvcre``) combination, a PROVEN pattern
+    already exercised by that widely-used golden fixture.
     """
     return pl.DataFrame(
         [
@@ -752,25 +1352,33 @@ def _specialised_lending() -> pl.DataFrame:
                 "sl_type": "project_finance",
                 "slotting_category": SLOTTING_CATEGORY_S6,
                 "is_hvcre": False,
-            }
+            },
+            {
+                "counterparty_reference": OB_S8,
+                "sl_type": "project_finance",
+                "slotting_category": SLOTTING_CATEGORY_S8,
+                "is_hvcre": False,
+            },
         ],
         schema_overrides=dtypes_of(SPECIALISED_LENDING_SCHEMA),
     )
 
 
 def _guarantees() -> pl.DataFrame:
-    """The six guarantee rows — one per scenario, each partial cover.
+    """The eight guarantee rows — one per scenario, each partial cover.
 
     ``protection_type`` alternates ``"guarantee"`` / ``"credit_derivative"``
-    so both C 08.01 cols 0040/0050 are exercised. ``includes_restructuring``,
-    matched maturity/currency, and both unilateral flags False on every row —
-    no eligibility gate or maturity-mismatch haircut should zero any leg (see
-    the module docstring; confirmed empirically, not merely asserted, in the
-    fixture-builder verification run). GUAR_S6's ELIGIBILITY is unaffected by
-    any of this — it is fully eligible protection that the engine correctly
-    declines to APPLY because it would not help (guarantor RW >= own RW),
-    which is a wholly different gate (CRR Art. 213 / Art. 193(1), not
-    Art. 201).
+    so both C 08.01 cols 0040/0050 are exercised (4 ``"guarantee"`` / 4
+    ``"credit_derivative"`` with S7/S8 added — both were already exercised
+    by S1-S6, so S7/S8's values are a balance choice, not a new
+    requirement). ``includes_restructuring``, matched maturity/currency, and
+    both unilateral flags False on every row — no eligibility gate or
+    maturity-mismatch haircut should zero any leg (see the module docstring;
+    confirmed empirically, not merely asserted, in the fixture-builder
+    verification run). GUAR_S6's ELIGIBILITY is unaffected by any of this —
+    it is fully eligible protection that the engine correctly declines to
+    APPLY because it would not help (guarantor RW >= own RW), which is a
+    wholly different gate (CRR Art. 213 / Art. 193(1), not Art. 201).
     """
     rows: list[dict] = [
         _guarantee(GUAR_S1, GTOR_S1, LN_S1, AMOUNT_COVERED_S1, PCT_COVERED_S1, "guarantee"),
@@ -779,6 +1387,10 @@ def _guarantees() -> pl.DataFrame:
         _guarantee(GUAR_S4, GTOR_S4, LN_S4, AMOUNT_COVERED_S4, PCT_COVERED_S4, "credit_derivative"),
         _guarantee(GUAR_S5, GTOR_S5, LN_S5, AMOUNT_COVERED_S5, PCT_COVERED_S5, "guarantee"),
         _guarantee(GUAR_S6, GTOR_S6, LN_S6, AMOUNT_COVERED_S6, PCT_COVERED_S6, "guarantee"),
+        _guarantee(GUAR_S7, GTOR_S7, LN_S7, AMOUNT_COVERED_S7, PCT_COVERED_S7, "credit_derivative"),
+        _guarantee(
+            GUAR_S8, GTOR_S8, LN_S8_GTD, AMOUNT_COVERED_S8, PCT_COVERED_S8, "credit_derivative"
+        ),
     ]
     return pl.DataFrame(rows, schema_overrides=dtypes_of(GUARANTEE_SCHEMA))
 

--- a/tests/unit/reporting/corep/test_c07_crm_substitution.py
+++ b/tests/unit/reporting/corep/test_c07_crm_substitution.py
@@ -452,38 +452,76 @@ class TestSubstitutionFlows:
 def _irb_book_with_sa_guarantor() -> pl.LazyFrame:
     """An all-IRB-origin book whose only guarantee has an SA guarantor.
 
-    IRB_CORP_1 is unguaranteed (5,000). IRB_CORP_2 (3,000) is guaranteed
-    1,500 by an institution treated under the STANDARDISED approach post-CRM
-    (``approach_post_crm="standardised"`` — the CRR Art. 235 risk-weight
-    substitution route), while both rows' ORIGIN approach is
-    ``foundation_irb``. So ``c07_population`` (keyed on
-    ``reporting_approach_origin``) sees NO row from this book at all — the SA
-    guarantor never has its own exposure here — yet the inflow the guarantee
-    generates is destined for C 07.00's ``institution`` sheet by the guarantor's
-    POST-crm approach (``corep/crm_substitution.py``).
+    IRB_CORP_1 is unguaranteed (5,000). IRB_CORP_2 (3,000) is guaranteed 1,500
+    by an institution treated under the STANDARDISED approach post-CRM (the
+    CRR Art. 235 risk-weight substitution route), while every row's ORIGIN
+    approach is ``foundation_irb``. So the origin-approach population sees NO
+    row from this book at all — the SA guarantor never has its own exposure
+    here — yet the inflow the guarantee generates is destined for C 07.00's
+    ``institution`` sheet by the guarantor's POST-crm approach
+    (``corep/crm_substitution.py``).
+
+    TWO THINGS HERE ARE LOAD-BEARING AND WERE BOTH WRONG BEFORE.
+
+    1. THE POST-CRM TWINS ARE SET AS A PAIR. This frame used to set
+       ``approach_post_crm="standardised"`` with NO ``exposure_class_post_crm``,
+       so the shim sealed ``reporting_approach="standardised"`` alongside
+       ``reporting_class="corporate"`` — a leg simultaneously claiming to be an
+       SA exposure and to sit in the obligor's own class. PRODUCTION CANNOT EMIT
+       THAT: ``aggregator.py::_add_post_crm_reporting_class`` and
+       ``_post_crm_approach_expr`` carry the SAME is_guaranteed-and-beneficial
+       gate precisely so the two partition the same money the same way, and the
+       latter's docstring says an approach that migrates while the class does not
+       "would key a leg onto a sheet/template pair that never existed". Once
+       C 07.00's exposure-value and RWEA columns moved to the post-substitution
+       basis they read that pair, and the impossible state materialised a
+       phantom ``corporate`` sheet carrying the leg's whole EAD. If this test
+       ever fails again, FIX THE FRAME, NOT THE ASSERTION — a divergent pair is
+       the bug, not the thing under test.
+
+    2. THE GUARANTEED EXPOSURE IS SPLIT INTO ITS TWO LEGS, as CRM does
+       (``engine/crm/guarantees.py`` emits ``__G_<guarantor>`` and ``__REM``).
+       The single-row form is what made (1) impossible to express correctly: a
+       post-CRM class is a per-LEG attribute, so one row cannot say "only the
+       covered 1,500 migrated" — the whole 3,000 would land on the guarantor's
+       sheet. With the split, col 0200 on the institution sheet is the covered
+       1,500 and agrees with the col 0100 inflow instead of contradicting it.
+       Book totals are preserved (8,000 EAD / 5,300 RWEA); the retained and
+       covered halves keep the borrower's 0.60 weight because no assertion here
+       concerns risk weights and inventing a guarantor weight would pin a number
+       nothing tests.
     """
     return pl.LazyFrame(
         {
-            "exposure_reference": ["IRB_CORP_1", "IRB_CORP_2"],
-            "approach_applied": ["foundation_irb", "foundation_irb"],
-            "approach_post_crm": ["foundation_irb", "standardised"],
-            "exposure_class": ["corporate", "corporate"],
-            "drawn_amount": [5_000.0, 3_000.0],
-            "undrawn_amount": [0.0, 0.0],
-            "ead_final": [5_000.0, 3_000.0],
-            "rwa_final": [3_500.0, 1_800.0],
-            "risk_weight": [0.70, 0.60],
-            "pd_floored": [0.005, 0.01],
-            "lgd_floored": [0.45, 0.45],
-            "irb_maturity_m": [2.5, 3.0],
-            "expected_loss": [12.375, 13.5],
-            "scra_provision_amount": [0.0, 0.0],
-            "gcra_provision_amount": [0.0, 0.0],
-            "counterparty_reference": ["CP_A", "CP_B"],
-            "guaranteed_portion": [0.0, 1_500.0],
-            "protection_type": [None, "guarantee"],
-            "pre_crm_exposure_class": ["corporate", "corporate"],
-            "post_crm_exposure_class_guaranteed": ["corporate", "institution"],
+            "exposure_reference": ["IRB_CORP_1", "IRB_CORP_2__REM", "IRB_CORP_2__G_INST_GTOR"],
+            "approach_applied": ["foundation_irb"] * 3,
+            # The two post-CRM twins, always set together — see the docstring.
+            "approach_post_crm": ["foundation_irb", "foundation_irb", "standardised"],
+            "exposure_class": ["corporate"] * 3,
+            "exposure_class_post_crm": ["corporate", "corporate", "institution"],
+            "drawn_amount": [5_000.0, 1_500.0, 1_500.0],
+            "undrawn_amount": [0.0, 0.0, 0.0],
+            "ead_final": [5_000.0, 1_500.0, 1_500.0],
+            "rwa_final": [3_500.0, 900.0, 900.0],
+            "risk_weight": [0.70, 0.60, 0.60],
+            "pd_floored": [0.005, 0.01, 0.01],
+            "lgd_floored": [0.45, 0.45, 0.45],
+            "irb_maturity_m": [2.5, 3.0, 3.0],
+            "expected_loss": [12.375, 6.75, 6.75],
+            "scra_provision_amount": [0.0, 0.0, 0.0],
+            "gcra_provision_amount": [0.0, 0.0, 0.0],
+            "counterparty_reference": ["CP_A", "CP_B", "CP_B"],
+            "guaranteed_portion": [0.0, 0.0, 1_500.0],
+            "protection_type": [None, None, "guarantee"],
+            # Art. 235 substitution ACTUALLY applied on the covered leg. Stated
+            # explicitly rather than left absent: absence makes the decline gate
+            # a no-op, which happens to give the same answer here but says
+            # "the CRM sub-step never ran" rather than "the guarantee was
+            # recognised", and only the latter entitles the covered part to the
+            # guarantor's sheet.
+            "is_guarantee_beneficial": [None, None, True],
+            "pre_crm_exposure_class": ["corporate"] * 3,
+            "post_crm_exposure_class_guaranteed": ["corporate", "corporate", "institution"],
         }
     )
 


### PR DESCRIPTION
## What this fixes

A guaranteed exposure's covered part correctly left the obligor's sheet through the **pre-CCF flow columns** — but every **exposure-value** and **RWEA** column stayed keyed to the obligor. The money moved on one axis and not the other.

A £10m slotting loan guaranteed by a CQS1 corporate at 20% reported, on the guarantor's C 07.00 sheet:

| col | reported | should be |
|---|---|---|
| 0100 inflow | 10,000,000 ✅ | 10,000,000 |
| 0110 / 0150 | 10,000,000 ✅ | 10,000,000 |
| **0200 exposure value** | **0** ❌ | 10,000,000 |
| **0220 RWEA** | **0** ❌ | 0 |

With a 0%-RW sovereign guarantor col 0220 = 0 is right *by coincidence*, which is how this survived. Swap in any non-zero guarantor and the RWEA is simply absent from the template.

**Annex II is explicit.** Col 0200 is the *"exposure value after taking into account value adjustments, **all credit risk mitigants** and conversion factors"* — substitution is a credit risk mitigant. Cols 0090/0100: the covered part is *"deducted from the obligor's exposure class and **subsequently assigned to the protection provider's**"*.

## Four distinct defects

**1. A declined guarantee migrated anyway.** Where the engine declines a guarantee because it would not improve capital, the exposure kept its own risk weight for capital but still moved class and approach for *reporting* — booking an outflow and inflow for protection never recognised. A **70% slotting weight was published on the SA central-governments sheet**, where no such weight exists for any class. Two independent reproductions, at opposite ends of the weight scale: a 70% onto a sovereign sheet, and a 0% onto a corporate sheet.

**2. Exposure value and RWEA never followed the substitution.** Fixed across **C 07.00, C 08.01, C 08.06, C 09.01, C 09.02, C 02.00, OV1, CR10** — which had to move *together*, since several are defined by cross-reference to one another. Moving one alone makes two templates state different values for a quantity the regulator defines as identical.

**3. A substituted-away leg distorted the slotting grid.** A category holding one substituted and one plain leg reported the **EAD-weighted blend** of their weights — 60.5% inside a fixed Art. 153(5) **90%** band, with CR10 printing its fixed 90% beside an implied 60.5%.

**4. The covered part appeared as the guarantor's specialised lending.** `sl_type` is the *obligor's* characteristic, so a slotting-origin inflow populated "of which: specialised lending" on a corporate guarantor's sheet. Annex II admits those rows only for exposures applying the Art. 122B treatment — which a substituted-in part does not.

## Regulatory basis, verified verbatim

All quoted from `docs/assets/crr.pdf` and the PS1/26 instructions rather than recalled:

- **Art. 193(1)** (p.188) — mandatory, per-exposure: *"No exposure in respect of which an institution obtains credit risk mitigation shall produce a higher risk-weighted exposure amount or expected loss amount than an otherwise identical exposure ... with no credit risk mitigation."*
- **Art. 193(3)** (p.189) — the permissive limb, naming **both** approaches and expected loss.
- **Art. 113(3)** (p.110) — *"may be amended"*, per item; Art. 235(1) is expressly framed against it.
- **Annex II §3.4 ¶87** — geography splits by *immediate* obligor (original exposure) vs *ultimate* obligor (exposure value, RWEA).

An earlier draft cited **Art. 213** for the permissive election. That is wrong — Art. 213 is an *eligibility-conditions* article with no benefit test. Corrected across the code and the B3.1 spec. Two sessions reached for it independently, which is why the correction records *why* it is a natural mistake: Art. 213 sits inside the Sections that Art. 193(3)'s election is conditional on, so it is a **precondition of** the election, adjacent to it.

## Results

| | |
|---|---|
| Supervisory rules fixed | **19**, incl. 4 Error-severity |
| New breaks introduced | **0** (both regimes, six portfolios) |
| Tests | **10,558 passed, 0 failed** |
| Gate | arch_check, ruff, ty — all green |
| Arch-debt ratchets | **3 improved** and banked |

## Coverage was the root cause

`is_guarantee_beneficial` appeared in **zero** reporting fixtures and **zero** reporting unit tests, so the first fix passed 2,465 tests and moved no golden — because no frame the suite could build ever reached it. Two new scenarios make the affected paths reachable at all: a **cross-border** substitution (GB borrower, German guarantor) and a **slotting blend** (one substituted and one plain leg in one category). Both immediately found real defects, including an Error-severity break no existing scenario could reach.

Recurring theme, worth flagging for review: **several checks passed because they validated the wrong property.** A conservation identity that foots regardless of which sheet the money is on; a docs anchor that resolves without the referenced content existing; two register entries that were "fixed" only because nothing exercised them. Where a check could not distinguish correct from incorrect, this branch adds one that can.

## Deliberately not fixed

- **Art. 201(1) eligibility** — the exhaustive list of eligible unfunded-protection providers has no retail limb, so one fixture's guarantee should not be recognised at all. Capital-affecting; filed separately.
- **Supranational "Other countries"** (¶86) — C 09.01/02 have no such grouping at all. Materially larger than the ¶87 split.
- **PS1/26-side CRM verification** — the PRA Credit Risk Mitigation Part is not in `docs/assets/`, and the PRA *renumbers* (that document's "Article 193" is CRR Art. 161). The CRR chain is verified; the PS1/26 mandatory cap is not, and if absent it turns a compelled outcome into an election needing a policy basis.
