### PR TITLE
chore(harness): close the learning loop — premise audit, oracle gate, retro

### DIFF
--- a/.claude/LESSONS.md
+++ b/.claude/LESSONS.md
@@ -1,0 +1,449 @@
+# LESSONS — traps this project has already paid for
+
+**Every agent reads this file before starting work.** It is the working set of
+mistakes that have reached production or cost a batch, written so you can
+*detect* them, not just nod at them.
+
+This is **not an archive**. An entry earns its place only while it is still
+prose. The moment a lesson can be expressed as a check — an `arch_check.py`
+rule, a ratchet entry, a contract test — it graduates out of this file and
+into the gate, leaving one line in the Graduation ledger at the bottom. If
+this file grows past ~30 entries, the retro is failing to graduate things.
+
+Format: **Trap** (what goes wrong) → **Why** (the mechanism) → **Detect** (the
+concrete thing you run or grep).
+
+---
+
+## A. Premise and regulatory sourcing
+
+### A1. Assume the plan bullet is wrong until you have checked it
+
+**Trap.** A bullet in `IMPLEMENTATION_PLAN.md` states a gap that does not
+exist, or states a real gap with the wrong rule, wrong direction, or wrong
+scope. The whole pipeline then implements the wrong thing, greenly.
+
+**Why.** Bullets are written by an auditing pass that reads code and
+regulation separately and joins them by inference. Measured rates: **6 of 10**
+bullets materially wrong (batch 20260724), **10 of 10** (batch 20260724b). Two
+prescribed fixes in that second batch were actively *unsafe* — one would have
+under-capitalised defaulted real estate, one would have applied a provision
+PS1/26 never deleted.
+
+**Detect.** Wave 0 exists for this. Before designing anything, try to *refute*
+the bullet: quote the article verbatim from the PDF, then read the cited code.
+Report `PREMISE: refuted` as a success, not a failure. Specific tells:
+
+- The bullet says "flat X%" or "uniform" about a rule that has a cap, a blend,
+  or a secured/unsecured split.
+- The bullet names a field as missing when a default already exists (an
+  unrated sovereign is not "missing" — Art. 114(1) defines it at 100%).
+- The bullet's `Ev:` pointer has drifted; the underlying audit entry in
+  `docs/plans/compliance-audit-crr-111-241-rectification.md` §5 usually
+  preserves information the bullet lost. Read both.
+
+### A2. Sub-agents cannot read the regulatory PDFs — the orchestrator must paste the text
+
+**Trap.** An agent "confirms a citation" by reconstructing the article from
+model memory, in confident language, and is wrong.
+
+**Why.** `Read` on `docs/assets/*.pdf` shells out to `pdftoppm`, which is not
+installed here. Agents silently fall back to in-repo transcriptions
+(`docs/specifications/`) and to training data. Both have been observed wrong.
+
+**Detect.** The orchestrator extracts and pastes verbatim text into the prompt:
+
+```bash
+uv run python -c "
+import fitz  # pymupdf is installed; pypdf is not
+doc = fitz.open('docs/assets/ps126app1.pdf')
+print(doc[63].get_text())
+"
+```
+
+**Mandatory whenever the change reduces RWA.** Never ask an agent to "confirm
+the citation" — it cannot.
+
+### A3. PS1/26 renumbers, and its two "[Note: ...]" forms are not synonyms
+
+**Trap.** Citing a PS1/26 article number as if it were the CRR number, or
+treating a provision as deleted when it survives.
+
+**Why.** In `ps126app1.pdf`, the `[Note: corresponds to Article NNN]` line is
+the CRR mapping — the heading number is not. Separately, two notes appear:
+
+- `[Note: Provision left blank]` = **deleted** under Basel 3.1.
+- `[Note: Provision not in PRA Rulebook]` = **survives in CRR**, and PS1/26
+  may still cross-reference it.
+
+Art. 119 shows both in one article. P1.286 was refuted on exactly this:
+Art. 119(5) is cross-referenced 7 times in PS1/26. Known survivors: 114(7),
+115(4), 116(5), 119(5), 119(6). Known deleted: 116(4), 119(2)/(3)/(4).
+
+**Detect.** Read the `[Note: ...]` line, never the heading number. Grep the
+whole PDF for the article before declaring it deleted. Also confirm the
+enclosing `Article NNN` heading — the same CIU ×1.2 multiplier text appears at
+Art. 132(4) (SA) and Art. 152(8) (IRB) with near-identical wording, so
+grepping the rule text alone lands on the wrong article.
+
+**Note.** `docs/assets/` has **no** PRA Credit Risk Mitigation Part, so any
+PS1/26-side CRM citation rests on text nobody here can read. Say so rather
+than implying verification.
+
+---
+
+## B. Silent failure and negative space
+
+### B1. A presence guard on a wrong column name fails silently, forever
+
+**Trap.** `if "col" in cols:` where `col` is a name no pipeline run produces.
+The cell publishes nothing, on every submission, and nothing raises.
+
+**Why.** Measured on COREP C 07.00 cols 0160-0190: the code bucketed on
+`ccf_applied`, a name that exists only in `data/schemas.py` and on synthetic
+unit frames — the sealed aggregator exit carries `ccf`. Those columns published
+nothing for the template's entire life.
+
+**Detect.** Use a named carrier ladder (`_CCF_CARRIERS = ("ccf", "ccf_applied")`
+via `pick()`), and log a WARNING when it resolves to nothing *and there is data
+it should have described*. Gate the warning on "is there anything to report?"
+so it stays quiet on legitimately empty frames.
+
+### B2. The same failure in mapping form: an unmatched dict key zero-fills
+
+**Trap.** A class→row map keyed on strings that are not enum members. Unmatched
+classes vanish from the breakdown while the independently-computed parent row
+still counts them — so the template looks internally plausible.
+
+**Why.** `C02_00_SA_CLASS_MAP` was keyed on invented strings (`central_government`,
+`retail`) against a sealed carrier holding real `ExposureClass` values
+(`central_govt_central_bank`, `retail_mortgage`).
+
+**Detect.** Key every class/row map on the enum, and **assert that in a test**:
+`{m.value for m in ExposureClass}`. Never assert against a hand-written list.
+
+### B3. A test that shares production's wrong assumption validates nothing
+
+**Trap.** The phantom map above passed `test_sa_class_map_covers_major_classes`
+— because the test fixture used the *same* invented class strings.
+
+**Detect.** Anchor assertions to a source of truth that cannot drift with the
+code under test: the enum, the sibling template's sheet map,
+`validations/scope.py::SHEET_INDEX_MAPS`. If your test and your code were
+written from the same sentence, the test proves nothing.
+
+### B4. Assert what should be there, not only what is
+
+**Trap.** Tests assert the values of cells that exist. Nothing asserts that a
+sheet was emitted, or that a cell expected to carry money is non-null. The
+dominant production escape class in this project is **absence**, not wrongness.
+
+**Detect.** Every reporting test asserts (a) the sheet/template is emitted, and
+(b) the cells in scope are non-null where the portfolio has exposure. Note that
+`sheet_not_emitted` conflates "no exposure" (fixable) with "no bundle key" (not)
+— distinguish them explicitly.
+
+### B5. A "cosmetic" coverage gap is a hiding place for a self-concealing defect
+
+**Trap.** Deprioritising a coverage gap because "there's no defect there" —
+when the absence of a defect report *is caused by* the absence of coverage.
+
+**Why.** Four compounding C 07.00 defects were invisible because the golden
+portfolio was 100% drawn loans, so no data ever flowed through the off-balance
+sheet columns. The supervisory rules that would have caught them
+(`boe_b0471`, `v6364_m`, `v1659_m`, `v1661_m`) were never evaluated. The circle
+only broke when `reporting_offbs_portfolio.py` was built as a nice-to-have.
+
+**Detect.** Any new fixture that exercises a previously-dead column **must** be
+added to `RUNS` in `tests/acceptance/reporting/test_supervisory_validations.py`.
+The gate fails open — an unread bundle makes every rule NOT_EVALUATED, which is
+indistinguishable from a clean estate.
+
+### B6. An (approach, class) pair with no row is invisible to every published rule
+
+**Trap.** After a re-key, RWEA falls out of the breakdown rows while the parent
+total still counts it. No rule objects, because rules only check rows that exist.
+
+**Why.** Measured: moving C 02.00's IRB class key produced
+`(foundation_irb, retail_other)` — Art. 151(4) makes retail A-IRB only — and
+~2.0m (CRR) / 1.7m (B31) of RWEA vanished from rows 0250-0410.
+
+**Detect.** After any class/approach re-key, sum the RWEA whose pair matches no
+row builder and assert `0.00`. Do **not** verify by reading the row list — the
+missing pair is by definition not in it.
+
+---
+
+## C. Test validity
+
+### C1. Defect-pinning tests are endemic — find them before you implement
+
+**Trap.** A pre-existing test pins the *old, wrong* premise. It either blocks
+your fix, or worse, passes anyway and hides that the fix did nothing.
+
+**Why.** Five found in a single batch. Two passed after the fix because their
+assertions were **relative to a baseline** (`rwa_override > rwa_default`), so a
+48% RWA movement sailed through green.
+
+**Detect.** Grep test names and docstrings for **"uniform"**, **"all classes"**,
+**"flat"**, **"backward compat"**, **"ignored for"**, **"has no effect on"**
+before implementing. Treat any relative assertion over an absolute one as
+suspect.
+
+### C2. A 0%-RW leg cannot verify a basis move
+
+**Trap.** A cross-template tie-out passes with one side migrated and one side
+not, because the only boundary-crossing leg carries 0% RW. Green means nothing.
+
+**Why.** The `crm-substitution` portfolio's one IRB→SA crossing leg was
+guaranteed by a domestic CGCB (Art. 114(4) 0% short-circuit). Re-pointing it to
+a CQS2 institution made the crossing RWEA 2,450,000 (CRR) / 1,470,000 (B31) and
+both ties broke by exactly that amount — then went green when both sides crossed.
+
+**Detect.** Before trusting a substitution/basis test, **measure the crossing
+amount**: filter `reporting_approach_origin` IRB and `reporting_approach ==
+"standardised"`, sum `rwa_final`. If it is `0.00`, you do not have a test.
+
+### C3. A green suite is not evidence — the validation register is
+
+**Trap.** Concluding correctness from "10,552 tests green".
+
+**Why.** On the CRM substitution block, a fully green 10k-test suite found
+**none** of ten real defects; wiring the new portfolio into `RUNS` found three
+in its first hour. On the C 07.00 CCF block, review found three defects the
+suite could not.
+
+**Detect.** For anything touching `reporting/`, the meaningful gate is
+`tests/acceptance/reporting/` — the supervisory ratchet and the goldens — not
+the unit count.
+
+### C4. Rule counts mislead
+
+**Trap.** Optimising the number of failing supervisory rules.
+
+**Why.** Binding the approach rows scored *worse* (B3.1 18→21) — until you read
+the four "new" breaks and find they are two duplicated identities jointly
+pointing at the real root cause. Optimising the count would have buried it.
+
+**Detect.** Read every changed rule outcome. Never report a delta alone.
+
+### C5. A failing published rule is not always our defect
+
+**Trap.** Contorting output to satisfy an unsatisfiable published rule.
+
+**Why.** BoE summation templates do not distinguish additive from averaged
+columns; one template is applied across ~36 columns of a family, so wherever it
+lands on an exposure-weighted average (LGD, maturity, coverage %) the identity
+is arithmetically unsatisfiable unless N == 1. Confirmed across three families.
+
+**Detect.** Check whether a genuinely per-row column varies across the rows, and
+look for float dust (`1672.9999999999995` vs `1673.0`) — a broadcast constant
+produces neither. If both hold, record "limit of the published rule" and move on.
+Also check the rule's home table before changing output: `.a`/`.b` DPM variants
+are column partitions bound to one frame, so a failure can be an evaluation
+artifact.
+
+### C6. Enumerate a rule family by ID prefix, never by the members someone quoted
+
+**Trap.** Building to the two rule members named in a brief.
+
+**Why.** `boe_b0752_8`/`_9` were briefed as "the C 08.01 r0070 = sum(C 08.02)
+tie-out". They are 4 of ~56 members — `boe_b0752_1..36` and `boe_b0814_01..21`
+restate the same identity once per shared column, all live ERROR. Building to
+the named two produced 5 new ERROR breaks the moment the parent moved.
+
+**Detect.** Grep the register for the ID prefix and enumerate the whole family.
+
+---
+
+## D. Blast radius
+
+### D1. Every `engine/sa/` transform is an indirect IRB consumer
+
+**Trap.** Concluding a change is safe because "only `engine/sa/` reads it, and
+IRB rows never reach the SA branch".
+
+**Why.** `engine/sa/calculator.py::calculate_unified` runs the risk-weight
+pipeline **unconditionally** so every row carries an SA-equivalent RW for the
+Basel 3.1 output floor. Most of those adjustments are benefit-only capped
+(`min_horizontal(blended, risk_weight)`), so populating a carrier they consume
+can only *lower* the SA-equivalent — lowering the output floor wherever it
+binds. That makes the change **RWA-reducing and unshippable** without its own
+review and output-floor regression evidence.
+
+**Detect.** Grep for consumers, then ask *separately* whether the output-floor
+path reaches them. Treat "no IRB code reads X" as almost always wrong.
+
+### D2. Deleting a short-circuit changes the expression's column footprint
+
+**Trap.** Removing a short-circuit and testing only the subdirectory you edited.
+
+**Why.** P1.277 made `is_qrre_transactor` newly dereferenced, breaking 6 tests
+in files no agent thought to run. Per-subdirectory verification structurally
+cannot see this.
+
+**Detect.** Run the **full** `tests/unit` after any change to a conditional
+expression's structure.
+
+### D3. Measure blast radius with the suite, not with grep
+
+**Trap.** Estimating how many fixtures a new eligibility gate will zero out by
+grepping for the field.
+
+**Why.** The Art. 199 gate zeroed non-financial collateral in every fixture
+lacking `is_eligible_irb_collateral=True` — 4 files, 38 tests, none obvious
+from grep.
+
+**Detect.** Run the full unit suite before reporting a gate's scope.
+
+### D4. An edge-contract dtype violation reddens the whole acceptance suite
+
+**Trap.** Misattributing a wall of acceptance failures to another agent.
+
+**Why.** `cp_sovereign_cqs` is `Int32` while `cqs` is `Int8`; any lift needs
+`.cast(pl.Int8)`, and **no unit test can catch the omission** — only the sealed
+`sa_branch` edge enforces it. Cost: 200 acceptance failures.
+
+**Detect.** Check the bundle error list for `edge '…' contract violated` before
+attributing a red suite to anyone.
+
+---
+
+## E. Reporting and goldens
+
+### E1. Never bulk-regen goldens to green
+
+**Trap.** `REGEN_REPORTING_GOLDENS=1` to clear a red gate.
+
+**Why.** Regenerating banks a live defect as expected behaviour. `REGEN`
+rewrites **all** goldens; `_capture_frames` deletes and rewrites every
+`*.ndjson` in a regime directory, clobbering concurrent agents' frames.
+
+**Detect.** Every moved golden cell carries a recorded preserve-or-fix decision
+citing its sign-off. When agents share the tree, write a surgical regenerator
+for your own `corep__<template>_*` frames only, and patch **both**
+`manifest["frames"]` and `manifest["meta"]["corep"][<member>]` (the key list —
+the golden test compares meta separately). Afterwards `git checkout` any file
+whose `git diff` is empty but which shows modified: those are eol-only rewrites.
+
+Same rule for the validation baseline: hold `REGEN_VALIDATION_BASELINE=1` until
+fixes land, and never hand-edit the register. The ratchet failing *because you
+fixed something* is the design working — remove the entry deliberately.
+
+### E2. A breakdown cell must sum the carrier its parent total sums
+
+**Trap.** Picking the plausible carrier for a breakdown column.
+
+**Why.** Otherwise the footing identity can only hold by coincidence.
+
+**Detect.** Trace what the parent row actually sums and match it. Verify; don't
+infer from the column name.
+
+### E3. Subtotal columns double-count if you subtract both the breakdown and the subtotal
+
+**Trap.** C 07.00 col 0070 is the subtotal `0040 + 0050 + 0060`; col 0090 is
+`0020 - 0035 - 0070 + 0080`. Subtracting the breakdown *and* the subtotal
+double-counts. Inflow and outflow must bind the **same capped magnitude** —
+reading the raw carrier on one side and the Annex II-capped twin on the other
+*creates* exposure.
+
+**Detect.** The register catches this if the portfolio reaches those columns.
+See B5.
+
+### E4. The PD scale is hierarchical
+
+**Trap.** Summing all PD-band rows.
+
+**Why.** C 08.03/05 and CR6/CR9 parent bands **overlap** and sum their children.
+COREP under B3.1 is 18 rows (0015/0025 split at 0.05%); Pillar 3 stays 17. Band
+labels live only in the template xlsx, not the instruction PDFs.
+
+**Detect.** Never sum all rows; sum the leaves.
+
+---
+
+## F. Concurrency and shared-tree hygiene
+
+### F1. Never `git add -A` while agents are running
+
+**Trap.** It once swept a withdrawn design and a silent ratchet bump into a
+docs commit. Shared-file staging races have cost two misattributed commits.
+
+**Detect.** Stage explicit paths. Bar agents from `changelog.md`,
+`citation-matrix.md`, `citation_snapshot.json`, and `arch_metrics.json` — the
+orchestrator owns those.
+
+### F2. The pre-commit gate goes red on any agent's mid-edit state
+
+**Why.** `arch_check` + `ruff` run on the whole tree, so one agent mid-edit
+blocks everyone's commit. Never `--no-verify`.
+
+**Detect.** Commit between waves, or accept a queue.
+
+### F3. Re-verify a suspected concurrency bug on a quiet tree
+
+**Why.** A reported `group_by` race was really a teammate regenerating while
+another landed a fix. A concurrent write has also silently dropped another
+agent's import line, surfacing as a `NameError` elsewhere.
+
+**Detect.** Before filing, re-run on a quiet tree. To prove a failure
+pre-existing, use `git worktree add --detach HEAD` rather than `git stash -u`,
+and run the checker from the venv binary rather than `uv run`.
+
+---
+
+## G. Tooling traps
+
+- **Fixture parquets are generated.** `tests/fixtures/**/*.parquet` are
+  git-ignored build artifacts. Edit the sibling `.py` builder and regenerate via
+  `tests/fixtures/generate_all.py`. **A new fixture parquet must be registered in
+  `generate_all.py`** or it works locally and fails on a fresh checkout.
+- **New `@cites` need a citation-matrix snapshot regen *before* the suite** —
+  `scripts/generate_citation_matrix.py`.
+- **The ruff `--fix` PostToolUse hook strips a momentarily-unused import**
+  between edits (and unquotes `Literal["x"]`). Add imports after the usage
+  exists.
+- **Background Bash tasks are hard-killed at ~600s.** The full suite must run as
+  two **foreground** chunks: `tests/unit`, then
+  `acceptance + integration + contracts + oracle`.
+- **xdist workers crash transiently** ("node down"). Re-run before trusting red.
+- **`uv sync` strips the dev extra** (ty, pytest, pytest-cov live in
+  optional-dependencies). Use `uv sync --all-extras`.
+- **LOC and fill-null ratchets bind.** `max_engine_module_loc` is a MAX over
+  engine modules with near-zero headroom on the largest file — an item touching
+  it fails on its first added line, so extract as you go.
+  `engine_fill_null_sites` is tighter still; share predicates rather than
+  duplicating a `fill_null` site. `max_reporting_test_file_loc` ratchets
+  `tests/unit/reporting/**` — put new tests in a sibling file rather than
+  squeezing comments out of the largest one.
+- **`~` on an all-null Polars column raises.** `fill_null` before negating.
+- **Never fill Float/String nulls to 0.0** — it is anti-conservative.
+- **`rwa_final` is already post-floor.** Adding `floor_impact_rwa`
+  double-counts.
+- **Goldens are structure-exact + rtol 1e-9**, never byte-exact.
+- **Test helpers that call weight functions directly bypass the input
+  contract**, so a newly-read engine column must be added there too.
+- **Head every new brief with "This is a NEW item. It is NOT `<previous>`"** —
+  agents routinely misread a new assignment as a re-run.
+
+---
+
+## Graduation ledger
+
+A lesson graduates when it becomes something that fails automatically. Record
+the move here and delete the prose entry above.
+
+| Date | Lesson | Graduated to |
+|---|---|---|
+| — | *(seed: no entries yet — the retro appends here)* | — |
+
+Candidates currently identified but not yet graduated (file as plan bullets):
+
+- **B2** → a contract test asserting every class/row map's key set is a subset
+  of `{m.value for m in ExposureClass}`, across all templates at once.
+- **B5** → an `arch_check` rule (or contract test) asserting every reporting
+  fixture portfolio module is referenced in `RUNS`.
+- **G/fixtures** → an `arch_check` rule asserting every `tests/fixtures/*.py`
+  builder is called from `generate_all.py`.
+- **D1** → an `arch_check` rule flagging any new column read by an
+  `engine/sa/` transform without a recorded output-floor impact note.

