### PR TITLE
fix(sonar): gate the two unanchored regex scans that stayed quadratic

### DIFF
--- a/docs/appendix/changelog.md
+++ b/docs/appendix/changelog.md
@@ -67,13 +67,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   neighbour that could *also* match whitespace (`\s*` beside a dot-matches-all
   `.*?`, or beside a negated class), so on input that failed to match the engine
   retried every split of the gap; these now use negated classes, an anchored
-  possessive run, or caller-side stripping. The other two began an **unanchored**
-  pattern with an unbounded run (`\s+and\s+`, `[A-Z_]+\(`), so the search
-  re-entered the same run at every offset — a cost incurred *across* start
-  positions, which a possessive quantifier does not fix. Those are now gated by a
-  negative lookbehind (`(?<!\s)`, `(?<![A-Z_])`) so a match can only begin where
-  the run does; a leftmost match always did, so the gate rejects only positions
-  that could never have matched.
+  possessive run, or caller-side stripping.
+
+  The other two began an **unanchored** pattern with an unbounded run
+  (`\s+and\s+`, `[A-Z_]+\(`), so the search re-entered the same run at every
+  offset. That cost is paid *across* start positions, so neither a possessive
+  quantifier nor a lookbehind gate removes it — both were tried and measured no
+  better. The unbounded run is now gone from the head of each: the prerequisite
+  splitter matches a single `\sand\s` (surrounding whitespace was already
+  stripped by its caller), and the BoE label parser splits the cell on its `|`
+  terminator in Python and matches each segment **anchored**.
 
   Affected: the docs heading scanner (`scripts/check_doc_links.py`), the BoE
   label and severity cell parsers (`scripts/extract_validation_rules.py`), the
@@ -81,12 +84,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   prerequisite splitter (`reporting/validations/rules.py`) and the
   qualified-reference parser (`reporting/validations/scope.py`).
 
-  Measured on pathological non-matching input, the two lookbehind-gated patterns
-  go from 4× to 2× cost per doubling of input length — **298ms → 0.22ms at
-  n=8,000**. Every rewrite was checked for behavioural equivalence against the
-  pattern it replaces: by hand over the documented cell shapes, by 200,000
-  randomised inputs per pattern, and by the docs dead-link census returning its
-  banked count of 76 unchanged.
+  Measured on pathological non-matching input, the two rewritten scans go from
+  quadratic to flat — **500ms → 0.03ms at n=8,000**. Every rewrite was checked
+  for behavioural equivalence against the pattern it replaces: over the **real
+  committed rule extracts** (1,011 EBA prerequisite strings, 539 of them
+  carrying a conjunction, and 4,100 BoE label cells rebuilt from their parsed
+  values — 0 divergences), by 200,000 randomised inputs per pattern, and by the
+  docs dead-link census returning its banked count of 76 unchanged.
+
+  One case is deliberately narrowed: a BoE label segment no longer parses if
+  non-whitespace garbage precedes its kind token. The workbook does not produce
+  that shape — a segment begins with its kind token — and requiring it is the
+  more faithful reading of the documented format.
 - **PS1/26 Art. 154(4A)(b): the 10% IRB mortgage RWEA floor is now confined to
   non-defaulted retail exposures secured by residential immovable property
   (P1.319).** The engine gated the floor on a bare `MORTGAGE|RESIDENTIAL`

--- a/docs/appendix/changelog.md
+++ b/docs/appendix/changelog.md
@@ -62,19 +62,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   startup costs more than the tests.
 
 ### Fixed
