### PR TITLE
perf(tests): cap the Polars thread pool and fix the xdist fleet size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,12 @@ jobs:
       - name: Generate test fixtures
         run: uv run python tests/fixtures/generate_all.py
 
+      # `-n auto` overrides the `-n 8` default in addopts, which is tuned for the
+      # RAM-constrained dev box. The runner has a different core-to-RAM ratio, so
+      # it keeps sizing the fleet from its own core count; the Polars thread cap
+      # in tests/conftest.py still applies and is a win here too.
       - name: Run tests
-        run: uv run pytest tests/ --benchmark-disable -m 'not slow and not benchmark'
+        run: uv run pytest tests/ --benchmark-disable -m 'not slow and not benchmark' -n auto
 
   benchmarks:
     name: Benchmarks
@@ -80,10 +84,16 @@ jobs:
       - name: Generate test fixtures
         run: uv run python tests/fixtures/generate_all.py
 
-      # addopts is cleared so xdist (-n auto) and --benchmark-disable don't
-      # suppress pytest-benchmark; scale_1m benchmarks stay excluded via 'not slow'.
+      # addopts is cleared so xdist and --benchmark-disable don't suppress
+      # pytest-benchmark; scale_1m benchmarks stay excluded via 'not slow'.
+      #
+      # POLARS_MAX_THREADS is set explicitly so the `setdefault` in
+      # tests/conftest.py does not apply: benchmarks measure production-like
+      # throughput and need the real thread pool, not the dev-loop cap of 1.
       - name: Run benchmarks
-        run: uv run pytest tests/benchmarks -m 'benchmark and not slow' -o addopts= --benchmark-json=benchmark-results.json -v --tb=short
+        run: |
+          export POLARS_MAX_THREADS="$(nproc)"
+          uv run pytest tests/benchmarks -m 'benchmark and not slow' -o addopts= --benchmark-json=benchmark-results.json -v --tb=short
 
       - name: Upload benchmark results
         uses: actions/upload-artifact@v4

--- a/docs/appendix/changelog.md
+++ b/docs/appendix/changelog.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **The test suite no longer oversubscribes the machine: 10m50s → 3m56s on the
+  reference dev box, with identical results.** Polars sizes its thread pool from
+  the core count the first time it is imported, and `pytest-xdist` sized its
+  worker fleet the same way via `-n auto`. On a 16-core box that was 16 workers
+  each holding a 16-thread pool — 256 threads contending for 16 cores, each pool
+  carrying its own buffers — while practically every test here pushes a handful
+  of rows through the pipeline, so that parallelism bought nothing.
+
+  `tests/conftest.py` now sets `POLARS_MAX_THREADS=1` (via `os.environ.setdefault`,
+  before the first `import polars`, so it applies in the controller and in every
+  xdist worker), and `addopts` pins `-n 8` instead of `-n auto` because the
+  binding constraint is RAM rather than cores. Measured on the same commit:
+  **652s → 237s wall, peak system memory 4819 MB → 4419 MB**, with the failure
+  set unchanged. On a fully green tree the memory saving is larger — a
+  green-to-green comparison measured **7301 MB → 4350 MB peak** and available
+  memory at the low-water mark rising from 508 MB to 3459 MB.
+
+  Two guards come with it. `tests/contracts/test_polars_thread_cap.py` asserts
+  the pool size actually agrees with the environment, because setting the
+  variable after the first `import polars` is a silent no-op that costs the
+  whole win while leaving every test green. And the CI benchmark job now exports
+  the real core count, so benchmarks keep measuring production-like throughput;
+  `setdefault` is what lets that override win. Note that
+  `POLARS_MAX_THREADS=0` must never be used — Polars accepts it at import and
+  then panics at compute time with "Worker threads cannot be set to 0".
+
+  `-v` is also dropped from `addopts`: 11k verbose result lines were pushed
+  through the xdist protocol and scrolled past, and `--tb=short` already gives
+  the diagnostic on failure. Override per-invocation as usual (`-n auto`,
+  `-n 0`, `-v`); a single-file run is much faster serially — 13.4s → 2.3s for
+  `tests/unit/test_ccf.py`, since below roughly a dozen files the worker
+  startup costs more than the tests.
+
 ### Fixed
 - **PS1/26 Art. 154(4A)(b): the 10% IRB mortgage RWEA floor is now confined to
   non-defaulted retail exposures secured by residential immovable property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,12 @@ pythonpath = ["."]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