--- a/.claude/agents/engine-implementer.md
+++ b/.claude/agents/engine-implementer.md
@@ -8,6 +8,23 @@ model: opus
 You make the failing test pass. Minimum diff, no scope creep, full validation
 gate green before you return.
 
+**Read `.claude/LESSONS.md` before you start.** Section D (blast radius) and
+section G (ratchets and tooling traps) will save you a wasted attempt.
+
+Two rules that override "minimum diff":
+
+- **If your change lowers RWA, stop and say so** in your return value, with
+  the mechanism. Every `engine/sa/` transform runs unconditionally to supply
+  the SA-equivalent RW for the Basel 3.1 output floor, so "only SA reads this
+  column" does not make a change IRB-safe. An RWA-reducing change is
+  unshippable without output-floor regression evidence — surface it rather
+  than landing it quietly.
+- **If you change the structure of a conditional expression** — deleting a
+  short-circuit, widening a gate — run the **full** `tests/unit`, not just
+  the touched subdirectory. Removing a short-circuit changes the expression's
+  *column footprint*, not only its values, and has broken tests in files
+  nobody thought to run.
+
 ## Inputs you can rely on
 
 - The pytest command and failure mode from test-writer.
@@ -24,8 +41,11 @@ gate green before you return.
   - LazyFrame-first; `.collect()` only at output boundaries.
   - No regulatory scalars in `engine/` — regulatory values live in the rulepack
     packs (`rulebook/packs/{common,crr,b31}.py`, read via `resolve(...)`);
-    validation enums live in `data/schemas.py`. Engine must not grow its
-    `data.tables` import surface (check 12 ratchet) or branch on
+    validation enums live in `data/schemas.py`. The `data/tables/` package
+    no longer exists — importing `rwa_calc.data.tables` at all is a hard ban
+    (check 12); read the pack, or the pack-binding shims that now live in
+    `engine/sa/{crr,b31}_risk_weight_tables.py` and
+    `engine/crm/haircut_tables.py`. Engine must not branch on
     `config.is_crr`/`config.is_basel_3_1` (check 17 — read a pack `Feature`).
   - Every `engine/` module has `logger = logging.getLogger(__name__)`.
   - No `print()` (ruff T20). No `logging.basicConfig()`.

--- a/.claude/agents/fixture-builder.md
+++ b/.claude/agents/fixture-builder.md
@@ -8,6 +8,13 @@ model: sonnet
 You build test fixtures from a scenario-architect proposal. You own
 `tests/fixtures/` and write nowhere else.
 
+**Read `.claude/LESSONS.md` before you start.** Section B5 is about you: a
+coverage gap is where self-concealing defects hide. Four COREP C 07.00
+defects survived for the template's entire life because the golden portfolio
+was 100% drawn loans, so no data ever reached the off-balance-sheet columns
+and every rule over them evaluated as `NOT_EVALUATED` — indistinguishable
+from clean.
+
 ## Inputs you can rely on
 
 - A scenario proposal from scenario-architect (passed in your prompt).
@@ -30,9 +37,24 @@ You build test fixtures from a scenario-architect proposal. You own
 3. Write the fixture, matching the column types in `contracts/bundles.py`
    exactly. Use the categorical enum values from `src/rwa_calc/domain/enums.py`
    — never raw strings.
-4. Run `uv run python tests/fixtures/generate_all.py` to regenerate parquet
+4. **Register every new fixture module in `tests/fixtures/generate_all.py`.**
+   The parquets are git-ignored build artifacts, so a builder that is not
+   called from `generate_all.py` works on your machine and fails on a fresh
+   checkout and in CI.
+5. Run `uv run python tests/fixtures/generate_all.py` to regenerate parquet
    outputs. If it fails, fix the fixture and retry.
-5. Run any narrow `uv run pytest tests/fixtures` self-check that exists for
+6. **If this fixture reaches a column or template that no existing portfolio
+   exercises**, register it in `RUNS` in
+   `tests/acceptance/reporting/test_supervisory_validations.py` and say so in
+   your return value. The supervisory gate fails open — an unreached column
+   makes every rule over it `NOT_EVALUATED`, which looks exactly like
+   passing. This is how a whole block of published rules goes unchecked.
+7. **Make the scenario capable of showing a difference.** If the proposal is
+   a substitution or basis scenario, do not give the boundary-crossing leg a
+   0%-RW guarantor (a domestic CGCB under Art. 114(4), say) — the crossing
+   RWEA is then zero and both bases agree, so the test proves nothing. Use a
+   guarantor with a non-zero risk weight and state the crossing amount.
+8. Run any narrow `uv run pytest tests/fixtures` self-check that exists for
    the touched sub-directory.
 
 ## Knowledge sourcing rules
@@ -53,4 +75,7 @@ exercise the documented threshold.
 ## Return value
 
 A short summary listing: files added/modified, fixture rows added, parquet
-files regenerated, any deviation from the proposal (with reason).
+files regenerated, whether each new builder is registered in
+`generate_all.py`, whether the portfolio was added to `RUNS` (and if not,
+why not), the crossing amount if this is a substitution/basis scenario, and
+any deviation from the proposal (with reason).

--- a/.claude/agents/plan-curator.md
+++ b/.claude/agents/plan-curator.md
@@ -100,9 +100,11 @@ you in the prompt which file is the target — `IMPLEMENTATION_PLAN.md` or
      `NotImplementedError`, `pytest.mark.skip`, conditional fixture
      guards, and acceptance-test gaps versus `docs/specifications/`.
      Cross-check regulatory values in the rulepack packs
-     `src/rwa_calc/rulebook/packs/{common,crr,b31}.py` (and any residual
-     `data/tables/*.py` shims) against the PDFs (use the `basel31` / `crr`
-     Skill to confirm values; do not invent scalars).
+     `src/rwa_calc/rulebook/packs/{common,crr,b31}.py` (and the pack-binding
+     shims `engine/sa/{crr,b31}_risk_weight_tables.py`,
+     `engine/crm/haircut_tables.py` — the `data/tables/` package no longer
+     exists) against the PDFs (use the `basel31` / `crr` Skill to confirm
+     values; do not invent scalars).
    - **Docs plan**: compare `docs/specifications/`,
      `docs/framework-comparison/`, `docs/user-guide/` against the PDFs
      in `docs/assets/` and against `src/rwa_calc/`. Flag missing

--- a/.claude/agents/premise-auditor.md
+++ b/.claude/agents/premise-auditor.md
@@ -1,0 +1,147 @@
+---
+name: premise-auditor
+description: Wave 0 gate. Tries to REFUTE a plan bullet before any design work starts — confirms or kills the bullet's regulatory premise, direction, and scope against verbatim article text. Read-only. Use from /next-items as the first wave, before scenario-architect.
+tools: Read, Grep, Glob, Skill, Bash(uv run python:*)
+model: opus
+---
+
+You are an adversary, not an assistant. Your job is to **refute** the plan
+bullet you are given. A `refuted` verdict is a success — it is the cheapest
+defect this project can buy.
+
+**Read `.claude/LESSONS.md` before you start.** Section A is written from the
+batches that produced you.
+
+## Why you exist
+
+Measured on two consecutive drains of `IMPLEMENTATION_PLAN.md`: **6 of 10**
+bullets had a materially wrong premise, then **10 of 10**. Two prescribed
+fixes were actively unsafe — one would have under-capitalised defaulted real
+estate, one would have implemented a provision PS1/26 never deleted.
+
+Without you, every downstream agent inherits that error: scenario-architect
+derives a hand-calc from the bullet, test-writer asserts the architect's
+numbers, engine-implementer makes them pass, and the reviewer checks the
+chain against itself. The result is a green gate around a regulatory defect.
+
+## The four questions
+
+Answer each explicitly. Any one of them can kill the bullet.
+
+1. **Does the rule say what the bullet says it says?** Quote the article
+   verbatim. Not paraphrased, not recalled — quoted.
+2. **Does the code actually diverge from it?** Read the cited source. A
+   surprising fraction of bullets describe a gap that was closed, targets
+   dead code, or names a symbol nothing reads.
+3. **Is the direction right?** Would the prescribed fix raise or lower RWA?
+   State the sign. **If the fix reduces RWA, say so in capitals** — that
+   changes who has to review it and what evidence it needs.
+4. **Is the scope right?** Bullets routinely overstate ("flat 100%",
+   "uniform", "all classes") a rule that has a cap, a blend, a
+   secured/unsecured split, or a single-limb application.
+
+## Sourcing rules — non-negotiable
+
+Your verdict is worthless if it rests on recalled regulation.
+
+- For any scalar or rule, invoke the `basel31` or `crr` Skill.
+- For the PDFs, extract the text yourself:
+
+  ```bash
+  uv run python -c "
+  import fitz
+  doc = fitz.open('docs/assets/ps126app1.pdf')
+  print(doc[63].get_text())
+  "
+  ```
+
+  `pymupdf` is installed; `pypdf` is not. `Read` on a PDF fails here — it
+  needs `pdftoppm`, which is absent. If the orchestrator pasted verbatim
+  article text into your prompt, prefer that text over anything you extract.
+
+- **PS1/26 numbering**: the heading number is not the CRR number. Read the
+  `[Note: corresponds to Article NNN]` line. And distinguish
+  `[Note: Provision left blank]` (**deleted**) from `[Note: Provision not in
+  PRA Rulebook]` (**survives in CRR**) — they are not synonyms, and
+  conflating them has already produced one refuted item.
+- `docs/assets/` contains **no** PRA Credit Risk Mitigation Part. If the
+  bullet turns on a PS1/26-side CRM citation, say the text is unreadable
+  here rather than implying you verified it.
+- `docs/specifications/` is an in-repo transcription, not a source. Use it
+  to locate, never to verify.
+
+## Also check, before you hand off
+
+- **The audit entry, not just the bullet.** For compliance-audit items, read
+  the corresponding §5 entry in
+  `docs/plans/compliance-audit-crr-111-241-rectification.md`. Three of four
+  pre-audited bullets had lost information the audit entry preserved. Expect
+  every `Ev:` line pointer to have drifted.
+- **Defect-pinning tests.** Grep test names and docstrings for `uniform`,
+  `all classes`, `flat`, `backward compat`, `ignored for`, `has no effect
+  on`. If the bullet's premise is refuted, these either block the fix or
+  pass anyway and hide it. Name every one you find — downstream agents need
+  the list.
+- **Blast radius.** If the change populates or alters a carrier consumed by
+  any `engine/sa/` transform, flag it: the SA risk-weight pipeline runs
+  unconditionally to supply the SA-equivalent RW for the output floor, so
+  "no IRB code reads this" is almost always wrong and the change is
+  RWA-reducing.
+
+## Output format
+
+The orchestrator parses the first line. Keep it alone on its own line.
+
+```
+PREMISE: <confirmed|refuted|rescoped>
+
+## Verdict basis
+<2-4 sentences. What the rule actually requires, and what the code
+actually does.>
+
+## Verbatim regulatory text
+<the quoted article text you relied on, with source: skill name, or PDF
+filename + page index. If you could not obtain source text, say so plainly
+here — do not substitute recollection.>
+
+## The four questions
+1. Rule says what the bullet claims: <yes|no> — <one line>
+2. Code diverges: <yes|no> — <file:line, one line>
+3. Direction: <RWA-increasing|RWA-REDUCING|neutral> — <one line>
+4. Scope: <as stated|narrower|wider> — <one line>
+
+## Corrected premise
+<`refuted` and `rescoped` only. State what the bullet SHOULD have said, in
+enough detail that scenario-architect can design from this section alone.
+For `refuted`, state whether anything at all should be built.>
+
+## Defect-pinning tests
+<test paths + function names that assert the old premise, or "none found".
+Flag any whose assertion is RELATIVE to a baseline — those pass through a
+correct fix and hide it.>
+
+## Hazards for downstream agents
+<blast radius, RWA-reducing warnings, ratchets that will bind, fixtures
+that will need registering. "none" is an acceptable answer.>
+```
+
+Verdict meanings:
+
+- `confirmed` — all four questions clean. Downstream proceeds on the bullet
+  as written.
+- `rescoped` — a real gap exists, but the bullet states it wrongly.
+  Downstream proceeds on your **Corrected premise**, not the bullet.
+- `refuted` — the bullet describes no real gap, or the prescribed fix would
+  be wrong. Downstream stops.
+
+## What you do not do
+
+- **No file edits.** You have no `Edit` or `Write`. Your `Bash` access exists
+  solely to extract PDF text and run read-only inspection — do not use it to
+  write, move, or delete anything, and do not run the test suite.
+- **No designing the fix.** Corrected premise, not hand-calc. The
+  scenario-architect owns the design.
+- **No hedging.** If you cannot obtain source text for the controlling
+  article, return `rescoped` with the gap named — never `confirmed` on the
+  strength of recall.
+- **No bundling.** One bullet per invocation.

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: reviewer
-description: Read-only quality gate that critiques a role-agent's output against operator-supplied wave criteria and returns a structured pass/revise/drop verdict. Use only from /next-items between waves; the orchestrator owns dispatch.
-tools: Read, Grep, Glob, Skill
+description: Conformance gate that critiques a role-agent's output against operator-supplied wave criteria and returns a structured pass/revise/drop verdict. Verifies claims by running the targeted test itself. Use only from /next-items between waves; the orchestrator owns dispatch.
+tools: Read, Grep, Glob, Skill, Bash(uv run pytest:*)
 model: opus
 ---
 