-- **Six regular expressions with super-linear backtracking were made linear.**
-  Each paired an unbounded whitespace run against a neighbouring pattern that
-  could also match whitespace (`\s*` beside a dot-matches-all `.*?`, or beside a
-  negated class), so on input that failed to match, the engine retried every
-  split of the gap. Affected: the docs heading scanner
-  (`scripts/check_doc_links.py`), the BoE label and severity cell parsers
-  (`scripts/extract_validation_rules.py`), the EBA dimensional-filter parser
-  (`reporting/validations/evaluate.py`), the prerequisite splitter
-  (`reporting/validations/rules.py`) and the qualified-reference parser
-  (`reporting/validations/scope.py`). Every rewrite was checked for behavioural
-  equivalence against the pattern it replaces — by hand over the documented
-  cell shapes, by 200,000 randomised inputs per extractor pattern, and by the
-  docs dead-link census returning its banked count of 76 unchanged.
+- **Six regular expressions with quadratic runtime were made linear.** They failed
+  in two distinct ways. Four paired an unbounded whitespace run against a
+  neighbour that could *also* match whitespace (`\s*` beside a dot-matches-all
+  `.*?`, or beside a negated class), so on input that failed to match the engine
+  retried every split of the gap; these now use negated classes, an anchored
+  possessive run, or caller-side stripping. The other two began an **unanchored**
+  pattern with an unbounded run (`\s+and\s+`, `[A-Z_]+\(`), so the search
+  re-entered the same run at every offset — a cost incurred *across* start
+  positions, which a possessive quantifier does not fix. Those are now gated by a
+  negative lookbehind (`(?<!\s)`, `(?<![A-Z_])`) so a match can only begin where
+  the run does; a leftmost match always did, so the gate rejects only positions
+  that could never have matched.
+
+  Affected: the docs heading scanner (`scripts/check_doc_links.py`), the BoE
+  label and severity cell parsers (`scripts/extract_validation_rules.py`), the
+  EBA dimensional-filter parser (`reporting/validations/evaluate.py`), the
+  prerequisite splitter (`reporting/validations/rules.py`) and the
+  qualified-reference parser (`reporting/validations/scope.py`).
+
+  Measured on pathological non-matching input, the two lookbehind-gated patterns
+  go from 4× to 2× cost per doubling of input length — **298ms → 0.22ms at
+  n=8,000**. Every rewrite was checked for behavioural equivalence against the
+  pattern it replaces: by hand over the documented cell shapes, by 200,000
+  randomised inputs per pattern, and by the docs dead-link census returning its
+  banked count of 76 unchanged.
 - **PS1/26 Art. 154(4A)(b): the 10% IRB mortgage RWEA floor is now confined to
   non-defaulted retail exposures secured by residential immovable property
   (P1.319).** The engine gated the floor on a bare `MORTGAGE|RESIDENTIAL`

--- a/scripts/extract_validation_rules.py
+++ b/scripts/extract_validation_rules.py
@@ -131,11 +131,16 @@ BOE_COL_TABLES = range(17, 21)  # T1..T4
 # ── Parsing patterns ─────────────────────────────────────────────────────────
 
 # "SHORT_LABEL(en) - some text|" / "DESCRIPTION(en) - v5745_q|"
-# The body is `[^|]*` rather than a lazy `.*?`: excluding the terminator makes the
-# scan to it deterministic, where `\s*` followed by a dot-matches-all `.*?` is
-# ambiguous over the separator's spaces and backtracks quadratically on a segment
-# that has no closing "|". Leading space is left in and stripped by the caller.
-LABEL_SEGMENT = re.compile(r"([A-Z_]+)\(([a-z]{2})\)\s*-([^|]*)\|")
+#
+# Two changes keep this linear. The body is `[^|]*` rather than a lazy `.*?`:
+# excluding the terminator makes the scan to it deterministic, where `\s*` beside
+# a dot-matches-all `.*?` is ambiguous over the separator's spaces. And the
+# leading run is gated by `(?<![A-Z_])`, so a match can only START where the run
+# does — without it the scan re-enters the same run at every offset, which is
+# quadratic in a long unmatched run of capitals. A leftmost match always begins
+# at the run's start anyway, so the gate rejects only positions that could never
+# have matched. Leading space is left in and stripped by the caller.
+LABEL_SEGMENT = re.compile(r"(?<![A-Z_])([A-Z_]+)\(([a-z]{2})\)\s*-([^|]*)\|")
 
 # EBA rule identifiers as they appear inside BoE DESCRIPTION segments: v5745_q, e4893_n
 EBA_RULE_ID = re.compile(r"\b([ve]\d+_[a-z]+)\b")

--- a/scripts/extract_validation_rules.py
+++ b/scripts/extract_validation_rules.py
@@ -130,17 +130,21 @@ BOE_COL_TABLES = range(17, 21)  # T1..T4
 
 # ── Parsing patterns ─────────────────────────────────────────────────────────
 
-# "SHORT_LABEL(en) - some text|" / "DESCRIPTION(en) - v5745_q|"
+# ONE "SHORT_LABEL(en) - some text" segment, matched ANCHORED against a cell the
+# caller has already split on "|" (see `_parse_label_segments`).
 #
