### PR TITLE
fix(ci): bump gh-action-pypi-publish to v1.14.2 for metadata 2.5

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,7 +77,7 @@ jobs:
           path: dist/
 
       - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: https://test.pypi.org/legacy/
 
@@ -96,4 +96,4 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/docs/appendix/changelog.md
+++ b/docs/appendix/changelog.md
@@ -231,6 +231,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `hypothesis` to the dev dependencies (portfolio search and shrinking).
 
 ### Fixed
+- **PyPI publishing works again: the release action was too old to accept the
+  metadata the build now emits.** `pypa/gh-action-pypi-publish` was pinned at
+  v1.14.0, whose bundled Twine rejects core packaging metadata 2.5 —
+  `InvalidDistribution: '2.5' is not a valid metadata version` — and `uv build`
+  resolves its build backend fresh, so the wheel started declaring
+  `Metadata-Version: 2.5` without anything in this repository changing. v0.3.24
+  published on 5 August and v0.3.25 did not. Bumped to v1.14.2, which carries
+  Twine 7 precisely to accept 2.5. The failure surfaced only at upload, after
+  the version bump, tag and GitHub Release already existed — nothing in the
+  local release flow builds and validates a distribution the way PyPI does.
 - **The release script now regenerates every version-stamped generated artifact.**
   `docs/data-model/regulatory-tables.md`, `docs/development/confidence-matrix.md`
   and `tests/contracts/data/confidence_snapshot.json` each embed the package


### PR DESCRIPTION
## What broke

The `v0.3.25` publish run ([31485781382](https://github.com/OpenAfterHours/rwa_calculator/actions/runs/31485781382)) failed at the pre-upload check:

```
Checking dist/rwa_calc-0.3.25-py3-none-any.whl:
ERROR InvalidDistribution: Invalid distribution metadata:
      '2.5' is not a valid metadata version
```

Not an auth or trusted-publishing failure — the OIDC exchange never got a chance to run.

## Why now, with no change on our side

`uv build` resolves the build backend fresh on every run, and the current backend emits `Metadata-Version: 2.5`. The locally built wheel confirms it:

```
dist/rwa_calc-0.3.25-py3-none-any.whl
Metadata-Version: 2.5
```

`pypa/gh-action-pypi-publish` was pinned at `cef22109…` (v1.14.0, April 2026), whose bundled Twine predates metadata 2.5 and rejects it. `v0.3.24` published on 5 August; nothing in this repo changed between then and `v0.3.25` — the wheel simply outgrew the checker.

## Fix

Bump both call sites (TestPyPI and PyPI) to `dc37677b` — v1.14.2. From its release notes:

> @takluyver's update of Twine to v7 that we use internally (#416). This version will let them upload their sdists and wheels containing core packaging metadata v2.5 to (Test)PyPI.

## After merging

The publish workflow is read from the commit the release tag points at (the failed run's `head_sha` was the tag's commit, not master's), so `v0.3.25` has to be moved onto the merge commit before re-triggering, and the release re-published to fire `release: published` again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