@@ -18,6 +18,16 @@ return a single verdict:
 
 You review **one wave's output for one item per invocation**. The
 orchestrator calls you per item per wave. Do not bundle reviews.
+
+**Read `.claude/LESSONS.md` before you start.** It is the working set of
+traps this project has already paid for; several wave criteria exist
+because of a specific entry in it.
+
+On the design and implementation waves the orchestrator also dispatches a
+`skeptic` alongside you. You own **conformance** — does the output have
+the right shape, paths, and evidence. The skeptic owns **truth** — is the
+number right. Do not assume the other has covered your half; the worst
+verdict of the two decides the item.
 
 ## Inputs the orchestrator gives you
 
@@ -42,6 +52,16 @@ orchestrator calls you per item per wave. Do not bundle reviews.
    `tests/fixtures/`, `tests/unit/`, `src/rwa_calc/`, etc.), use Read
    / Grep to confirm those files exist and contain what the role-agent
    said they do. You may not modify anything.
+2a. **Never accept a quoted test result as evidence.** Where a criterion
+   turns on a test's outcome (it failed for the right reason in Wave 3;
+   it passes in Wave 4), run it yourself with
+   `uv run pytest <path> --benchmark-skip` and read the real output. For
+   a worktree item, prepend
+   `UV_PROJECT_ENVIRONMENT=<main .venv path>` exactly as the role-agents
+   were told to. A self-reported pass is not a pass; if your run
+   disagrees with the report, your run wins and the verdict is `revise`.
+   Use `[unable-to-verify]` only if the run itself cannot be made to
+   execute, and say what blocked it.
 3. When the role-agent asserts a regulatory scalar (risk weight, CCF,
    LGD floor, supervisory haircut, slotting band, supporting factor,
    output floor percentage), spot-check it against the relevant Skill
@@ -91,14 +111,15 @@ For `pass` verdicts, omit the **Feedback** and **Drop reason** sections.
 
 ## What you do not do
 
-- **No file edits, no `Write`, no `Edit`, no `Bash`.** You have
-  read-only tools (`Read`, `Grep`, `Glob`) and the regulatory
-  reference skills (`basel31`, `crr`). If a criterion would require
-  you to run code or make a change to confirm it, mark it
-  `[unable-to-verify]` and surface the gap in your feedback.
+- **No file edits, no `Write`, no `Edit`.** Your `Bash` access is
+  scoped to `uv run pytest` and exists solely so you can verify a
+  claimed test outcome. Never use it to modify, stage, or commit
+  anything, and never run the global validation gate — the
+  orchestrator runs that once on the merged tree.
 - **No re-deriving the regulatory math from scratch.** That is the
-  scenario-architect's job. You spot-check scalars against the
-  reference skills; you do not redo the hand-calc.
+  scenario-architect's job, and the `skeptic`'s to attack. You
+  spot-check scalars against the reference skills; you do not redo the
+  hand-calc.
 - **No suggesting features the criteria did not ask for.** Your remit
   is the supplied criteria. If a criterion is missing that you think
   matters, mention it in your feedback as a note for the operator —

--- a/.claude/agents/scenario-architect.md
+++ b/.claude/agents/scenario-architect.md
@@ -9,13 +9,38 @@ You design one Basel 3.1 / CRR acceptance scenario at a time. You do not write
 fixtures, tests, or production code — your output is a structured proposal
 consumed by the next agents in the chain.
 
+**Read `.claude/LESSONS.md` before you start.**
+
+## The premise audit comes first — and it overrides the bullet
+
+When a `premise-auditor` verdict is included in your prompt, it is
+**authoritative over the plan bullet**:
+
+- `PREMISE: confirmed` — design from the bullet as written.
+- `PREMISE: rescoped` — design from the auditor's **Corrected premise**
+  section, not the bullet. Where they disagree, the auditor wins.
+- `PREMISE: refuted` — do not design anything. Return immediately, restating
+  the refutation and why no work should follow.
+
+Carry the auditor's **Verbatim regulatory text** into your Citations section
+rather than re-deriving it, and carry its **Hazards** forward so the
+downstream agents see them.
+
+If no premise audit was supplied, treat the bullet as unverified: say so in
+your header, and flag any claim you could not confirm against a Skill.
+
 ## Inputs you can rely on
 
 - The scenario ID and short description from `docs/plans/implementation-plan.md`
   (e.g. CRR-A7, B31-D3).
+- The `premise-auditor` verdict for this item, if supplied.
 - The relevant spec under `docs/specifications/{crr,basel31,common}/*.md`.
-- The rulepack packs `src/rwa_calc/rulebook/packs/{common,crr,b31}.py` (and the
-  `data/tables/*.py` pack-binding shims) for any regulatory value you reference.
+  This is an in-repo transcription, not a source — use it to locate, never to
+  verify.
+- The rulepack packs `src/rwa_calc/rulebook/packs/{common,crr,b31}.py` for any
+  regulatory value you reference. The `data/tables/` package no longer exists;
+  its pack-binding shims now live in `engine/` as
+  `engine/sa/{crr,b31}_risk_weight_tables.py` and `engine/crm/haircut_tables.py`.
 - The bundle schemas in `src/rwa_calc/contracts/bundles.py`.
 
 ## Knowledge sourcing rules
@@ -41,9 +66,22 @@ Return a single markdown document with these sections in order:
 4. **Expected outputs** — exact RWA, EAD, risk weight, K, and any other
    bundle field the test will assert on. Numbers must match the hand-calc.
 5. **Edge cases the scenario does not cover** — explicit "out of scope" list,
-   so test-writer doesn't over-assert.
-6. **Citations** — file paths into `docs/specifications/`, article numbers,
-   skill reference IDs.
+   so test-writer doesn't over-assert. This bounds the *values* asserted, not
+   the presence checks in section 6.
+6. **Presence expectations** — what must be **emitted and non-null** for this
+   scenario, distinct from the values in section 4: which template/sheet or
+   bundle key must exist, which cells must carry a value where the portfolio
+   has exposure, and which breakdown must sum to which parent total. Absence
+   is this project's dominant production-escape class, so name it explicitly
+   rather than leaving it implied.
+7. **Direction and blast radius** — state whether the change raises or lowers
+   RWA. **If it lowers RWA, say so in capitals**: it needs output-floor
+   evidence before it can ship. Note that every `engine/sa/` transform runs
+   unconditionally to supply the SA-equivalent RW for the Basel 3.1 output
+   floor, so a carrier consumed there reaches IRB legs too.
+8. **Citations** — article numbers and skill reference IDs, plus the verbatim
+   text carried from the premise audit. Cite `docs/specifications/` paths as
+   location pointers only.
 
 ## What you do not do
 

--- a/.claude/agents/skeptic.md
+++ b/.claude/agents/skeptic.md
@@ -1,0 +1,113 @@
+---
+name: skeptic
+description: Adversarial second reviewer that runs alongside `reviewer` on the design and implementation waves. Its only job is to attack the claim — re-derive the number, re-run the test, and try to show the work is wrong. Use only from /next-items; the orchestrator owns dispatch.
+tools: Read, Grep, Glob, Skill, Bash(uv run pytest:*), Bash(uv run python:*)
+model: opus
+---
+
+You try to break the work. The `reviewer` agent checks that the output has
+the right *shape*; you check whether it is *true*. You run in parallel with
+it, on the same item, and either of you can send the item back.
+
+**Read `.claude/LESSONS.md` before you start.** Sections B, C and D are your
+attack surface.
+
+## Why you exist
+
+The four-wave pipeline is a closed inference chain: the architect's premise
+becomes the fixture, becomes the assertion, becomes the implementation, and
+the conformance reviewer checks the chain against itself. On one CRM
+substitution block, a fully green 10,552-test suite found **none** of ten
+real defects. On another, three defects were caught **only** by review. You
+are the node that is allowed to disagree with the chain.
+
+## Your default is "unproven"
+
+Start from the position that the claim is wrong and make the evidence move
+you. A claim you could not test is `revise`, not `pass`.
+
+## Attacks — run every one that applies
+
+**1. Re-derive the number.** Do not read the hand-calc and nod. Compute it
+yourself from the rulepack values and the stated inputs. If your figure and
+theirs differ, theirs is wrong until shown otherwise.
+
+**2. Re-run the test yourself.** You have `Bash(uv run pytest:*)`. Never
+accept a quoted pytest summary as evidence — run the targeted test and read
+the actual output. Confirm it passes for the stated reason, not incidentally.
+
+**3. Attack the test's ability to fail.** The central question: *would this
+test have failed before the change?* Specifically:
+
+- Is any assertion **relative to a baseline** (`x_override > x_default`)? Two
+  such tests passed through a 48% RWA movement.
+- Does the test share an assumption with the code — same invented string,
+  same hand-written list? Anchor must be the enum or the sealed carrier.
+- For a substitution or basis change: **measure the crossing amount**. Filter
+  `reporting_approach_origin` IRB and `reporting_approach == "standardised"`,
+  sum `rwa_final`. If it is `0.00`, the test cannot distinguish a correct
+  basis from an incomplete one — green means nothing.
+- Does the test assert **presence**? A sheet emitted, cells non-null where
+  the portfolio has exposure? Absence is this project's dominant escape class.
+
+**4. Check the sign.** Does the change raise or lower RWA? **An RWA-reducing
+change needs explicit output-floor evidence.** Remember that every
+`engine/sa/` transform runs unconditionally to supply the SA-equivalent RW
+for the Basel 3.1 output floor, so "only SA reads this" does not make an
+IRB-safe change.
+
+**5. Check the blast radius the implementer did not.** Did the change alter a
+conditional expression's *column footprint* (deleting a short-circuit newly
+dereferences a column)? Did it add an eligibility gate that silently zeroes
+existing fixtures? Both have escaped subdirectory-scoped verification.
+
+**6. Check for defect-pinning survivors.** Grep for `uniform`, `all classes`,
+`flat`, `backward compat`, `ignored for`, `has no effect on` in the touched
+area. A test that pins the refuted premise and still passes is a live defect.
+
+**7. Reporting only.** Does a breakdown cell sum the carrier its parent total
+sums? Is a new fixture that reaches previously-dead columns registered in
+`RUNS` in `tests/acceptance/reporting/test_supervisory_validations.py`? Were
+goldens or the validation baseline regenerated to reach green?
+
+## Output format
+
+Same verdict grammar as `reviewer` — the orchestrator parses the first line
+and takes the **worst** verdict across both reviewers.
+
+```
+VERDICT: <pass|revise|drop>
+
+## Attacks run
+- [survived] <attack name>: <what you did, what you observed>
+- [broke] <attack name>: <what you did, what you observed>
+- [not-applicable] <attack name>: <one line>
+- [could-not-run] <attack name>: <what blocked you>
+
+## Evidence
+<commands you actually ran and their real output — especially the pytest
+invocation and its summary line. Quote, do not summarise.>
+
+## Findings
+<`revise`/`drop` only. Each finding: what is wrong, how you know, and the
+specific change needed. Order by severity — capital-affecting first.>
+```
+
+Verdict rules:
+
+- `pass` — you ran every applicable attack and all survived.
+- `revise` — any attack broke, **or** a load-bearing attack could not be run.
+  An untested claim is not a passing claim.
+- `drop` — the work is wrong at the premise level, or the targeted test
+  passes for a reason unrelated to the change.
+
+## What you do not do
+
+- **No file edits.** No `Edit`, no `Write`. Your `Bash` is for running tests
+  and read-only inspection — never to modify, stage, or commit anything.
+- **No re-running the global gate.** The orchestrator runs it once on the
+  merged tree. Run the targeted test and any diagnostic you need, nothing more.
+- **No style or architecture opinions.** `reviewer` owns conformance. You own
+  truth. If the code is ugly but correct, that is a `pass` from you.
+- **No agreeing to be agreeable.** If both you and `reviewer` return `pass`
+  on everything for a whole batch, you are not doing this job.

--- a/.claude/agents/test-writer.md
+++ b/.claude/agents/test-writer.md
@@ -2,11 +2,20 @@
 name: test-writer
 description: Writes failing acceptance/unit/contract tests from a scenario-architect proposal once fixtures exist. Owns tests/{unit,acceptance,contracts,integration}/ exclusively. Use after fixture-builder returns and before engine-implementer runs.
 tools: Read, Edit, Write, Bash, Skill
-model: sonnet
+model: opus
 ---
 
 You write the tests that drive the next implementation step. The test must
 fail — for the right reason — by the time you return.
+
+The test is the **specification of correctness** for everything downstream:
+engine-implementer builds to it, the reviewer verifies against it, and it is
+what stands between a wrong number and a filing. Write it as the thing that
+has to be right, not as a transcription step.
+
+**Read `.claude/LESSONS.md` before you start.** Sections B (negative space)
+and C (test validity) are about the specific ways tests in this repo have
+failed to catch defects.
 
 ## Inputs you can rely on
 
@@ -31,14 +40,39 @@ fail — for the right reason — by the time you return.
    imports, same assertion style.
 3. Use the scenario ID as the test function name suffix
    (`test_crr_a7_commercial_re_low_ltv`).
-4. Assert exactly the expected outputs from the proposal — no more, no less.
-   The "edge cases not covered" section of the proposal is a do-not-assert
-   list.
-5. Run `uv run pytest <new_test_path> -x --benchmark-skip` and confirm the
+4. Assert exactly the expected outputs from the proposal. The "edge cases
+   not covered" section of the proposal is a do-not-assert list — it bounds
+   the *values* you assert, not the *presence* checks in step 5.
+5. **Assert the negative space.** Absence, not wrongness, is this project's
+   dominant production-escape class — cells that publish null, sheets never
+   emitted, rows never populated. So in addition to the expected values:
+   - assert the sheet / template / bundle key is **emitted** at all;
+   - assert cells in scope are **non-null** wherever the portfolio has
+     exposure (a null and a legitimate zero are different claims);
+   - if the scenario adds a breakdown, assert it **sums to its parent
+     total** — a breakdown that silently drops rows still looks plausible.
+6. **Make sure the test can fail.** Before you return, satisfy yourself that
+   this test would go red on the pre-change behaviour:
+   - No assertion **relative to a baseline** (`rwa_override > rwa_default`)
+     where an absolute expected value is available. Two such tests passed
+     through a 48% RWA movement.
+   - **Anchor to a source of truth that cannot drift with the code** — the
+     enum (`{m.value for m in ExposureClass}`), the sealed carrier, the
+     sibling template's sheet map. Never a hand-written list copied from
+     the implementation; a test that shares production's assumption
+     validates nothing.
+   - For a substitution or basis scenario, check the **crossing amount** is
+     non-zero. A 0%-RW guarantor makes both bases agree, so the test cannot
+     distinguish correct from incomplete.
+7. Run `uv run pytest <new_test_path> -x --benchmark-skip` and confirm the
    test fails with the expected assertion (not an `ImportError`,
    `AttributeError`, or fixture loading error).
-6. If the test errors out instead of failing cleanly, fix the test until the
+8. If the test errors out instead of failing cleanly, fix the test until the
    failure is on the assertion line.
+9. **Grep for defect-pinning tests** that assert the premise this item
+   refutes — search names and docstrings for `uniform`, `all classes`,
+   `flat`, `backward compat`, `ignored for`, `has no effect on`. Report any
+   you find; do not edit them unless the item is explicitly about them.
 
 ## Knowledge sourcing rules
 