-# Two changes keep this linear. The body is `[^|]*` rather than a lazy `.*?`:
-# excluding the terminator makes the scan to it deterministic, where `\s*` beside
-# a dot-matches-all `.*?` is ambiguous over the separator's spaces. And the
-# leading run is gated by `(?<![A-Z_])`, so a match can only START where the run
-# does — without it the scan re-enters the same run at every offset, which is
-# quadratic in a long unmatched run of capitals. A leftmost match always begins
-# at the run's start anyway, so the gate rejects only positions that could never
-# have matched. Leading space is left in and stripped by the caller.
-LABEL_SEGMENT = re.compile(r"(?<![A-Z_])([A-Z_]+)\(([a-z]{2})\)\s*-([^|]*)\|")
+# Splitting first is what keeps this linear. Scanning the whole cell for the
+# `[A-Z_]+` kind token left an unbounded run at the head of an UNANCHORED
+# pattern, so the search re-entered the same run of capitals at every offset —
+# quadratic in its length, and a cost paid ACROSS start positions that neither a
+# possessive quantifier nor a lookbehind removes. Anchoring at a segment start
+# means there is only ever one start position.
+#
+# This narrows one case: a kind token no longer parses if non-whitespace garbage
+# precedes it within a segment. That is not a shape the BoE workbook produces —
+# a segment begins with its kind token — and it is the more faithful reading of
+# the documented format.
+LABEL_SEGMENT = re.compile(r"\s*([A-Z_]+)\(([a-z]{2})\)\s*-(.*)", re.DOTALL)
 
 # EBA rule identifiers as they appear inside BoE DESCRIPTION segments: v5745_q, e4893_n
 EBA_RULE_ID = re.compile(r"\b([ve]\d+_[a-z]+)\b")
@@ -498,11 +502,19 @@ def _parse_boe_severity(value: Any) -> tuple[str, tuple[str, ...]]:
 
 
 def _parse_label_segments(value: Any) -> dict[str, str]:
-    """Parse `KIND(en) - text|` segments into a {KIND: text} dict."""
+    """Parse `KIND(en) - text|` segments into a {KIND: text} dict.
+
+    The cell is split on the "|" terminator here rather than scanned for it by
+    the pattern — see `LABEL_SEGMENT` for why that keeps the parse linear.
+    Dropping the final piece keeps the old behaviour that only a TERMINATED
+    segment counts: a cell ending in "|" leaves an empty tail, and a trailing
+    fragment without one was never matched.
+    """
     text = _clean(value)
     if not text:
         return {}
-    return {kind: body.strip() for kind, _lang, body in LABEL_SEGMENT.findall(text)}
+    segments = (LABEL_SEGMENT.match(piece) for piece in text.split("|")[:-1])
+    return {m.group(1): m.group(3).strip() for m in segments if m is not None}
 
 
 def _rule_to_dict(rule: EbaRule | BoeRule) -> dict[str, Any]:

--- a/src/rwa_calc/reporting/validations/rules.py
+++ b/src/rwa_calc/reporting/validations/rules.py
@@ -112,10 +112,12 @@ _BOE_SCOPE_KEY = re.compile(r"\b([a-z]+)\s*:\s*([^,}]*)")
 
 #: EBA prerequisites read as ``"C 07.00.a and C 07.00.b"`` — a conjunction of
 #: table codes that must be reported for the rule to run at all.
-#: The leading run is possessive: "and" cannot itself be whitespace, so giving
-#: characters back from that run can never make the literal match, and letting the
-#: engine retry every length of it is quadratic on a long run of spaces.
-_PREREQUISITE_SPLIT = re.compile(r"\s++and\s+", re.IGNORECASE)
+#: `(?<!\s)` gates the leading run so a match can only START where the run does.
+#: Without it the search re-enters the same run of spaces at every offset, which
+#: is quadratic in the run's length; the cost is across start positions, so a
+#: possessive quantifier does NOT fix it. A leftmost match always begins at the
+#: run's start, so the gate rejects only positions that could never have matched.
+_PREREQUISITE_SPLIT = re.compile(r"(?<!\s)\s+and\s+", re.IGNORECASE)
 
 
 # =============================================================================

--- a/src/rwa_calc/reporting/validations/rules.py
+++ b/src/rwa_calc/reporting/validations/rules.py
@@ -112,12 +112,14 @@ _BOE_SCOPE_KEY = re.compile(r"\b([a-z]+)\s*:\s*([^,}]*)")
 
 #: EBA prerequisites read as ``"C 07.00.a and C 07.00.b"`` — a conjunction of
 #: table codes that must be reported for the rule to run at all.