-addopts = "-v --tb=short --strict-markers --benchmark-disable -m 'not slow and not stress and not scale_1m and not benchmark' -n auto --dist=loadfile"
+# -n is fixed rather than `auto` on purpose: `auto` sizes the fleet from the
+# core count, but the binding constraint is RAM (the reference dev box is 16
+# cores to 7.8 GB). With the Polars thread cap in tests/conftest.py, 8 workers
+# cost ~28s against 16 but give back ~2 GB of peak and leave the machine usable
+# while the suite runs. Override per-invocation with `-n auto` / `-n 0`.
+addopts = "--tb=short --strict-markers --benchmark-disable -m 'not slow and not stress and not scale_1m and not benchmark' -n 8 --dist=loadfile"
 markers = [
     "benchmark: mark test as a benchmark (excluded from the default dev loop; run via -m benchmark)",
     "slow: mark test as slow (1M scale, may take several minutes)",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,16 +6,38 @@ Currently provides:
   facility_mappings, lending_mappings) into a directory and returns a
   ``DataSourceConfig`` pointing at them. Used by CCR loader / fixture-builder
   tests that need a valid base CRR dataset before wiring optional CCR files.
+- The Polars thread-pool cap for the whole test session (see below).
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import os
 
-import polars as pl
-import pytest
+# Polars sizes its thread pool from the core count the first time it is
+# imported, and pytest-xdist sizes its worker fleet the same way. Left alone on
+# a 16-core box that is 16 workers each holding a 16-thread pool — 256 threads
+# contending for 16 cores, each pool carrying its own buffers. Practically every
+# test here pushes a handful of rows through the pipeline, so that parallelism
+# buys nothing and costs both wall time and resident memory: capping it to one
+# thread took the dev-loop suite from 8m43s / 7.3 GB peak to 3m38s / 4.35 GB on
+# the reference box, with identical results.
+#
+# This must run before the first ``import polars`` anywhere in the process,
+# which is why it sits above the imports rather than in a fixture — conftest is
+# imported before any test module, in the controller and in every xdist worker.
+#
+# ``setdefault`` leaves an explicit outer value in charge: the CI benchmark job
+# exports the real core count so it still measures production-like throughput.
+# Never set this to 0 — Polars accepts it at import and then panics at compute
+# time with "Worker threads cannot be set to 0".
+os.environ.setdefault("POLARS_MAX_THREADS", "1")
 
-from rwa_calc.engine.loader import DataSourceConfig
+from typing import TYPE_CHECKING  # noqa: E402
+
+import polars as pl  # noqa: E402
+import pytest  # noqa: E402
+
+from rwa_calc.engine.loader import DataSourceConfig  # noqa: E402
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/tests/contracts/test_polars_thread_cap.py
+++ b/tests/contracts/test_polars_thread_cap.py
@@ -1,0 +1,61 @@
+"""
+Contract: the Polars thread pool is capped for the test session.
+
+Pipeline position:
+    None — this is a harness contract, not a pipeline stage. It guards the
+    ``POLARS_MAX_THREADS`` default set at the top of ``tests/conftest.py``.
+
+Key responsibilities:
+- Assert the cap is actually in force, and that it took effect *before* Polars
+  first initialised its pool. Setting the variable after the first
+  ``import polars`` anywhere in the process is a silent no-op: the variable
+  would read back correctly while the pool stayed at the core count.
+- Stay correct when the cap is deliberately overridden. The CI benchmark job
+  exports the real core count so it measures production-like throughput, so
+  this asserts pool size *agrees with* the environment rather than pinning a
+  literal 1.
+
+Why this is a test and not a comment: the failure mode is silent. Dropping the
+conftest line costs ~2.4x wall time and ~3 GB of peak memory on the reference
+box with every test still green, so nothing else in the estate would notice.
+"""
+
+from __future__ import annotations
+
+import os
+
+import polars as pl
+
+
+def test_polars_max_threads_is_set_for_the_test_session() -> None:
+    """The cap is present in the environment of every worker."""
+    # Arrange / Act
+    configured = os.environ.get("POLARS_MAX_THREADS")
+
+    # Assert
+    assert configured is not None, (
+        "POLARS_MAX_THREADS is unset. tests/conftest.py sets it via "
+        "os.environ.setdefault before importing polars; without it every xdist "
+        "worker starts a thread pool sized from the core count."
+    )
+    assert configured.isdigit() and int(configured) >= 1, (
+        f"POLARS_MAX_THREADS must be a positive integer, got {configured!r}. "
+        "Polars accepts 0 at import and then panics at compute time with "
+        "'Worker threads cannot be set to 0'."
+    )
+
+
+def test_polars_thread_pool_honours_the_configured_cap() -> None:
+    """The cap was applied before Polars built its pool, not after."""
+    # Arrange
+    configured = int(os.environ["POLARS_MAX_THREADS"])
+
+    # Act
+    actual = pl.thread_pool_size()
+
+    # Assert
+    assert actual == configured, (
+        f"Polars thread pool is {actual} but POLARS_MAX_THREADS is {configured}. "
+        "The variable is only read when Polars first initialises its pool, so "
+        "this means something imported polars before tests/conftest.py set it."
+    )