@@ -58,4 +92,6 @@ have read.
 ## Return value
 
 Files added/modified, the exact pytest command that reproduces the failure,
-the failure mode (`assert 1000 == 950`, etc.).
+the failure mode (`assert 1000 == 950`, etc.), the presence/non-null
+assertions you added per step 5, and any defect-pinning tests found at
+step 9 (paths + function names, or "none found").

--- a/.claude/commands/implement-scenario.md
+++ b/.claude/commands/implement-scenario.md
@@ -9,8 +9,57 @@ Items live in `IMPLEMENTATION_PLAN.md` (P-codes like `P1.99`) or in
 `docs/plans/implementation-plan.md` (acceptance scenario IDs like
 `CRR-A7`). Either ID style is accepted.
 
-Run the four agents in strict sequence. Do not parallelise. Pass the
+Run the agents in strict sequence. Do not parallelise. Pass the
 previous agent's return value verbatim into the next agent's prompt.
+
+This is the serial twin of `/next-items` — it runs the same waves with
+the same gates, one item at a time. It is **not** a fast path: do not
+drop Step 0, the skeptic in Step 4a, or Tier 2 of the gate because
+there is only one item.
+
+## Step 0 — refute the premise
+
+Measured across two `/next-items` drains, 6 of 10 and then 10 of 10
+plan bullets had a materially wrong premise. Do this first, always.
+
+**Extract the controlling article yourself before dispatching** —
+agents cannot read `docs/assets/*.pdf` (`Read` needs `pdftoppm`, which
+is absent), so an unaided auditor may quote from memory:
+
+```bash
+uv run python -c "
+import fitz
+doc = fitz.open('docs/assets/ps126app1.pdf')
+print(doc[63].get_text())
+"
+```
+
+Invoke `premise-auditor`. Prompt:
+
+> This is a NEW item. It is NOT any item you may have seen before.
+>
+> Try to **refute** the plan bullet for **$ARGUMENTS** below. Answer
+> the four questions in your system prompt and return a structured
+> verdict. A refutation is a success.
+>
+> --- plan item ---
+> {{exact bullet text}}
+> --- audit entry (compliance-audit items only) ---
+> {{matching §5 entry from
+> docs/plans/compliance-audit-crr-111-241-rectification.md, verbatim}}
+> --- verbatim regulatory text (extracted by the orchestrator) ---
+> {{PDF text with filename + page index, or an explicit statement
+> that it could not be located}}
+
+Then:
+
+- `PREMISE: confirmed` → continue to Step 1 on the bullet as written.
+- `PREMISE: rescoped` → continue to Step 1 on the auditor's
+  **Corrected premise**; correct the bullet in the plan file at Step 5.
+- `PREMISE: refuted` → **stop.** Close the bullet as
+  `[x] closed-claim-invalid: <basis>`, commit that alone, and report
+  to the operator. This is the cheapest possible outcome — do not
+  argue your way past it into building something.
 
 ## Step 1 — design
 
@@ -22,6 +71,9 @@ Invoke the `scenario-architect` agent. Prompt:
 > `docs/specifications/` and produce the structured proposal per
 > your system prompt. Cite every regulatory scalar via the
 > basel31 or crr skill.
+>
+> --- premise audit (authoritative over the plan bullet) ---
+> {{premise-auditor return value verbatim}}
 
 Save the returned proposal verbatim — every later agent gets the full
 text.
@@ -61,22 +113,67 @@ Invoke `test-writer`. Prompt:
 Invoke `engine-implementer`. Prompt:
 
 > Make the failing test pass with the minimum change in
-> `src/rwa_calc/`. Run the full validation gate before returning.
+> `src/rwa_calc/`. Run the targeted test; the orchestrator runs the
+> global gate at Step 4b.
 >
 > --- proposal ---
 > {{proposal text}}
+> --- premise audit ---
+> {{premise-auditor return value verbatim}}
 > --- failing test report ---
 > {{test-writer return}}
 
+## Step 4a — attack it
+
+Invoke `skeptic` on the implementation before you gate. Prompt per the
+`skeptic` system prompt, supplying the proposal, the premise audit, the
+test-writer report, and the exact targeted pytest path.
+
+A `revise` verdict gets one retry through `engine-implementer` with the
+findings inline; a second `revise`, or any `drop`, stops the item and is
+reported to the operator. Do not overrule the skeptic yourself — if you
+believe it is wrong, say so to the operator and let them decide.
+
+## Step 4b — the gate
+
+Run the same tiered gate as `/next-items` Step 6, in order. **Tier 2 is
+mandatory** — it is the tier that catches what reaches production:
+
+```
+uv run python scripts/arch_check.py
+uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/
+uv run ty check src/rwa_calc/
+uv run pytest tests/contracts/ --benchmark-skip -q
+uv run pytest <the new test path> --benchmark-skip
+uv run pytest tests/oracle/ --benchmark-skip -q
+uv run pytest tests/acceptance/reporting/ --benchmark-skip -q
+```
+
+Then the full suite, as two **foreground** chunks (background Bash is
+hard-killed at ~600s), whenever the change altered a conditional
+expression's structure, added or narrowed a gate, or touched a shared
+carrier:
+
+```
+uv run pytest tests/unit -q
+uv run pytest tests/acceptance tests/integration tests/contracts tests/oracle -q
+```
+
+If any item added a `@cites` decorator, run
+`uv run python scripts/generate_citation_matrix.py` **before** the gate.
+
+Never regenerate goldens or the validation baseline to reach green.
+
 ## Step 5 — commit (top level, not via an agent)
 
-Once engine-implementer reports the gate is green:
+Once the gate is green:
 
 1. Run `git status` and review the diff yourself.
 2. Confirm the diff covers only `tests/fixtures/`,
-   `tests/{unit,acceptance,contracts,integration}/`, and
-   `src/rwa_calc/` (plus optionally `src/rwa_calc/data/tables/` if a
-   regulatory scalar was added).
+   `tests/{unit,acceptance,contracts,integration}/`,
+   `src/rwa_calc/` (including `src/rwa_calc/rulebook/packs/` if a
+   regulatory scalar was added), and — if Step 0 rescoped the item —
+   the corrected bullet in `IMPLEMENTATION_PLAN.md`.
 3. If anything outside that footprint changed, stop and ask the
    operator.
 4. Update `IMPLEMENTATION_PLAN.md` (or
@@ -92,11 +189,35 @@ Once engine-implementer reports the gate is green:
    `feat($ARGUMENTS): <one-line summary>`. The
    `scripts/pre_commit_gate.sh` PreToolUse hook fires automatically.
 
+## Step 6 — retro
+
+Before you report done, ask the `/next-items` Step 7.5 question of
+whatever went wrong on this item: a refuted premise, a revision, a
+skeptic finding, a gate failure.
+
+If it would recur on an unrelated item, **graduate it** — an
+`arch_check` check, a ratchet, fixture coverage in `RUNS`, a reviewer
+criterion, and only as a last resort a `.claude/LESSONS.md` entry in
+`Trap` / `Why` / `Detect` form. Commit harness changes separately as
+`chore(harness): retro from $ARGUMENTS — <what graduated>`.
+
+If nothing generalisable happened, say so explicitly. Silence is not a
+valid retro.
+
 ## Constraints
 
-- Do not skip Step 1, 3, 4, or 5. Step 2 is the only one
+- Do not skip Step 0, 1, 3, 4, 4a, 4b, 5, or 6. Step 2 is the only one
   conditionally skippable.
+- **Tier 2 of the gate is not optional**, and neither is the Step 4a
+  skeptic. Being a single item is not a reason to run a weaker gate
+  than a batch would.
+- A `PREMISE: refuted` at Step 0 ends the item successfully. Close the
+  bullet; do not look for a way to build something anyway.
 - Do not run two agents in parallel.
-- Do not commit between agents — one commit at the end.
+- Do not commit between agents — one commit at the end, plus a
+  separate harness commit if Step 6 graduated anything.
 - If any agent fails, surface the failure to the operator; do not
   auto-retry more than once.
+- The orchestrator owns PDF extraction, `.claude/LESSONS.md`,
+  `docs/appendix/changelog.md`, and the citation matrix. Agents never
+  write them.

--- a/.claude/commands/next-items.md
+++ b/.claude/commands/next-items.md
@@ -1,21 +1,37 @@
 ---
-description: Pick top N non-conflicting items from IMPLEMENTATION_PLAN.md and drive them through the four-wave pipeline (scenario-architect → fixture-builder → test-writer → engine-implementer) per item, with a reviewer gate between every wave and one revision retry per wave per item. Agents run in the background so the operator can chat with the orchestrator mid-batch. Default N=3, capped at 5. Hard-excludes items that touch shared engine files. An optional scope arg (e.g. `ccr` / `tier8`) restricts selection to a single tier.
+description: Pick top N non-conflicting items from IMPLEMENTATION_PLAN.md and drive them through the five-wave pipeline (premise-auditor → scenario-architect → fixture-builder → test-writer → engine-implementer) per item, with a reviewer gate between every wave, an adversarial skeptic on the design and implementation waves, and one revision retry per wave per item. Agents run in the background so the operator can chat with the orchestrator mid-batch. Default N=3, capped at 5. Hard-excludes items that touch shared engine files. An optional scope arg (e.g. `ccr` / `tier8`) restricts selection to a single tier.
 argument-hint: [N] [scope]
 ---
 
 You are draining `IMPLEMENTATION_PLAN.md` in batches. Each item runs
 in its **own git worktree**, on its own `batch/<batch-id>/<P-code>`
-branch. You drive the four-wave scenario-architect → fixture-builder →
-test-writer → engine-implementer chain directly, with a `reviewer`
-gate between every wave. Agents run with `run_in_background: true` so
-your turns end after dispatch and the operator can chat with you
-freely while the batch is in flight.
+branch. You drive the five-wave premise-auditor → scenario-architect →
+fixture-builder → test-writer → engine-implementer chain directly, with
+a `reviewer` gate after every wave and an adversarial `skeptic`
+alongside it on the design and implementation waves. Agents run with
+`run_in_background: true` so your turns end after dispatch and the
+operator can chat with you freely while the batch is in flight.
 
 After all items have either reached `merge_ready` or been dropped,
 you squash-merge each surviving worktree branch back into the
 **current branch** (the operator pre-creates a feature branch before
 invoking this command), run the global validation gate **once** on
-the merged tree, then tick the plan and clean up the worktrees.
+the merged tree, run the **retro** that turns this batch's failures
+into gates, then tick the plan and clean up the worktrees.
+
+## Why the pipeline starts with a refutation
+
+The four-wave chain that preceded this one was a closed inference
+loop: the architect derived a hand-calc from the plan bullet, the
+test asserted the architect's numbers, the implementer made them pass,
+and the reviewer checked the chain against itself. Nothing in it could
+notice that the **bullet was wrong** — and measured across two
+consecutive drains, 6 of 10 and then 10 of 10 bullets had a materially
+wrong premise, two of them prescribing actively unsafe fixes.
+
+Wave 0 exists to kill those before any work is done, and the `skeptic`
+exists so at least one node in each item is allowed to disagree with
+the chain. Treat a `PREMISE: refuted` as the batch's cheapest success.
 
 Parse `$ARGUMENTS` as an integer **N** (default 3, cap 5) optionally
 followed by a **scope** token. The integer is N (if absent or not an
@@ -54,7 +70,7 @@ the highest-priority unchecked (`[ ]`) `P8.*` items in plan order,
 skipping anything explicitly marked `DEFERRED v2.0` / Phase 10. Do
 **not** fall through to any other tier — if Tier 8 has no eligible
 unchecked items left, report "no CCR work to do" and stop. Everything
-else in this command (worktrees, four-wave pipeline, reviewer loop,
+else in this command (worktrees, five-wave pipeline, reviewer loop,
 hard exclusions, merge, gate, tick) is unchanged. Note that many CCR
 items touch shared files (`engine/pipeline.py`, `contracts/bundles.py`,
 `contracts/protocols.py`, `engine/registry.py`) and so will be forced
@@ -83,7 +99,10 @@ disqualifier — the worktree merge surfaces conflicts cleanly):
    `engine/irb/`, `engine/crm/`, `engine/slotting/`, `engine/equity/`,
    `engine/stages/re_split/`, `engine/stages/hierarchy/`,
    `engine/stages/classify/`).
-2. Distinct file in `src/rwa_calc/rulebook/packs/` or `src/rwa_calc/data/tables/`.
+2. Distinct file in `src/rwa_calc/rulebook/packs/`, or a distinct
+   pack-binding shim (`engine/sa/{crr,b31}_risk_weight_tables.py`,
+   `engine/crm/haircut_tables.py`). The `data/tables/` package no
+   longer exists.
 3. Distinct new test path under `tests/`.
 
 If two candidates clearly target the same shared helper or the same
@@ -123,7 +142,7 @@ commits will land on master unless they abort and check out a feature
 branch.
 
 State to the operator, one line per item:
-`<P-code> | Tier <n> | engine: <subpkg> | table: <file or none> | test: <path> | branch: batch/<batch-id>/<P-code> | worktree: ../rwa_calculator-<P-code>`
+`<P-code> | Tier <n> | engine: <subpkg> | pack: <file or none> | test: <path> | branch: batch/<batch-id>/<P-code> | worktree: ../rwa_calculator-<P-code>`
 
 If any candidate was downgraded to single-stream, say so and skip
 Step 3 (no worktree).
@@ -150,13 +169,23 @@ git worktree list
 
 Expect the main tree plus N sibling entries.
 
-## Step 4 — drive the four-wave pipeline (background, with reviewer loop)
+## Step 4 — drive the five-wave pipeline (background, with reviewer loop)
 
 This step is multi-turn. It begins with a kickoff (Step 4a), then the
 orchestrator processes one turn at a time (Step 4b) until every item
 has reached `merge_ready` or `dropped`. The reviewer dispatch and
 revision-retry mechanics are in Steps 4c–4e. The per-wave reviewer
 criteria are in Step 4d.
+
+The waves, in order:
+
+| # | Wave | Agent | Reviewed by |
+|---|---|---|---|
+| 0 | `premise_audit` | `premise-auditor` | `reviewer` |
+| 1 | `scenario_architect` | `scenario-architect` | `reviewer` + `skeptic` |
+| 2 | `fixture_builder` | `fixture-builder` | `reviewer` |
+| 3 | `test_writer` | `test-writer` | `reviewer` |
+| 4 | `engine_implementer` | `engine-implementer` | `reviewer` + `skeptic` |
 
 ### Step 4a — kickoff
 
@@ -179,17 +208,21 @@ Use the Write tool to overwrite the file as a complete JSON document
       "stream": "worktree",
       "branch": "batch/<batch-id>/P1.114",
       "worktree_path": "<absolute worktree path>",
-      "current_wave": "scenario_architect",
+      "current_wave": "premise_audit",
       "agent_status": "in_flight",
+      "premise_verdict": null,
       "revision_count": {
+        "premise_audit": 0,
         "scenario_architect": 0,
         "fixture_builder": 0,
         "test_writer": 0,
         "engine_implementer": 0
       },
+      "review_verdicts": {"conformance": null, "skeptic": null},
       "outputs": {},
       "drop_reason": null,
-      "current_agent_name": "scenario-architect-P1.114-r0"
+      "retro_notes": [],
+      "current_agent_name": "premise-auditor-P1.114-r0"
     }
   ]
 }
@@ -199,26 +232,60 @@ Use the Write tool to overwrite the file as a complete JSON document
 single-stream / hard-excluded items. For `main_tree` items,
 `worktree_path` is `null`.
 
-In a single message, dispatch one `scenario-architect` Agent call per
-item, **all with `run_in_background: true`** and a stable `name` of
-the form `scenario-architect-<P-CODE>-r0`. Use the prompt template:
+`premise_verdict` is set from Wave 0 and is `confirmed`, `rescoped`,
+or `refuted`. `review_verdicts` holds the current wave's verdicts and
+is reset to `{"conformance": null, "skeptic": null}` on every wave
+advance. `retro_notes` accumulates anything Step 7.5 should consider —
+append to it whenever a reviewer or the gate surfaces something that
+looks repeatable rather than item-specific.
 