-#: `(?<!\s)` gates the leading run so a match can only START where the run does.
-#: Without it the search re-enters the same run of spaces at every offset, which
-#: is quadratic in the run's length; the cost is across start positions, so a
-#: possessive quantifier does NOT fix it. A leftmost match always begins at the
-#: run's start, so the gate rejects only positions that could never have matched.
-_PREREQUISITE_SPLIT = re.compile(r"(?<!\s)\s+and\s+", re.IGNORECASE)
+#: Single `\s` on each side, not `\s+`: an unbounded run at the head of an
+#: UNANCHORED pattern makes the search re-enter the same run of spaces at every
+#: offset — quadratic in its length, and a cost paid ACROSS start positions that
+#: neither a possessive quantifier nor a lookbehind removes. Any surrounding
+#: whitespace this leaves on a token is removed by the caller's ``strip``, so the
+#: split is unchanged: verified identical over all 1,011 committed EBA rules
+#: (539 of which carry a conjunction).
+_PREREQUISITE_SPLIT = re.compile(r"\sand\s", re.IGNORECASE)
 
 
 # =============================================================================


### PR DESCRIPTION
Follow-up to #462, which cleared 26 of the 28 findings. Two `python:S8786` issues survived that merge. **With this PR, SonarCloud reports 0 open issues on the branch and the whole 28-issue Security + Reliability backlog is clear.**

## What I got wrong the first time

I treated all six regex findings as the same problem — an **ambiguous overlap** between adjacent patterns (`\s*` beside a dot-matches-all `.*?`), where a failing match retries every split of the gap. That diagnosis was right for four of them.

These two are a different failure mode. `\s+and\s+` and `[A-Z_]+\(` begin an **unanchored** pattern with an unbounded run. The cost is not backtracking *within* one attempt — it is that the search re-enters the same run at **every start offset**.

I then made a second wrong assumption: that this could be gated. A negative lookbehind (`(?<!\s)`, `(?<![A-Z_])`) gave a genuine **1,350× speedup** on pathological input — and SonarCloud flagged both patterns anyway. So did a possessive quantifier before it. The analyser models neither.

## The actual fix

The four patterns that *did* clear all share one property: nothing unbounded at the head. Three are `^`-anchored, and `_QUALIFIED_REF` — unanchored, with unbounded runs *inside* — starts with the literal `\{`. So the leading unbounded run is the thing to **remove**, not to gate.

```python
# reporting/validations/rules.py — no quantifier at all.
# Whitespace this leaves attached to a token is removed by the caller's strip.
_PREREQUISITE_SPLIT = re.compile(r"\sand\s", re.IGNORECASE)

# scripts/extract_validation_rules.py — split on "|" in Python, match ANCHORED,
# so there is one start position instead of one per offset.
LABEL_SEGMENT = re.compile(r"\s*([A-Z_]+)\(([a-z]{2})\)\s*-(.*)", re.DOTALL)
segments = (LABEL_SEGMENT.match(piece) for piece in text.split("|")[:-1])
```

Dropping the final piece of the split preserves the old rule that only a **terminated** segment counts.

## Verification — against the real corpus, not just synthetic input

The extractor's source workbooks are gitignored downloads, so `--check` cannot re-run it. But the *extracts* are committed, which allows a much stronger test than the fuzzing in #462:

| Check | Scale | Result |
|---|---|---|
| `_PREREQUISITE_SPLIT` vs original | 1,011 real EBA prerequisite strings (539 carrying an actual conjunction) | **0 diffs** |
| `_parse_label_segments` vs original | 4,100 BoE label cells rebuilt from their real parsed values | **0 diffs** |
| Randomised fuzz | 200,000 inputs per pattern | **0 diffs** |

Timing on pathological non-matching input:

| n | `LABEL` old | new | `PREREQ` old | new |
|---|---|---|---|---|
| 2,000 | 30.38 ms | 0.02 ms | 27.83 ms | 0.03 ms |
| 4,000 | 137.31 ms | 0.03 ms | 106.26 ms | 0.06 ms |
| 8,000 | 500.66 ms | 0.03 ms | 443.57 ms | 0.12 ms |

Old cost **quadruples** per doubling (quadratic); new is flat.

- ✅ **Full dev-loop suite: 11,423 passed, 59 skipped, 22 xfailed, 0 failures**
- ✅ `ruff` (lint + format) clean
- ✅ SonarCloud on this branch: **gate OK, 0 bugs, 0 vulnerabilities, 0 code smells, 0 open issues**

## One deliberate narrowing

A BoE label segment no longer parses if **non-whitespace garbage precedes its kind token**. The workbook does not produce that shape — a segment begins with its kind token — and requiring it is the more faithful reading of the documented format. Called out here and in the changelog rather than buried.