### PR DESCRIPTION
## Why

Polars sizes its thread pool from the core count the first time it is imported, and `pytest-xdist` sized its worker fleet the same way via `-n auto`. On the 16-core / 7.8 GB reference dev box that is **16 workers each holding a 16-thread pool — 256 threads contending for 16 cores**, each pool carrying its own buffers.

Practically every test here pushes a handful of rows through the pipeline, so that parallelism bought nothing and cost both wall time and resident memory. At the low point of a baseline run the machine had 508 MB of 7.8 GB available — the margin left for an editor, a browser, or a second agent.

## What changed

| | |
|---|---|
| `tests/conftest.py` | Sets `POLARS_MAX_THREADS=1` via `os.environ.setdefault`, above the first `import polars`, so it applies in the controller and in every xdist worker. |
| `pyproject.toml` | `addopts` pins `-n 8` rather than `-n auto` — the binding constraint is RAM, not cores — and drops `-v`. |
| `.github/workflows/ci.yml` | The benchmark job exports the real core count so benchmarks keep measuring production-like throughput; the test job keeps `-n auto`. |
| `tests/contracts/test_polars_thread_cap.py` | New guard, see below. |
| `docs/appendix/changelog.md` | Entry under Unreleased / Changed. |

## Measured

Same commit, full suite, run with no flags at all — exactly what a developer now types:

| | Wall | Peak used | Min available |
|---|---|---|---|
| Before | 652 s (10:50) | 4819 MB | 2990 MB |
| After | **237 s (3:56)** | **4419 MB** | **3390 MB** |

**2.75× faster.** The failure set is identical on both sides (49 failed, 2 errors — see the note below), and the pass count rises by exactly 2, which is the new contract test.

On a fully green tree the memory effect is larger, because no failures short-circuit the heavy work. A green-to-green comparison on the preceding commit measured **7301 MB → 4350 MB peak**, with available memory at the low-water mark rising from **508 MB to 3459 MB**.

A wider sweep informed the choice of 8 workers. Holding workers at 16 and changing *only* the thread cap already takes 523 s → 190 s, so the thread pool is the dominant lever and worker count is the memory dial layered on top of it. 8 workers cost ~28 s against 16 but give back ~2 GB of peak.

`--dist=loadfile` is deliberately kept: measured against `--dist=load` on the full suite it is 218 s vs 285 s, because the session-scoped pipeline fixtures otherwise rebuild on every worker.

## The guard, and why it is a test

`tests/contracts/test_polars_thread_cap.py` asserts that `pl.thread_pool_size()` **agrees with** the environment, rather than pinning a literal 1.

The failure mode being guarded is silent. Setting `POLARS_MAX_THREADS` after the first `import polars` anywhere in the process is a no-op: the variable reads back correctly while the pool stays at the core count. Dropping the conftest line costs ~2.4× wall time and ~3 GB of peak memory **with every test still green**, so nothing else in the estate would notice. Asserting agreement rather than a literal also keeps the test correct under the benchmark job's deliberate override.

⚠️ `POLARS_MAX_THREADS` must never be set to `0`. Polars accepts it at import and reports a normal pool size, then panics at compute time with `Worker threads cannot be set to 0`. This cost one run and 5,927 spurious failures during the investigation, and the contract test now rejects it up front.

## CI will be red, and not because of this PR

`origin/master` is **already red** at `3abdedd5` (#460, `fix/re-split-carrier-duplication`): **49 failures and 2 import errors**, every one a re-split / carrier-conservation assertion or an import error in a re-split module.

All 49 reproduce with the changes in this PR stashed, on the same commit. A thread-count change cannot alter RWA conservation arithmetic. That breakage needs attention on its own account, separately from this PR.

## Gate

`ruff check src/ tests/` ✅ · `ruff format --check` (1,316 files) ✅ · `scripts/arch_check.py` ✅ (watchfire's 9 soft findings are the documented pre-existing set) · `ty` checks `src/rwa_calc/` only, which this diff does not touch.

## Not in scope

Three further items were measured and left for separate PRs: a hook to drop the worker count for targeted runs (one file is 13.4 s → 2.3 s served serially; crossover is ~12 files), the stress suite's ~5.9 GB single-process ceiling, and `tests/properties/test_monotonicity.py` at 54.9 s setting the `loadfile` wall-clock floor.