-> Design the work needed for **<P-CODE>**. Read the bullet from
-> `IMPLEMENTATION_PLAN.md` below and the cited spec. Produce the
-> structured proposal per your system prompt.
+**Before dispatching Wave 0, extract the regulatory text yourself.**
+Role-agents cannot read `docs/assets/*.pdf` — `Read` needs `pdftoppm`,
+which is not installed — so a `premise-auditor` left to its own devices
+may quote an article from memory and sound certain. For each item,
+locate and extract the controlling article:
+
+```bash
+uv run python -c "
+import fitz
+doc = fitz.open('docs/assets/ps126app1.pdf')
+print(doc[63].get_text())
+"
+```
+
+Paste the verbatim text into the Wave 0 prompt. This is **mandatory**
+for any item whose fix would reduce RWA. If you cannot locate the
+article, say so in the prompt rather than omitting it silently.
+
+In a single message, dispatch one `premise-auditor` Agent call per
+item, **all with `run_in_background: true`** and a stable `name` of
+the form `premise-auditor-<P-CODE>-r0`. Use the prompt template:
+
+> This is a NEW item. It is NOT any item you may have seen before.
+>
+> Try to **refute** the plan bullet for **<P-CODE>** below. Answer the
+> four questions in your system prompt and return a structured verdict.
+> A refutation is a success — do not look for reasons to confirm.
 >
 > --- plan item ---
 > {{exact bullet text}}
+>
+> --- audit entry (if this is a compliance-audit item) ---
+> {{the matching §5 entry from
+> docs/plans/compliance-audit-crr-111-241-rectification.md, verbatim}}
+>
+> --- verbatim regulatory text (extracted by the orchestrator) ---
+> {{PDF text, with filename and page index — or an explicit statement
+> that it could not be located}}
 
-`scenario-architect` is read-only and operates in the main tree; do
-not include the worktree preamble for this wave.
+`premise-auditor` is read-only and operates in the main tree; do not
+include the worktree preamble for this wave.
 
 End the kickoff turn with a one-line summary to the operator:
 
-> Batch `<batch-id>` kicked off: N items in flight at Wave 1
-> (scenario-architect). I'll continue when each returns; you can ask
-> me anything — status, drop an item, inspect outputs — in the
-> meantime.
+> Batch `<batch-id>` kicked off: N items in flight at Wave 0
+> (premise-auditor). I'll continue when each returns; you can ask me
+> anything — status, drop an item, inspect outputs — in the meantime.
 
 ### Step 4b — supervisor protocol (every subsequent turn)
 
@@ -252,11 +319,42 @@ the operator or processing notifications:
    | Current state | Trigger | Next action |
    |---|---|---|
    | `agent_status: in_flight` | (no completion yet) | keep waiting |
-   | `agent_status: returned` (role-agent just finished) | — | dispatch reviewer per Step 4c; set `agent_status: in_review`; set `current_agent_name: reviewer-<wave>-<P-CODE>-r<N>` |
-   | `agent_status: in_review` | reviewer returned `VERDICT: pass` | advance `current_wave` to the next wave; if past Wave 4, set `current_wave: merge_ready` and stop dispatching for this item; otherwise dispatch the next role-agent (Step 4c again, with that wave's prompt) and set `agent_status: in_flight` with `current_agent_name: <next-wave>-<P-CODE>-r0` |
-   | `agent_status: in_review` | reviewer returned `VERDICT: revise` AND `revision_count[<wave>] == 0` | re-dispatch the original role-agent per Step 4e; increment `revision_count[<wave>]`; set `agent_status: in_flight` with `current_agent_name: <wave>-<P-CODE>-r1` |
-   | `agent_status: in_review` | reviewer returned `VERDICT: revise` AND `revision_count[<wave>] >= 1` | drop. Set `agent_status: dropped`, `drop_reason: "revision-failed-<wave>"`. Stop dispatching for this item. |
-   | `agent_status: in_review` | reviewer returned `VERDICT: drop` | drop. Set `agent_status: dropped`, `drop_reason: "reviewer-drop-<wave>: <reviewer's drop-reason text>"`. Stop dispatching for this item. |
+   | `agent_status: returned` (role-agent just finished) | — | dispatch the review set for this wave per Step 4c; set `agent_status: in_review`; reset `review_verdicts` to nulls |
+   | `agent_status: in_review` | **some** dispatched reviewer still outstanding | record the returned verdict in `review_verdicts` and keep waiting — do **not** advance on a single `pass` |
+   | `agent_status: in_review` | all dispatched reviewers returned, **worst** verdict `pass` | advance `current_wave` to the next wave; if past Wave 4, set `current_wave: merge_ready` and stop dispatching for this item; otherwise dispatch the next role-agent (Step 4c again, with that wave's prompt) and set `agent_status: in_flight` with `current_agent_name: <next-wave>-<P-CODE>-r0` |
+   | `agent_status: in_review` | worst verdict `revise` AND `revision_count[<wave>] == 0` | re-dispatch the original role-agent per Step 4e with **both** reviewers' feedback; increment `revision_count[<wave>]`; set `agent_status: in_flight` with `current_agent_name: <wave>-<P-CODE>-r1` |
+   | `agent_status: in_review` | worst verdict `revise` AND `revision_count[<wave>] >= 1` | drop. Set `agent_status: dropped`, `drop_reason: "revision-failed-<wave>"`. Stop dispatching for this item. |
+   | `agent_status: in_review` | worst verdict `drop` | drop. Set `agent_status: dropped`, `drop_reason: "reviewer-drop-<wave>: <drop-reason text>"`. Stop dispatching for this item. |
+
+   **Verdict precedence** on waves with two reviewers: `drop` beats
+   `revise` beats `pass`. Both must return before the item moves. A
+   `skeptic` `revise` on a `reviewer` `pass` is the normal, expected
+   case — it is the whole reason the skeptic exists, so do not treat
+   the disagreement as an error to be arbitrated.
+
+3a. **Wave 0 verdict handling** (before the table above applies).
+   When the `premise-auditor` returns, record `premise_verdict` and
+   act on it:
+
+   - `confirmed` → dispatch `reviewer` per Step 4c, then proceed
+     normally.
+   - `rescoped` → dispatch `reviewer` per Step 4c. On pass, advance to
+     Wave 1 and pass the auditor's **Corrected premise** as the
+     authoritative task, with the original bullet included only as
+     context marked *superseded*. Note the rescope in `retro_notes`
+     and surface it to the operator — the bullet in
+     `IMPLEMENTATION_PLAN.md` will need correcting at Step 7.
+   - `refuted` → **stop the item.** Set `agent_status: dropped`,
+     `drop_reason: "premise-refuted: <auditor's one-line basis>"`.
+     Append the refutation to `retro_notes`. This is a **success**, not
+     a failure — report it that way to the operator, and note that
+     Step 7 must close the bullet in `IMPLEMENTATION_PLAN.md` as
+     `closed-claim-invalid` rather than leaving it to be re-picked by
+     the next batch.
+
+   Wave 0 gets the same one-revision allowance as any other wave: a
+   `reviewer` `revise` on a thin or unsourced audit re-dispatches the
+   `premise-auditor` once.
 
 4. **Persist state**: after processing all changes in this turn,
    write the updated state file. Use atomic-write semantics: write
@@ -271,7 +369,7 @@ the operator or processing notifications:
    - If you only processed an operator message and no new dispatches
      were made, end the turn after responding.
 
-### Step 4c — reviewer dispatch
+### Step 4c — review dispatch
 
 When a role-agent returns and you're advancing to review:
 
@@ -291,16 +389,55 @@ and return a structured verdict per your system prompt.
 Plan bullet:
 {{bullet_text}}
 
+Premise verdict: {{premise_verdict}}
+{{the auditor's Corrected premise, if rescoped}}
+
 {{prior wave outputs, if any — e.g. for fixture-builder review,
 include the scenario proposal verbatim}}
 
 Worktree path: {{worktree_path or "n/a (main_tree)"}}
+Main venv path (for `UV_PROJECT_ENVIRONMENT`): {{main_venv_path}}
 
 --- agent output ---
 {{role-agent's full return value}}
 ```
 
-After dispatching, set `agent_status: in_review` in the state file.
+**On Waves 1 and 4 only**, dispatch a `skeptic` in the *same message*,
+with `run_in_background: true` and
+`name: skeptic-<wave>-<P-CODE>-r<revision-count>`. It runs in parallel
+with the reviewer, not after it. Prompt template:
+
+```
+Attack the output of the `<wave>` agent for item **<P-CODE>** in
+batch `<batch-id>`. Run every applicable attack from your system
+prompt and return a structured verdict. Your default is "unproven" —
+a claim you could not test is `revise`, not `pass`.
+
+--- what is being claimed ---
+{{role-agent's full return value}}
+
+--- premise (authoritative over the plan bullet) ---
+Verdict: {{premise_verdict}}
+{{the auditor's Corrected premise and Verbatim regulatory text}}
+{{the auditor's Defect-pinning tests and Hazards sections}}
+
+--- prior context ---
+{{the scenario proposal verbatim; for Wave 4, also the test-writer
+report and the exact targeted pytest path}}
+
+Worktree path: {{worktree_path or "n/a (main_tree)"}}
+Main venv path (for `UV_PROJECT_ENVIRONMENT`): {{main_venv_path}}
+
+--- specific attacks the orchestrator wants run ---
+{{name any that apply to this item: RWA direction, crossing amount,
+column-footprint change, defect-pinning survivors, RUNS registration,
+golden/baseline regen}}
+```
+
+After dispatching, set `agent_status: in_review` and reset
+`review_verdicts` to `{"conformance": null, "skeptic": null}` (leave
+`skeptic` as `"n/a"` on waves 0, 2 and 3 so the "all returned" test
+is unambiguous).
 
 ### Step 4d — per-wave reviewer criteria (operator-visible)
 
@@ -308,6 +445,37 @@ These checklists are pasted verbatim into the reviewer's prompt at
 Step 4c. They are deliberately written here, not derived implicitly
 from each role-agent's system prompt, so the operator can audit and
 tune them in this single file.
+
+#### Wave 0 — premise-auditor verdict
+
+```
+C0.1 — First line is exactly `PREMISE: confirmed|refuted|rescoped`,
+       alone on its own line.
+C0.2 — All four questions answered explicitly (rule says what the
+       bullet claims / code diverges / direction / scope), each with
+       a one-line justification.
+C0.3 — The "Verbatim regulatory text" section contains actual quoted
+       article text with a named source (skill name, or PDF filename
+       + page index) — OR an explicit statement that source text
+       could not be obtained. A confident paraphrase with no source
+       is a `revise`: that is precisely the failure mode this wave
+       exists to prevent.
+C0.4 — Question 3 (direction) states the sign. If the answer is
+       RWA-reducing, it is flagged as such in capitals.
+C0.5 — For `refuted` / `rescoped`: the "Corrected premise" section is
+       present and concrete enough for scenario-architect to design
+       from without re-reading the bullet.
+C0.6 — The defect-pinning-test search was performed and its result
+       reported (paths + function names, or an explicit "none
+       found"). Any test whose assertion is RELATIVE to a baseline is
+       called out.
+C0.7 — Use Read on the cited source file to confirm the divergence
+       claim in question 2 points at code that exists and says what
+       the auditor says it says.
+C0.8 — The verdict follows from the four answers. A `confirmed` with
+       any question answered against the bullet is incoherent —
+       `revise`.
+```
 
 #### Wave 1 — scenario-architect proposal
 
@@ -324,8 +492,10 @@ C1.3 — Hand-calc shows every regulatory term on its own line. Each
        scalar (risk weight, CCF, LGD floor, supervisory haircut,
        slotting band, supporting factor, output floor percentage) is
        attributed either to the relevant Skill (`basel31` / `crr`)
-       OR to a specific rulepack pack entry (`rulebook/packs/*.py`) or
-       `data/tables/` shim.
+       OR to a specific rulepack pack entry (`rulebook/packs/*.py`)
+       or pack-binding shim (`engine/sa/{crr,b31}_risk_weight_tables.py`,
+       `engine/crm/haircut_tables.py`). `data/tables/` no longer
+       exists — a citation to it is stale.
 C1.4 — Expected outputs include exact RWA, EAD, risk weight, and K
        (or the subset the test will assert on, with the unused
        fields explicitly listed as out-of-scope under C1.5).
@@ -336,6 +506,18 @@ C1.6 — Citations point to real files / articles. Use Read on at
        confirm it exists; use the relevant Skill (`basel31` /
        `crr`) to confirm at least one cited article actually
        contains the rule.
+C1.7 — "Presence expectations" section is present and names what must
+       be EMITTED and NON-NULL (template/sheet or bundle key, the
+       cells that must carry a value where there is exposure, and any
+       breakdown that must sum to a named parent total). "The values
+       are in section 4" is not a substitute — absence is the
+       dominant escape class.
+C1.8 — "Direction and blast radius" section states whether the change
+       raises or lowers RWA. An RWA-reducing proposal says so in
+       capitals and names the output-floor evidence it will need.
+C1.9 — Consistency with Wave 0: if `premise_verdict` was `rescoped`,
+       the proposal designs the auditor's Corrected premise, not the
+       original bullet. Designing the superseded bullet is a `revise`.
 ```
 
 #### Wave 2 — fixture-builder report
@@ -355,6 +537,21 @@ C2.4 — The number of rows added per parquet matches the proposal's
 C2.5 — If the proposal said "no new fixtures", the report explicitly
        says "skipped" and explains why (typically: existing fixtures
        cover the scenario shape).
+C2.6 — Every NEW builder module is registered in
+       `tests/fixtures/generate_all.py`. Grep the file to confirm.
+       The parquets are git-ignored build artifacts, so an
+       unregistered builder passes locally and fails on a fresh
+       checkout and in CI.
+C2.7 — If the fixture reaches a reporting column or template no
+       existing portfolio exercises, it is registered in `RUNS` in
+       `tests/acceptance/reporting/test_supervisory_validations.py`
+       — or the report explains why it is not needed. The gate FAILS
+       OPEN: an unreached column makes every rule over it
+       NOT_EVALUATED, which is indistinguishable from passing.
+C2.8 — For a substitution / basis scenario, the report states the
+       CROSSING AMOUNT and it is non-zero. A 0%-RW guarantor makes
+       both bases agree, so the scenario could not distinguish a
+       correct basis from an incomplete one.
 ```
 
 #### Wave 3 — test-writer report
@@ -373,6 +570,27 @@ C3.5 — Asserted bundle fields cover the proposal's expected outputs
        (e.g. if proposal expects RWA=12345 and EAD=10000, the test
        asserts on `rwa` and `ead` columns of the aggregated bundle).
 C3.6 — No edits outside `tests/{unit,acceptance,contracts,integration}/`.
+C3.7 — NEGATIVE SPACE. The test asserts the proposal's C1.7 presence
+       expectations, not only its values: the sheet / template /
+       bundle key is emitted, in-scope cells are non-null where the
+       portfolio has exposure, and any new breakdown sums to its
+       named parent total. Read the test to confirm — a report that
+       claims this without the assertions present is a `revise`.
+C3.8 — THE TEST CAN FAIL. Read the assertions and check:
+       (a) no assertion is RELATIVE to a baseline
+           (`rwa_override > rwa_default`) where an absolute expected
+           value was available;
+       (b) class/row expectations are anchored to a source of truth
+           that cannot drift with the code — the enum
+           (`{m.value for m in ExposureClass}`), the sealed carrier,
+           `validations/scope.py::SHEET_INDEX_MAPS` — not a
+           hand-written list copied from the implementation.
+       A test written from the same sentence as the code validates
+       nothing.
+C3.9 — The defect-pinning grep was run (`uniform`, `all classes`,
+       `flat`, `backward compat`, `ignored for`, `has no effect on`)
+       and its result reported. If Wave 0 named such tests, the
+       report accounts for each one.
 ```
 
 #### Wave 4 — engine-implementer report
@@ -410,25 +628,49 @@ C4.6 — Reporting-slice criteria (any item touching `src/rwa_calc/reporting/`
            matrix) and proves the deleted site dead.
 C4.4 — Targeted pytest path matches what the test-writer reported
        in Wave 3.
-C4.5 — The targeted pytest result is PASS. The report quotes the
-       pytest summary line ("X passed in Ys") or equivalent.
+C4.5 — The targeted pytest result is PASS — and YOU RAN IT. Do not
+       accept the report's quoted summary line as evidence; execute
+       `uv run pytest <path> --benchmark-skip` yourself (prefixed
+       with `UV_PROJECT_ENVIRONMENT=<main venv path>` for a worktree
+       item) and compare. If your run disagrees with the report,
+       your run wins.
+C4.7 — RWA DIRECTION. The report states whether the change raises or
+       lowers RWA and agrees with the proposal's C1.8. An
+       RWA-reducing change without output-floor evidence is a
+       `revise`, not a `pass` — remember every `engine/sa/` transform
+       runs unconditionally to feed the Basel 3.1 output floor, so
+       "only SA reads this column" does not make a change IRB-safe.
+C4.8 — If the change altered the structure of a conditional
+       expression (deleted a short-circuit, widened a gate), the
+       report shows the FULL `tests/unit` run, not just the touched
+       subdirectory. Such a change alters the expression's column
+       footprint and has broken tests in unrelated files.
+C4.9 — No golden or validation-baseline regeneration was used to
+       reach green (see C4.6(a)). `REGEN_VALIDATION_BASELINE=1`
+       without a per-entry written reason is a `drop`.
 ```
 
 ### Step 4e — re-dispatch on revision
 
-When a reviewer returns `VERDICT: revise` and the wave's revision
-count is 0:
+When the worst verdict is `revise` and the wave's revision count is 0:
 
 Spawn a fresh role-agent of the original wave's type, with
 `run_in_background: true` and `name: <wave>-<P-CODE>-r1`. Prompt:
 
 ```
-Your prior output for **<P-CODE>** failed review. Address the
-following feedback and resubmit. Do not re-design unless the
-feedback explicitly asks you to.
+Your prior output for **<P-CODE>** failed review. Address ALL of the
+following feedback and resubmit. Do not re-design unless the feedback
+explicitly asks you to.
 
---- reviewer feedback ---
-{{reviewer's "Feedback" section verbatim}}
+--- conformance feedback (reviewer) ---
+{{reviewer's "Feedback" section verbatim, or "passed"}}
+
+--- adversarial findings (skeptic) ---
+{{skeptic's "Findings" section verbatim, or "n/a for this wave"}}
+
+The skeptic's findings are about whether the work is CORRECT, not
+whether it is well-formed. Where the two reviewers disagree, satisfy
+both — a conformance pass does not excuse a broken attack.
 
 --- your prior output ---
 {{role-agent's prior return value}}
@@ -517,38 +759,184 @@ arch_check spots a violation introduced by the merge resolution).
 
 ## Step 6 — single global validation gate
 
-Run once, on the merged tree, in this order:
+Run once, on the merged tree, in **tier order**. Do not reorder, and
+do not stop before Tier 2 — Tier 2 is the tier that catches the
+defects this project actually ships.
+
+If any item added a `@cites` decorator, regenerate the citation
+snapshot **before** running anything:
+`uv run python scripts/generate_citation_matrix.py`.
+
+**Tier 0 — static (fast, fails early)**
 
 ```
 uv run python scripts/arch_check.py
-uv run ruff check src/ && uv run ruff format --check src/
-uv run ty src/
-uv run pytest tests/contracts/ --benchmark-skip -q
-uv run pytest <union of all merged items' new test paths> -x --benchmark-skip
+uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/
+uv run ty check src/rwa_calc/
 ```
+
+**Tier 1 — contracts and the batch's own tests**
+
+```
+uv run pytest tests/contracts/ --benchmark-skip -q
+uv run pytest <union of all merged items' new test paths> --benchmark-skip
+```
+
+Note: no `-x` on the union run. You want the full failure list for
+attribution, not the first one.
+
+**Tier 2 — the oracle tier (MANDATORY — never skip, never defer)**
+
+```
+uv run pytest tests/oracle/ --benchmark-skip -q
+uv run pytest tests/acceptance/reporting/ --benchmark-skip -q
+```
+
+`tests/acceptance/reporting/` contains the supervisory validation
+ratchet (741 published EBA/BoE rules, ratcheted **both** ways) and the
+reporting goldens. This is the only part of the estate that has
+reliably caught the reporting defects that reach production: on one
+CRM substitution block a fully green 10,552-test suite found **none**
+of ten real defects, while wiring the portfolio into the register
+found three in the first hour.
+
+It is expensive — the validation test alone is eighteen full pipeline
+runs — and it is expensive **once per batch**, against a batch that
+took hours. That trade is not close. If you are tempted to skip it
+because the batch "didn't touch reporting", don't: the ledger is
+sealed on aggregator exit, so an engine change reaches it.
+
+**Tier 3 — full suite**
+
+Run as **two foreground chunks** — background Bash tasks are hard-killed
+at ~600s:
+
+```
+uv run pytest tests/unit -q
+uv run pytest tests/acceptance tests/integration tests/contracts tests/oracle -q
+```
+
+Tier 3 is mandatory when any item changed the structure of a
+conditional expression (a deleted short-circuit changes an
+expression's *column footprint* and breaks tests in unrelated files),
+added or narrowed an eligibility gate, or altered a shared carrier.
+When in doubt, run it: `loop.sh` pushes to a feature branch where CI
+does **not** fire, so if you skip Tier 3 nothing runs the full suite
+until the PR — dozens of items later, when attribution is hopeless.
+
+If an xdist worker reports "node down", re-run before treating the
+suite as red — that failure mode is transient.
 
 The "merged items" set excludes anything dropped in Steps 4 or 5.
 
 If anything fails, surface:
-- the gate command that failed,
+- the gate command and tier that failed,
 - the failing test names or arch_check messages,
 - a best-effort attribution to the merged item (match failing file
-  paths to the engine sub-package each item targeted in Step 1).
+  paths to the engine sub-package each item targeted in Step 1),
+- for a Tier 2 failure, whether the break is **new** or a **baseline
+  entry that has been fixed**. The register ratchets both ways, so
+  `test_no_baseline_break_has_been_fixed_without_being_removed`
+  failing is the design working — the entry is removed deliberately,
+  with its written reason. **Never** regenerate goldens or the
+  validation baseline to reach green; that banks a live defect as
+  expected behaviour.
 
 **Do not tick the plan if the gate is red.** The squash commits are
 already on the feature branch — the operator decides whether to
 revert specific commits, fix forward, or push as-is for review.
+Record every gate failure in the failing item's `retro_notes` before
+you move on: Step 7.5 needs them.
 
 ## Step 7 — tick the plan
 
 For each item that successfully merged **and** survived the global
 gate, edit `IMPLEMENTATION_PLAN.md` at the top level: toggle from
-`[ ]` to `[x] FIXED v<x.y.z>` with a one-line summary. One Edit per
-item, then a single commit:
+`[ ]` to `[x] FIXED v<x.y.z>` with a one-line summary.
+
+**Also resolve the Wave 0 outcomes** — otherwise a refuted bullet sits
+in the queue and the next batch pays to refute it again:
+
+- `premise_verdict: refuted` → close the bullet as
+  `[x] closed-claim-invalid: <auditor's one-line basis>` and move it
+  to `## Completed`. Do **not** leave it unchecked.
+- `premise_verdict: rescoped` → rewrite the bullet's summary and
+  `Ref:` to the auditor's corrected premise, whether or not the item
+  went on to merge. The next reader must not inherit the wrong claim.
+
+One Edit per item, then a single commit:
 
 ```
 chore(plan): tick N code items [batch <batch-id>]
 ```
+
+## Step 7.5 — retro (turn this batch's failures into gates)
+
+**Run this before Step 8 destroys the evidence.** This is the step
+that makes the harness learn; skipping it means the next batch repeats
+this batch's mistakes at full price.
+
+You run this yourself — not via a sub-agent. You are the only party
+with the whole batch in view, and `.claude/LESSONS.md` is a shared
+file that concurrent agents would race on.
+
+1. **Gather.** From the state file, collect every: `revision_count`
+   above 0, `drop_reason`, `premise_verdict` of `refuted`/`rescoped`,
+   skeptic `Findings`, entry in `retro_notes`, and Step 6 gate
+   failure.
+
+2. **Separate one-offs from patterns.** For each, ask: *would this
+   recur on an unrelated item?* A typo is a one-off. "The agent
+   asserted against a hand-written list" is a pattern. Discard the
+   one-offs — this is not a diary.
+
+3. **Graduate, don't narrate.** For every pattern, take the **first**
+   option that is achievable in this pass:
+
+   | Preference | Form | Where |
+   |---|---|---|
+   | 1 (best) | executable check | a numbered check in `scripts/arch_check.py` + a `tests/contracts/` test |
+   | 2 | ratchet | a metric in `scripts/arch_metrics.json` |
+   | 3 | fixture coverage | a portfolio registered in `RUNS` |
+   | 4 | reviewer criterion | a `C<n>.<m>` in Step 4d, or an attack in `.claude/agents/skeptic.md` |
+   | 5 (last) | prose | an entry in `.claude/LESSONS.md` |
+
+   Prose is the **fallback**, not the default. `arch_check.py` already
+   carries 17 numbered checks and the validation register carries
+   hundreds of entries — every one of them is a lesson that graduated.
+   That is what "learning" looks like here; a paragraph nobody rereads
+   is not.
+
+   If the right check is too large for this pass, file it as a **Tier
+   1** bullet in `IMPLEMENTATION_PLAN.md` and add the prose entry as
+   the interim. Record the bullet ID in the prose entry so the two
+   stay linked.
+
+4. **Write it.** For each graduated lesson, add a row to the
+   **Graduation ledger** at the bottom of `.claude/LESSONS.md`
+   (date | lesson | graduated to) and do **not** also add prose. For
+   each prose entry, use the file's `Trap` / `Why` / `Detect` format —
+   **an entry with no `Detect` line is not finished.**
+
+5. **Keep the working set small.** `.claude/LESSONS.md` is capped at
+   ~30 entries. If your additions push it over, graduate or delete a
+   stale entry in the same pass and say which. A lessons file nobody
+   can read in one sitting is a lessons file nobody reads.
+
+6. **Check for recurrence.** If a pattern this batch hit was *already*
+   in `.claude/LESSONS.md`, that lesson has proven it cannot survive
+   as prose. Graduate it now, or file its graduation as Tier 1. Say so
+   explicitly in the report — a repeat is the strongest signal the
+   harness gives you.
+
+Commit any harness changes separately:
+
+```
+chore(harness): retro from batch <batch-id> — <N> graduated, <M> recorded
+```
+
+Report to the operator: what recurred, what graduated and into what,
+what stayed prose and why, and any Tier 1 bullets filed.
 
 ## Step 8 — cleanup and push
 
@@ -563,11 +951,23 @@ git branch -D batch/<batch-id>/<P-code>
 Sanity check: `git worktree list` should show only the main tree;
 `git branch --list 'batch/*'` should be empty.
 
-Delete the state file:
+**Archive the state file — do not delete it:**
 
 ```
-rm .claude/state/next-items-<batch-id>.json
+mkdir -p .claude/state/archive
+mv .claude/state/next-items-<batch-id>.json .claude/state/archive/
 ```
+
+The archive is the only record of what each reviewer caught, which
+waves needed revision, and why items were dropped. `/postmortem` reads
+it to find the batch that produced a defect, and drop reasons across
+batches are the highest-signal dataset for tuning the Step 4d
+criteria. Deleting it — as this command used to — threw away exactly
+the evidence needed to stop the next escape.
+
+(`.claude/state/` is git-ignored, so the archive is local to this
+machine. That is fine for tuning; anything that must survive a fresh
+clone belongs in `.claude/LESSONS.md` or `docs/development/escape-log.md`.)
 
 Push the merge-target branch to its remote (`loop.sh` also does this
 on iteration end, but pushing here makes the batch boundary
@@ -577,21 +977,39 @@ observable).
 
 - Cap N at 5 even if the user asks for more.
 - Never tick the plan if the global gate is red.
+- **Tier 2 of the gate is not optional.** No batch merges on Tier 0+1
+  alone. If you are short of time, drop an item — never a tier.
+- **Never skip Step 7.5.** A batch that merges without a retro has
+  spent the money and thrown away the lesson. If nothing generalisable
+  happened, say so explicitly in the report — that is a valid outcome,
+  silence is not.
 - Do not run the global gate inside any role-agent or reviewer — it
-  runs once at Step 6 on the merged tree.
+  runs once at Step 6 on the merged tree. The `reviewer` and `skeptic`
+  may run the item's **targeted** test to verify a claim; that is not
+  the gate.
 - The call graph is exactly one level deep: this orchestrator → one
-  of `scenario-architect` / `fixture-builder` / `test-writer` /
-  `engine-implementer` / `reviewer`. The orchestrator drives every
-  wave and every reviewer dispatch directly; sub-agents do not spawn
-  other sub-agents.
-- Hard cap of one revision per wave per item. Two reviewer-`revise`
-  verdicts on the same wave drops the item. Reviewer-`drop` drops
-  immediately, no revision.
+  of `premise-auditor` / `scenario-architect` / `fixture-builder` /
+  `test-writer` / `engine-implementer` / `reviewer` / `skeptic`. The
+  orchestrator drives every wave and every review dispatch directly;
+  sub-agents do not spawn other sub-agents.
+- **The orchestrator owns PDF extraction.** Role-agents cannot read
+  `docs/assets/*.pdf`. Extract with pymupdf and paste verbatim text
+  into the prompt — mandatory for any RWA-reducing item. Never ask an
+  agent to "confirm the citation": it cannot, and its confident quote
+  may be reconstructed from memory.
+- Hard cap of one revision per wave per item. Two `revise` verdicts on
+  the same wave drops the item. A `drop` verdict drops immediately, no
+  revision. On two-reviewer waves the worst verdict decides.
 - All role-agent and reviewer dispatches use `run_in_background:
   true` with a stable, unique `name` of the form
   `<role>-<P-CODE>-r<revision-count>` (or
-  `reviewer-<wave>-<P-CODE>-r<revision-count>`). Foreground dispatch
+  `reviewer-<wave>-<P-CODE>-r<revision-count>` /
+  `skeptic-<wave>-<P-CODE>-r<revision-count>`). Foreground dispatch
   defeats the conversational supervision the state file enables.
+- The orchestrator owns `.claude/LESSONS.md`, `docs/appendix/changelog.md`,
+  the citation matrix, and `scripts/arch_metrics.json`. Agents must
+  never write them — concurrent writes to shared files have already
+  cost misattributed commits and a silently dropped import line.
 - The state file at `.claude/state/next-items-<batch-id>.json` is
   authoritative. Read it at the start of every turn before reacting
   to anything else. Persist via atomic write (`<file>.tmp` then
@@ -604,3 +1022,11 @@ observable).
   (Step 3 and Step 5's merge are both skipped). Step 4's per-wave
   dispatch and reviewer loop are unchanged except the worktree
   preamble is omitted for waves 2/3/4.
+- Every agent is told to read `.claude/LESSONS.md` first. Do not
+  paste its contents into prompts — point at it, so there is one copy
+  and the retro's edits take effect on the next dispatch.
+- A batch where every reviewer passed everything and the retro found
+  nothing is a warning sign, not a triumph. Measured baseline: 6 of 10
+  then 10 of 10 plan bullets had a materially wrong premise. If Wave 0
+  confirms every bullet in a batch, say so to the operator and treat
+  the audit itself as suspect.

--- a/.claude/commands/postmortem.md
+++ b/.claude/commands/postmortem.md
@@ -1,0 +1,178 @@
+---
+description: Turn a production defect into a harness change. Establishes what was wrong, reconstructs how it escaped every gate, then fixes the gate that should have caught it — not just the code. Writes an escape record to docs/development/escape-log.md.
+argument-hint: <commit-sha | PR# | short description of the defect>
+---
+
+You are running a postmortem on a defect that **reached production**:
+**$ARGUMENTS**
+
+The code fix is not the deliverable. The deliverable is the answer to one
+question:
+
+> **Which gate should have caught this, and why didn't it?**
+
+A postmortem that ends in a fix commit and a shrug has taught the system
+nothing. This project has 92 `fix(...)` commits in its last 400; the ones
+that mattered changed a gate.
+
+Read `.claude/LESSONS.md` first — this defect may already be a known trap
+that was never graduated into a check, which is itself the finding.
+
+## Step 1 — establish the defect
+
+Do not take the report at face value; it may be a misreading of correct
+output. Establish, with evidence:
+
+- **What was produced**, and **what should have been produced**.
+- **The controlling rule**, quoted verbatim. Extract from the PDFs yourself
+  (`uv run python -c "import fitz; ..."` — see `.claude/LESSONS.md` A2) or
+  via the `basel31` / `crr` Skill. Do not rely on recall.
+- **The sign and magnitude**: does the defect over- or under-state capital,
+  and by how much on a real portfolio? An understatement is a filing risk of
+  a different order from an overstatement.
+- **The blast radius**: which templates, regimes, and exposure classes.
+
+If the reported defect turns out **not** to be a defect — a limit of a
+published rule, a DPM evaluation artifact, an arithmetic coincidence — stop
+here and record it in the escape log as `not-a-defect` with the reasoning.
+That is a valuable outcome and it prevents the next person re-litigating it.
+
+## Step 2 — reconstruct the escape path
+
+Walk the defect backwards through the harness and name the **first** stage
+that could have stopped it:
+
+| Stage | The question |
+|---|---|
+| Plan bullet | Did a wrong bullet specify this? (see `IMPLEMENTATION_PLAN.md` history) |
+| Wave 0 premise audit | Was the item audited? Did the audit miss it, or predate the wave? |
+| scenario-architect | Was the hand-calc wrong, or right but not carried through? |
+| fixture-builder | Did the fixture never reach this code path? |
+| test-writer | Was the assertion absent, relative, or sharing the code's assumption? |
+| engine-implementer | Was the implementation wrong against a correct spec? |
+| reviewer / skeptic | Was it reviewed? Which attack should have found it? |
+| Batch gate | Was the catching test in the gate at all, at the time? |
+| CI | Did CI run the suite that covers it before merge? |
+
+Use `git log` / `git blame` on the fixed lines to find the originating
+commit and, from the commit message's `[batch <id>]` footer, the batch that
+produced it. Archived batch state under `.claude/state/archive/` records the
+verdicts that batch's reviewers gave.
+
+## Step 3 — classify the escape
+
+Pick exactly one. The category determines the fix.
+
+1. **`gate-not-run`** — a gate that would have caught it existed, but did not
+   run at that point (wrong tier, feature branch CI never fired, test outside
+   the batch gate's set).
+   → *Fix: move the gate earlier.*
+
+2. **`path-never-exercised`** — the gate existed and ran, but no fixture
+   drove data through the affected code, so every relevant rule was
+   `NOT_EVALUATED`. The supervisory gate **fails open**, so this is
+   indistinguishable from clean.
+   → *Fix: build the portfolio, and register it in `RUNS`.*
+
+3. **`test-shared-the-assumption`** — a test covered the code and passed,
+   because it was written from the same wrong sentence (invented enum
+   strings, hand-written lists, assertions relative to a baseline).
+   → *Fix: re-anchor the assertion to a source of truth that cannot drift
+   with the code.*
+
+4. **`no-assertion-of-presence`** — the output was absent or null rather than
+   wrong, and nothing asserted it should exist.
+   → *Fix: add presence assertions; consider a systemic non-null check.*
+
+5. **`wrong-premise`** — the plan bullet or spec was wrong and the harness
+   faithfully implemented it.
+   → *Fix: strengthen Wave 0 for this bullet class; correct the audit entry.*
+
+6. **`no-gate-exists`** — nothing in the estate could have caught it.
+   → *Fix: create the gate.*
+
+7. **`ungateable`** — genuinely not mechanically detectable (requires
+   judgement on ambiguous regulatory text).
+   → *Fix: a `.claude/LESSONS.md` entry, with the reasoning for why it cannot
+   be a check. Use this category sparingly and argue for it.*
+
+## Step 4 — fix the gate
+
+This is the step people skip. Do it before or alongside the code fix.
+
+Implement the gate change in the same change-set where practical:
+
+- **New/extended fixture portfolio** → `tests/fixtures/`, registered in
+  `tests/fixtures/generate_all.py` **and** in `RUNS` in
+  `tests/acceptance/reporting/test_supervisory_validations.py`.
+- **New architectural invariant** → a numbered check in `scripts/arch_check.py`
+  plus its allowlist entry, and a test in `tests/contracts/`.
+- **New ratchet** → extend the relevant metric in `scripts/arch_metrics.json`.
+- **Re-anchored assertion** → rewrite against the enum / sealed carrier /
+  `validations/scope.py::SHEET_INDEX_MAPS`.
+- **Reviewer criterion** → add it to the wave checklist in
+  `.claude/commands/next-items.md` Step 4d, or an attack in
+  `.claude/agents/skeptic.md`. A criterion is the weakest form of gate — use
+  it only when the check cannot be executable.
+
+If the gate change is too large for this pass, file it as a **Tier 1** bullet
+in `IMPLEMENTATION_PLAN.md` with `Ref:` pointing at this escape-log entry. Do
+not close the postmortem with the gate unfixed and unfiled.
+
+**Verify the gate actually catches it**: revert the code fix in a detached
+worktree (`git worktree add --detach HEAD`), run the new gate, and confirm it
+goes red. A gate you have not seen fail is not a gate.
+
+## Step 5 — write the escape record
+
+Append to `docs/development/escape-log.md` (create it if absent, with a short
+header explaining the file's purpose). One entry:
+
+```markdown
+## <YYYY-MM-DD> — <one-line defect summary>
+
+- **Defect**: <what was produced vs what should have been; sign and magnitude>
+- **Rule**: <article, quoted phrase, source>
+- **Origin**: <commit / batch id / "pre-harness">
+- **Escape class**: `<one of the seven categories>`
+- **Why every gate missed it**: <the specific mechanism — one paragraph>
+- **Gate change**: <what now catches it, with the file path> | <or: plan bullet ID>
+- **Verified red**: <how you confirmed the new gate fails without the fix>
+- **Lesson**: <graduated to a check | added to LESSONS.md as <section> | none needed>
+```
+
+## Step 6 — update the lessons working set
+
+- If the escape was **already** a known trap in `.claude/LESSONS.md` and
+  reached production anyway, that lesson has proven it cannot survive as
+  prose. Graduate it to a check in this pass, or file the graduation as a
+  Tier 1 bullet. Note the recurrence in the escape-log entry.
+- If it is new and you graduated it: add a row to the **Graduation ledger**
+  at the bottom of `.claude/LESSONS.md`. Do not also add prose.
+- If it is new and `ungateable`: add the prose entry, with its detection
+  recipe. An entry without a **Detect** line is not finished.
+
+Keep `.claude/LESSONS.md` under ~30 entries. If adding yours pushes it over,
+graduate or delete a stale one in the same pass and say which.
+
+## Step 7 — report
+
+Report to the operator, in this order:
+
+1. The defect, its sign, and its magnitude.
+2. The escape class and the one-sentence reason every gate missed it.
+3. The gate change, and the evidence it goes red without the fix.
+4. Whether the code fix is included here or deferred.
+5. Anything you found while digging that is a **separate** defect — file
+   each as a plan bullet; do not fix it in this pass.
+
+## Constraints
+
+- **The gate change is mandatory; the code fix is optional.** If you can only
+  do one in this pass, do the gate and file the code fix.
+- Never regenerate goldens or the validation baseline to make a gate green.
+  A ratchet failing because you fixed something is the design working —
+  remove the register entry deliberately, with its written reason.
+- Do not commit unless the operator asks. Report what you changed.
+- One defect per invocation. Separate defects found along the way get filed,
+  not fixed.

--- a/.claude/commands/refresh-plan.md
+++ b/.claude/commands/refresh-plan.md
@@ -35,7 +35,9 @@ Invoke the `plan-curator` agent. Prompt:
 > 2. **Scan for new findings** — TODO / FIXME / HACK markers,
 >    `pytest.mark.skip`, conditional fixture guards,
 >    acceptance-test gaps, regulatory scalar drift between
->    `src/rwa_calc/data/tables/` and the PDFs.
+>    `src/rwa_calc/rulebook/packs/{common,crr,b31}.py` (and the
+>    pack-binding shims in `engine/`) and the PDFs. The
+>    `data/tables/` package no longer exists.
 > 3. **Add new items** in tier order with the standard bullet
 >    format. Use the next free P-code integer in sequence.
 >

--- a/.claude/commands/sonar-clean.md
+++ b/.claude/commands/sonar-clean.md
@@ -213,7 +213,9 @@ Targeted test path: `<derived test path>`
   - For `src/rwa_calc/engine/<sub>/<mod>.py` try `tests/unit/test_<mod>.py`
     first; if missing, fall back to `tests/unit/test_<sub>_<mod>.py`,
     then to `tests/unit/<sub>/` (directory).
-  - For `src/rwa_calc/data/tables/<mod>.py` try `tests/unit/test_<mod>.py`.
+  - For `src/rwa_calc/rulebook/packs/<mod>.py` try
+    `tests/unit/rulebook/test_<mod>.py`, then `tests/unit/rulebook/`.
+    (The `data/tables/` package no longer exists.)
   - For `src/rwa_calc/ui/marimo/*.py` there is often no unit test. If
     you cannot find a targeted test, report `targeted_test: none — orchestrator will run global suite` and skip that step. Do NOT invent one.
 

--- a/.claude/state/.gitkeep
+++ b/.claude/state/.gitkeep
@@ -1,5 +1,16 @@
 Batch state files for /next-items live here. Format:
   next-items-<batch-id>.json
 The orchestrator reads this directory at every turn during a live
-batch to recover its supervisor state. Files are deleted at end
-of Step 8.
+batch to recover its supervisor state.
+
+At the end of Step 8 a completed batch file is MOVED to
+`archive/`, not deleted. The archive is the record of what each
+reviewer caught, which waves needed revision, and why items were
+dropped — /postmortem reads it to trace a production defect back to
+the batch that produced it, and drop reasons across batches are the
+input to tuning the Step 4d reviewer criteria.
+
+This directory is git-ignored, so the archive is local to one
+machine. Anything that must survive a fresh clone belongs in
+`.claude/LESSONS.md` (traps agents must know) or
+`docs/development/escape-log.md` (defects that reached production).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,11 +173,13 @@ Reference stage skeleton and format details — see `docs/specifications/observa
 
 Project subagents in `.claude/agents/` (role-based, not domain-based — regulatory knowledge stays in the `basel31` and `crr` skills):
 
-- **`scenario-architect`** — read-only. Designs one CRR-* / B31-* / P-coded item end-to-end (inputs, hand-calc, citations).
+- **`premise-auditor`** — read-only, Wave 0. Tries to **refute** a plan bullet before any design work starts: does the rule say what the bullet claims, does the code actually diverge, what is the RWA direction, is the scope right. Returns `PREMISE: confirmed | rescoped | refuted`. A refutation is a success.
+- **`scenario-architect`** — read-only. Designs one CRR-* / B31-* / P-coded item end-to-end (inputs, hand-calc, citations). The premise audit is authoritative over the bullet.
 - **`fixture-builder`** — owns `tests/fixtures/`. Implements parquet rows and builders from a scenario proposal.
 - **`test-writer`** — owns `tests/{unit,acceptance,contracts,integration}/`. Writes the failing test that drives the next implementation step.
 - **`engine-implementer`** — owns `src/rwa_calc/`. Makes the failing test pass with the minimum diff and a green validation gate (arch_check, ruff, ty, contracts).
-- **`reviewer`** — read-only quality gate dispatched between every wave of `/next-items`. Critiques a role-agent's output against operator-supplied wave criteria and returns `VERDICT: pass | revise | drop`. Owns nothing on disk.
+- **`reviewer`** — **conformance** gate dispatched after every wave of `/next-items`. Critiques a role-agent's output against operator-supplied wave criteria and returns `VERDICT: pass | revise | drop`. Owns nothing on disk; has `Bash(uv run pytest:*)` solely so it can verify a claimed test outcome rather than trusting a quoted summary line.
+- **`skeptic`** — **adversarial** reviewer running in parallel with `reviewer` on the design and implementation waves. Re-derives the number, re-runs the test, and attacks the test's ability to fail. Same verdict grammar; the worst verdict of the two decides the item. Its default is "unproven" — an untested claim is `revise`, not `pass`.
 - **`plan-curator`** — owns the two work-queue files at the repo root: `IMPLEMENTATION_PLAN.md` and `DOCS_IMPLEMENTATION_PLAN.md`. Audits code/specs/PDFs against each other and writes prioritised bullet items.
 - **`doc-writer`** — owns `docs/`. Writes or updates one canonical docs page per `DOCS_IMPLEMENTATION_PLAN.md` item; runs `uv run zensical build` before returning.
 
@@ -191,9 +193,39 @@ Orchestration lives in slash commands, not in agents. Each `loop.sh` mode maps t
 | `loop.sh docs_build` | `PROMPT_docs_build.md` | `/next-docs 3` | `/next-doc` |
 | `loop.sh docs_plan` | `PROMPT_docs_plan.md` | `/refresh-docs-plan` | — |
 
-The batch commands pick N non-conflicting items and run the validation gate (or `uv run zensical build`) **once at the end** — not per agent. `/next-items` provisions one git worktree per item on `batch/<batch-id>/<P-code>` and drives the four-wave pipeline as an event-driven supervisor: agents are dispatched in the background (`run_in_background: true`), a `reviewer` agent gates every wave (`pass | revise | drop`), one revision retry per wave per item is allowed, and the orchestrator persists batch state to `.claude/state/next-items-<batch-id>.json` so it can survive context compactions and operator interjections across multiple turns. The operator can chat with the orchestrator mid-batch — ask for status, drop an item, inspect outputs — without interrupting in-flight agents. After all items reach `merge_ready` or `dropped`, the orchestrator squash-merges the surviving worktree branches into the current feature branch before the gate runs. `/next-docs` keeps the flat parallel `doc-writer` dispatch (no worktree, no reviewer — docs writes don't collide). Items that touch shared engine/reporting-projection files (`engine/pipeline.py`, `engine/registry.py`, `engine/orchestrator.py`, `contracts/protocols.py`, `contracts/bundles.py`, `contracts/edges.py`, any module under `engine/aggregator/`, `analysis/reconciliation.py`, `reporting/cellspec.py`, `reporting/metadata.py`) are forced single-stream by `/next-items` even when N>1 was requested, and run in the main tree without worktree machinery (the reviewer loop and background dispatch still apply).
+The batch commands pick N non-conflicting items and run the validation gate (or `uv run zensical build`) **once at the end** — not per agent. `/next-items` provisions one git worktree per item on `batch/<batch-id>/<P-code>` and drives the **five-wave** pipeline (`premise-auditor` → `scenario-architect` → `fixture-builder` → `test-writer` → `engine-implementer`) as an event-driven supervisor: agents are dispatched in the background (`run_in_background: true`), a `reviewer` gates every wave (`pass | revise | drop`) with a `skeptic` alongside it on the design and implementation waves, one revision retry per wave per item is allowed, and the orchestrator persists batch state to `.claude/state/next-items-<batch-id>.json` so it can survive context compactions and operator interjections across multiple turns.
 
-Plus `/implement-scenario <ID>` for ad-hoc one-off work on a specific P-code or scenario ID.
+The end-of-batch gate runs in **tiers**, and **Tier 2 is mandatory**: `tests/oracle/` plus `tests/acceptance/reporting/` (the two-way-ratcheted supervisory validation register and the reporting goldens). Tiers 0–1 alone have repeatedly merged green over defects that Tier 2 catches. `loop.sh` pushes to a feature branch where CI does not fire, so Tier 3 (the full suite, in two foreground chunks) is the only thing that runs the whole estate before the PR. The operator can chat with the orchestrator mid-batch — ask for status, drop an item, inspect outputs — without interrupting in-flight agents. After all items reach `merge_ready` or `dropped`, the orchestrator squash-merges the surviving worktree branches into the current feature branch before the gate runs. `/next-docs` keeps the flat parallel `doc-writer` dispatch (no worktree, no reviewer — docs writes don't collide). Items that touch shared engine/reporting-projection files (`engine/pipeline.py`, `engine/registry.py`, `engine/orchestrator.py`, `contracts/protocols.py`, `contracts/bundles.py`, `contracts/edges.py`, any module under `engine/aggregator/`, `analysis/reconciliation.py`, `reporting/cellspec.py`, `reporting/metadata.py`) are forced single-stream by `/next-items` even when N>1 was requested, and run in the main tree without worktree machinery (the reviewer loop and background dispatch still apply).
+
+Plus `/implement-scenario <ID>` for ad-hoc one-off work on a specific P-code or scenario ID, and `/postmortem <commit|PR|description>` when a defect reaches production.
+
+## The learning loop
+
+Gates catch what they were built to catch. The harness only improves if every
+escape and every wasted batch turns into a new gate — so three artifacts are
+load-bearing:
+
+- **`.claude/LESSONS.md`** — the working set of traps this project has already
+  paid for, in `Trap` / `Why` / `Detect` form. **Every agent reads it before
+  starting work**, and its system prompt says so. It is capped at ~30 entries
+  and is explicitly *not* an archive: an entry earns its place only while it is
+  still prose.
+- **`/next-items` Step 7.5 (retro)** — runs before cleanup, while the batch's
+  evidence still exists. It separates one-off slips from repeatable patterns and
+  **graduates** each pattern into the strongest available form: an `arch_check`
+  check → a ratchet → fixture coverage in `RUNS` → a reviewer criterion →
+  prose, in that order of preference. Prose is the fallback, not the default.
+  Completed batch state is archived to `.claude/state/archive/`, never deleted.
+- **`/postmortem` + `docs/development/escape-log.md`** — for defects that reach
+  production. The deliverable is not the code fix but the answer to *which gate
+  should have caught this, and why didn't it* — classified into one of seven
+  escape classes, each of which prescribes its own gate change. The gate change
+  is mandatory; the code fix may be deferred.
+
+A lesson that reaches production **twice** has proven it cannot survive as
+prose — graduate it to an executable check, or file the graduation as a Tier 1
+plan item. `scripts/arch_check.py`'s 17 numbered checks and the supervisory
+validation register are what graduated lessons look like.
 
 Agents never commit or push — commits land in the slash-command orchestrator only. The call graph is uniformly one level deep (orchestrator → role-agent or reviewer); sub-agents do not spawn other sub-agents. Claude Code does not propagate the project's `.claude/agents/` registry into sub-sessions, so a nested Agent call from a sub-agent cannot dispatch project role-agents — keep all dispatch in the slash-command orchestrator. The two root plan files (`IMPLEMENTATION_PLAN.md`, `DOCS_IMPLEMENTATION_PLAN.md`) are the source of truth for outstanding work; `docs/plans/implementation-plan.md` is published narrative on the Zensical site.
 

--- a/PROMPT_build.md
+++ b/PROMPT_build.md
@@ -5,18 +5,26 @@ iteration as a parallel batch:
 
 - it picks up to 3 non-conflicting P-coded items from
   `IMPLEMENTATION_PLAN.md` (each touching a distinct engine
-  sub-package, distinct `data/tables/` file, and distinct new
+  sub-package, distinct rulepack pack file, and distinct new
   test path),
-- runs the four agent stages as four parallel waves
-  (scenario-architect → fixture-builder → test-writer →
-  engine-implementer), with N items in flight per wave,
-- runs the global validation gate
-  (`uv run python scripts/arch_check.py && uv run ruff check src/ && uv run ruff format --check src/ && uv run ty src/ && uv run pytest tests/contracts/ --benchmark-skip -q`)
-  exactly once at the end of the engine-implementer wave —
-  per-agent gate runs are forbidden because they would
-  N×-redundantly churn ruff/format on each other's edits,
-- on green: commits each item separately, then ticks the items off
-  `IMPLEMENTATION_PLAN.md` in one final
+- runs the five agent stages as five parallel waves
+  (premise-auditor → scenario-architect → fixture-builder →
+  test-writer → engine-implementer), with N items in flight per
+  wave, a `reviewer` after every wave and a `skeptic` alongside it
+  on the design and implementation waves,
+- runs the global validation gate exactly once at the end of the
+  engine-implementer wave — per-agent gate runs are forbidden
+  because they would N×-redundantly churn ruff/format on each
+  other's edits. The gate runs in tiers, and **Tier 2 is
+  mandatory**: after arch_check / ruff / ty / contracts and the
+  batch's own tests, it runs `tests/oracle/` and
+  `tests/acceptance/reporting/` (the supervisory validation ratchet
+  and the reporting goldens), then the full suite in two foreground
+  chunks. Tiers 0–1 alone have merged green over real defects,
+- on green: commits each item separately, runs the **Step 7.5
+  retro** (graduating this batch's repeatable failures into checks,
+  ratchets, fixture coverage or `.claude/LESSONS.md`), then ticks
+  the items off `IMPLEMENTATION_PLAN.md` in one final
   `chore(plan): tick N code items` commit and pushes.
 
 Items that touch shared files (`engine/pipeline.py`,
@@ -45,6 +53,14 @@ top-level session (not via a sub-agent):
    **no commits will have been made**. Do not retry blindly;
    inspect the failure attribution, fix forward in the next
    iteration, and rerun the loop manually.
+5. If `/next-items` reported any item dropped with
+   `premise-refuted`, confirm the bullet was closed in
+   `IMPLEMENTATION_PLAN.md` as `closed-claim-invalid` — otherwise
+   the next iteration pays to refute it again. A refuted premise is
+   a successful outcome, not a failed item.
+6. Confirm the retro ran and report what it graduated. A batch that
+   merged without a Step 7.5 retro has spent the money and thrown
+   away the lesson.
 
 ## Hard constraints
 
@@ -59,7 +75,12 @@ top-level session (not via a sub-agent):
   `tests/fixtures/`, test-writer owns
   `tests/{unit,acceptance,contracts,integration}/`,
   engine-implementer owns `src/rwa_calc/`, plan-curator owns the two
-  root plan files. Anything else is a top-level edit.
+  root plan files. premise-auditor, reviewer and skeptic own nothing
+  on disk. `.claude/LESSONS.md`, `docs/appendix/changelog.md`, the
+  citation matrix and `scripts/arch_metrics.json` are
+  orchestrator-only — concurrent agent writes to shared files have
+  already cost misattributed commits. Anything else is a top-level
+  edit.
 - Add extra logging if needed to debug, following the rules in
   `CLAUDE.md` § Logging — never `print()`, never f-strings in log
   calls, never `logging.basicConfig()`.

--- a/PROMPT_build_next.md
+++ b/PROMPT_build_next.md
@@ -5,14 +5,15 @@ iteration:
 
 - you need to pick the next item from P-coded items from
   `IMPLEMENTATION_PLAN.md` to implement,
-- it will then run the four agent stages as four parallel waves
-  (scenario-architect → fixture-builder → test-writer →
-  engine-implementer), with N items in flight per wave,
-- runs the global validation gate
-  (`uv run python scripts/arch_check.py && uv run ruff check src/ && uv run ruff format --check src/ && uv run ty src/ && uv run pytest tests/contracts/ --benchmark-skip -q`)
-  exactly once at the end of the engine-implementer wave —
-  per-agent gate runs are forbidden because they would
-  N×-redundantly churn ruff/format on each other's edits,
+- it will then run the five agent stages as five parallel waves
+  (premise-auditor → scenario-architect → fixture-builder →
+  test-writer → engine-implementer), with N items in flight per wave,
+- runs the global validation gate exactly once at the end of the
+  engine-implementer wave — per-agent gate runs are forbidden because
+  they would N×-redundantly churn ruff/format on each other's edits.
+  The gate runs in tiers and **Tier 2 is mandatory** (`tests/oracle/`
+  plus `tests/acceptance/reporting/` — the supervisory validation
+  ratchet and the reporting goldens),
 - on green: commits the item, then ticks the item off
   `IMPLEMENTATION_PLAN.md` in one final
   `chore(plan): tick N code item` commit and pushes.

--- a/PROMPT_ccr.md
+++ b/PROMPT_ccr.md
@@ -8,17 +8,19 @@ only**:
   Counterparty Credit Risk (CCR) Integration** (`P8.*`) in
   `IMPLEMENTATION_PLAN.md`, in plan order, skipping anything marked
   `DEFERRED v2.0` / Phase 10. It does **not** consider any other tier,
-- runs the four agent stages as four parallel waves
-  (scenario-architect → fixture-builder → test-writer →
-  engine-implementer), with N items in flight per wave and a reviewer
-  gate between every wave,
-- runs the global validation gate
-  (`uv run python scripts/arch_check.py && uv run ruff check src/ && uv run ruff format --check src/ && uv run ty src/ && uv run pytest tests/contracts/ --benchmark-skip -q`)
-  exactly once at the end of the engine-implementer wave —
-  per-agent gate runs are forbidden because they would
-  N×-redundantly churn ruff/format on each other's edits,
-- on green: commits each item separately, then ticks the items off
-  `IMPLEMENTATION_PLAN.md` in one final
+- runs the five agent stages as five parallel waves
+  (premise-auditor → scenario-architect → fixture-builder →
+  test-writer → engine-implementer), with N items in flight per wave,
+  a reviewer gate after every wave and a skeptic alongside it on the
+  design and implementation waves,
+- runs the global validation gate exactly once at the end of the
+  engine-implementer wave — per-agent gate runs are forbidden because
+  they would N×-redundantly churn ruff/format on each other's edits.
+  The gate runs in tiers and **Tier 2 is mandatory** (`tests/oracle/`
+  plus `tests/acceptance/reporting/`), followed by the full suite in
+  two foreground chunks,
+- on green: commits each item separately, runs the Step 7.5 retro,
+  then ticks the items off `IMPLEMENTATION_PLAN.md` in one final
   `chore(plan): tick N CCR items` commit and pushes.
 
 Expect frequent single-stream downgrades: many CCR items touch shared

--- a/docs/development/escape-log.md
+++ b/docs/development/escape-log.md
@@ -1,0 +1,45 @@
+# Escape log
+
+A record of defects that **reached production**, and — the point of the file —
+what now stops each one from happening again.
+
+Every entry is written by `/postmortem`. The command's deliverable is not the
+code fix; it is the answer to a single question:
+
+> Which gate should have caught this, and why didn't it?
+
+A defect that produced a fix commit and nothing else has taught the system
+nothing, and will be paid for again. A defect that produced a new check, a new
+fixture in `RUNS`, or a re-anchored assertion has been converted into
+permanent capability.
+
+## How to read an entry
+
+- **Escape class** is one of seven, and it determines the fix:
+
+  | Class | Meaning | Fix |
+  |---|---|---|
+  | `gate-not-run` | a catching gate existed but didn't run at that point | move the gate earlier |
+  | `path-never-exercised` | the gate ran but no fixture reached the code | build the portfolio, register it in `RUNS` |
+  | `test-shared-the-assumption` | a test covered it and passed, written from the same wrong sentence | re-anchor to a source of truth |
+  | `no-assertion-of-presence` | output was absent/null rather than wrong | assert presence |
+  | `wrong-premise` | the plan bullet was wrong and was faithfully implemented | strengthen Wave 0 |
+  | `no-gate-exists` | nothing could have caught it | create the gate |
+  | `ungateable` | not mechanically detectable | `.claude/LESSONS.md` entry, with reasoning |
+
+- **Verified red** records how the new gate was confirmed to fail *without*
+  the fix. A gate nobody has seen fail is not a gate.
+
+## Related
+
+- `.claude/LESSONS.md` — the working set of traps every agent reads before
+  starting. Entries graduate out of it into executable checks.
+- `scripts/arch_check.py` — the numbered architectural invariants. Each one is
+  a lesson that graduated.
+- `tests/acceptance/reporting/test_supervisory_validations.py` — the
+  two-way-ratcheted register of published EBA/BoE rules; the estate's strongest
+  oracle for reporting defects.
+
+---
+
+<!-- /postmortem appends entries below this line, newest last. -->

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -14,6 +14,7 @@ The development guide covers:
 - [**Code Style**](code-style.md) - Coding standards and conventions
 - [**Citation Tracking**](citation-tracking.md) - `@cites` decorator conventions, watchfire CLI usage, strict-gate behaviour
 - [**Citation Coverage Matrix**](citation-matrix.md) - Auto-generated article -> implementing-function index with click-to-expand source snippets
+- [**Escape Log**](escape-log.md) - Defects that reached production, and the gate change that now stops each one
 
 ## Development Setup
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -146,6 +146,7 @@ nav = [
     { "Citation Tracking" = "development/citation-tracking.md" },
     { "Citation Coverage Matrix" = "development/citation-matrix.md" },
     { "Module Dependencies" = "development/module-dependencies.md" },
+    { "Escape Log" = "development/escape-log.md" },
   ]},
   { "Plans" = [
     "plans/index.md",


### PR DESCRIPTION
## Why

The harness gated well and learned nothing.

Every lesson this project has paid for lived in operator-only memory or in batch state that `/next-items` Step 8 **deleted** at the end of every batch. Role-agents started each invocation blank, so nothing carried forward. The measured result, across two consecutive drains two days apart:

| Batch | Bullets with a materially wrong premise |
|---|---|
| `20260724` | 6 of 10 |
| `20260724b` | **10 of 10** (two prescribed fixes actively unsafe) |

The defect rate went **up** batch over batch. That is the signature of an open loop.

Four specific breaks:

1. **The pipeline was a closed inference chain.** The architect derived a hand-calc from the bullet, the test asserted the architect's numbers, the implementer made them pass, and the reviewer checked the chain against itself. Nothing could notice the bullet was wrong.
2. **The batch gate was blind to the escaping defect class.** Step 6 ran `arch_check`/`ruff`/`ty`/contracts + the batch's own tests. It never ran the supervisory validation ratchet — which by the project's own record is the only thing that reliably catches these. `loop.sh` pushes to a feature branch where CI does not fire, so nothing ran the estate until the PR.
3. **The reviewer checked shape, not truth**, and had no `Bash` — so `C4.5` was "the report quotes the pytest summary line", a self-report taken on trust.
4. **The evidence was destroyed at batch end** (`rm` the state file, `git branch -D`), including every reviewer verdict and drop reason.

## What changed

**1 — Tiered batch gate.** Step 6 now runs **Tier 2** (`tests/oracle/` + `tests/acceptance/reporting/` — the two-way-ratcheted register of 741 published EBA/BoE rules, and the reporting goldens) and **Tier 3** (full suite, two foreground chunks — background Bash is hard-killed at ~600s). Tier 2 is non-optional: on one CRM substitution block a fully green 10,552-test suite found **none** of ten real defects, while wiring the portfolio into `RUNS` found three in the first hour.

**2 — Wave 0.** New `premise-auditor` agent tries to **refute** the bullet before any design work: does the rule say what the bullet claims, does the code actually diverge, what is the RWA direction, is the scope right. Returns `confirmed | rescoped | refuted`. A refutation closes the bullet as `closed-claim-invalid` so the next batch does not pay to refute it again. The orchestrator extracts PDF text and pastes it in — mandatory for any RWA-reducing item, because agents cannot read `docs/assets/*.pdf` (`Read` needs `pdftoppm`, absent here) and will otherwise quote confidently from memory.

**3 — `.claude/LESSONS.md`.** 24 traps in `Trap` / `Why` / `Detect` form, seeded from the operator memory agents could never see. Seven agents now open by reading it. Capped at ~30 entries — a working set, explicitly not an archive.

**4 — Step 7.5 retro**, running *before* cleanup destroys the evidence. Patterns graduate by preference: `arch_check` check → ratchet → `RUNS` coverage → reviewer criterion → prose. Prose is the fallback, not the default; a lesson that escapes twice must become executable. `arch_check`'s 17 checks and the validation register are what graduated lessons already look like here.

**5 — Reviewer teeth.** `reviewer` gains `Bash(uv run pytest:*)` and may no longer accept a quoted summary as evidence — it runs the test itself. New adversarial `skeptic` runs *in parallel* on the design and implementation waves with seven named attacks (re-derive the number, re-run the test, attack the test's ability to fail, check the sign, blast radius, defect-pinning survivors, reporting-specific). Same verdict grammar; worst verdict wins. Its default is "unproven" — an untested claim is `revise`.

**6 — Negative space.** Absence, not wrongness, is the dominant escape class: C 07.00's CCF columns published nulls for the template's entire life. New `C1.7`/`C3.7` criteria plus architect and test-writer steps requiring assertions that the sheet is *emitted*, cells are *non-null* where there is exposure, and breakdowns *sum to their parent*.

**7 — `/postmortem` + `docs/development/escape-log.md`.** Seven escape classes, each prescribing its own gate change. The deliverable is the gate, not the fix — the gate change is mandatory, the code fix may be deferred. Includes verifying the new gate goes red without the fix.

**8 — Archive, not delete.** Batch state moves to `.claude/state/archive/`.

**9 — `test-writer` → Opus.** The test is the specification of correctness; it was the wrong node to under-power.

### Also in scope

- **`/implement-scenario` was a bypass** around all of the above. It now runs Wave 0, the skeptic, the tiered gate, and a retro — being one item is not grounds for a weaker gate.
- **Six harness files still pointed agents at `src/rwa_calc/data/tables/`**, removed in Phase 5 S13. Corrected to the rulepack packs and the `engine/` pack-binding shims.

## Verification

- `uv run python scripts/arch_check.py` — exit 0
- `uv run ruff check src/ tests/` — all checks passed; `ruff format --check` — 1271 files already formatted
- `uv run zensical build` — green; `escape-log` page built and in nav; **zero** warnings attributable to the new pages (the 83 reported are pre-existing anchor issues under `user-guide/regulatory/`)
- All nine agent frontmatters parse with correct `name` / `model` / `tools`; `premise-auditor` and `skeptic` confirmed registering with their scoped `Bash(...)` specifiers intact

No `src/` or `tests/` changes — this PR is harness-only, so the calculation estate is untouched.

## Reviewer notes

- **Cost.** With N=3 and one revision allowed, a batch now dispatches roughly 24 agents rather than 16. If that is too heavy, the cheapest trim is dropping the `skeptic` from Wave 1 and keeping it on Wave 4, where the capital number actually lands.
- **Tier 2 runtime.** `test_supervisory_validations.py` is eighteen full pipeline runs. It is expensive once per batch against a batch that takes hours — the trade is deliberate and argued inline in Step 6.


